### PR TITLE
Add bootstrap process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ build-dev:
 	docker build -t kaprien-repo-worker:dev .
 
 run-dev:
-	# $(MAKE) build-dev
+	$(MAKE) build-dev
 	docker login ghcr.io
-	docker-compose pull
+	docker pull ghcr.io/kaprien/kaprien-rest-api:dev
 	docker-compose up --remove-orphans
 
 init-repository:
@@ -16,6 +16,10 @@ stop:
 clean:
 	$(MAKE) stop
 	docker-compose rm --force
+
+purge:
+	$(MAKE) clean
+	docker rmi kaprien-repo-worker_kaprien-repo-worker --force
 
 reformat:
 	black -l 79 .

--- a/app.py
+++ b/app.py
@@ -151,7 +151,11 @@ def _get_config(settings):
 def kaprien_repo_worker(action, settings, payload):
 
     config = _get_config(settings)
-    if action == "add_targets":
+    if action == "add_initial_metadata":
+        repository_function = getattr(config.repository, action)
+        repository_function(payload.get("metadata"))
+
+    elif action == "add_targets":
         repository_function = getattr(config.repository, action)
         repository_function(payload.get("targets"))
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -103,11 +103,13 @@ class TestApp:
         monkeypatch.setattr("app.MetadataRepository", lambda *a: mocked_repo)
 
         result = app.kaprien_repo_worker(
-            "add_targets", test_settings, {"key": "value"}
+            "add_targets", test_settings, {"targets": {"key": "value"}}
         )
 
         assert result is None
-        assert mocked_repo.add_targets.calls == [pretend.call(None)]
+        assert mocked_repo.add_targets.calls == [
+            pretend.call({"key": "value"})
+        ]
 
     def test_kaprien_repo_worker_invalid_action(self, monkeypatch):
         monkeypatch.setenv("KAPRIEN_WORKER_ID", "test")


### PR DESCRIPTION
Add the feature to process the initial metadata in the
kaprien-repo-worker, in that case the kaprien-rest-api can send it using
the message queue.

Small improvements to Makefile

Closes #13 

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>