### PR TITLE
RabbitMQ pinned, run-dev pull always kaprien api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ build-dev:
 run-dev:
 	# $(MAKE) build-dev
 	docker login ghcr.io
+	docker-compose pull
 	docker-compose up --remove-orphans
 
 init-repository:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   kaprien-mq:
-    image: rabbitmq:3-management-alpine
+    image: rabbitmq:3.10.7-management-alpine
     container_name: kaprien-mq
     volumes:
      - "kaprien-mq-data:/var/lib/rabbitmq"


### PR DESCRIPTION
This adds the development RabbitMQ with pinned version and always the
`make run-dev` will pull the latest dev version from Github Registry.

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>