### PR TITLE
Infrastructure and automatic tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,15 +55,9 @@ coverage.xml
 *.mo
 *.pot
 
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
+# kaprien stuff:
+data/
+data-test/
 
 # Scrapy stuff:
 .scrapy

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=builder /root/.local/lib/python3.10/site-packages /usr/local/lib/pyt
 FROM pre-final
 
 WORKDIR /opt/kaprien-repo-worker
-
+RUN mkdir /data
 COPY app.py /opt/kaprien-repo-worker
 COPY repo_worker /opt/kaprien-repo-worker/repo_worker
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ stop:
 clean:
 	$(MAKE) stop
 	docker-compose rm --force
+	rm -rf ./data
 
 purge:
 	$(MAKE) clean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,14 +9,13 @@ volumes:
   kaprien-redis-data:
 
 services:
-  kaprien-mq:
+  rabbitmq:
     image: rabbitmq:3.10.7-management-alpine
     container_name: kaprien-mq
     volumes:
      - "kaprien-mq-data:/var/lib/rabbitmq"
      - "kaprien-storage:/var/opt/kaprien/storage"
      - "kaprien-keystorage:/var/opt/kaprien/keystorage"
-     - "kaprien-settings:/var/opt/kaprien/settings/"
     ports:
       - 5672:5672
       - 15672:15672
@@ -26,21 +25,20 @@ services:
     tty: true
 
   kaprien-rest-api:
-    #image: ghcr.io/kaprien/kaprien-rest-api:dev
+    # image: ghcr.io/kaprien/kaprien-rest-api:dev
     image: kaprien-rest-api:dev
     volumes:
-      - kaprien-rest-api-data:/opt/kaprien-rest-api/database
-      - kaprien-settings:/var/opt/kaprien/settings/
+      - kaprien-rest-api-data:/data
     command: uvicorn app:kaprien_app --host 0.0.0.0 --port 8000 --reload
     ports:
       - 80:8000
     environment:
-      - SETTINGS_FILE=/var/opt/kaprien/settings/settings.ini
       - KAPRIEN_RABBITMQ_SERVER="guest:guest@kaprien-mq:5672"
+      - KAPRIEN_REDIS_SERVER="redis://redis"
       - SECRETS_KAPRIEN_TOKEN_KEY="secret"
       - SECRETS_KAPRIEN_ADMIN_PASSWORD="secret"
     depends_on:
-      kaprien-mq:
+      rabbitmq:
         condition: service_healthy
   web:
     image: python:3.10-slim-buster
@@ -60,19 +58,20 @@ services:
   kaprien-repo-worker:
     build:
       context: .
-    command: "watchmedo auto-restart -d /opt/kaprien-repo-worker -R -p '*.py' -- celery -A app worker -l debug -Q metadata_repository -n kaprien@dev"
+    command: "watchmedo auto-restart -d /opt/kaprien-repo-worker -R -p '*.py' -- celery -A app worker -B -l debug -Q metadata_repository -n kaprien@dev"
     environment:
+      - DATA_DIR=./data
       - KAPRIEN_STORAGE_BACKEND="LocalStorage"
       - KAPRIEN_KEYVAULT_BACKEND="LocalKeyVault"
       - KAPRIEN_LOCAL_STORAGE_BACKEND_PATH="/var/opt/kaprien/storage"
       - KAPRIEN_LOCAL_KEYVAULT_PATH="/var/opt/kaprien/keystorage"
-      - KAPRIEN_RABBITMQ_SERVER="guest:guest@kaprien-mq:5672"
+      - KAPRIEN_RABBITMQ_SERVER="guest:guest@rabbitmq:5672"
+      - KAPRIEN_REDIS_SERVER="redis://redis"
       - KAPRIEN_WORKER_ID="dev"
     volumes:
       - ./:/opt/kaprien-repo-worker:z
       - kaprien-storage:/var/opt/kaprien/storage
       - kaprien-keystorage:/var/opt/kaprien/keystorage
-      - kaprien-settings:/var/opt/kaprien/settings/
     depends_on:
-      kaprien-mq:
+      rabbitmq:
         condition: service_healthy

--- a/repo_worker/worker_settings.py
+++ b/repo_worker/worker_settings.py
@@ -1,14 +1,22 @@
 import importlib
 import logging
+import os
 from dataclasses import dataclass
 from typing import Optional
 
-from dynaconf import Dynaconf
+from dynaconf import Dynaconf, loaders
 
 # the 'service import is used by get_config() for automatically discovery
 from repo_worker import services  # noqa
 from repo_worker.tuf import MetadataRepository
 from repo_worker.tuf.interfaces import IKeyVault, IStorage
+
+DATA_DIR = os.getenv("DATA_DIR", "/data")
+os.makedirs(DATA_DIR, exist_ok=True)
+TASK_SETTINGS_FILE = os.path.join(DATA_DIR, "task_settings.ini")
+last_task_settings = Dynaconf(
+    settings_files=[TASK_SETTINGS_FILE],
+)
 
 
 @dataclass
@@ -17,96 +25,115 @@ class WorkerConfig:
     repository: MetadataRepository
 
 
-def get_config(
-    worker_settings: Dynaconf, task_settings: Optional[Dynaconf] = None
-) -> WorkerConfig:
-    if task_settings is not None:
-        for task_k_settings, task_v_setting in task_settings.items():
-            worker_settings.store[task_k_settings] = task_v_setting
+class Configuration:
+    def __init__(self):
+        self.config: WorkerConfig
 
-        worker_settings.update(task_settings)
-
-    settings = worker_settings
-
-    storage_backends = [
-        storage.__name__.upper() for storage in IStorage.__subclasses__()
-    ]
-
-    if type(settings.STORAGE_BACKEND) != str and issubclass(
-        settings.STORAGE_BACKEND, tuple(IStorage.__subclasses__())
-    ):
-        logging.debug(
-            f"STORAGE_BACKEND is defined as {settings.STORAGE_BACKEND}"
-        )
-
-    elif settings.STORAGE_BACKEND.upper() not in storage_backends:
-        raise ValueError(
-            f"Invalid Storage Backend {settings.STORAGE_BACKEND}. Supported "
-            f"Storage Backends {', '.join(storage_backends)}"
-        )
-    else:
-        settings.STORAGE_BACKEND = getattr(
-            importlib.import_module("repo_worker.services"),
-            settings.STORAGE_BACKEND,
-        )
-
-        if missing := [
-            s.name
-            for s in settings.STORAGE_BACKEND.settings()
-            if s.required and s.name not in settings
-        ]:
-            raise AttributeError(
-                f"'Settings' object has not attribute(s) {', '.join(missing)}"
+    def update(
+        self,
+        worker_settings: Dynaconf,
+        task_settings: Optional[Dynaconf] = None,
+    ) -> WorkerConfig:
+        if task_settings is not None:
+            worker_settings.update(task_settings)
+            last_task_settings.update(task_settings)
+            loaders.write(
+                last_task_settings.SETTINGS_FILE_FOR_DYNACONF[0],
+                last_task_settings.to_dict(),
             )
 
-        settings.STORAGE_BACKEND.configure(settings)
-        storage_kwargs = {
-            s.argument: settings.store[s.name]
-            for s in settings.STORAGE_BACKEND.settings()
-        }
-        settings.STORAGE = settings.STORAGE_BACKEND(**storage_kwargs)
+        settings = worker_settings
 
-    keyvault_backends = [
-        keyvault.__name__.upper() for keyvault in IKeyVault.__subclasses__()
-    ]
+        storage_backends = [
+            storage.__name__.upper() for storage in IStorage.__subclasses__()
+        ]
 
-    if type(settings.KEYVAULT_BACKEND) != str and issubclass(
-        settings.KEYVAULT_BACKEND, tuple(IKeyVault.__subclasses__())
-    ):
-        logging.debug(
-            f"KEYVAULT_BACKEND is defined as {settings.KEYVAULT_BACKEND}"
-        )
-
-    elif settings.KEYVAULT_BACKEND.upper() not in keyvault_backends:
-        raise ValueError(
-            f"Invalid Key Vault Backend {settings.KEYVAULT_BACKEND}. "
-            f"Supported Key Vault Backends: {', '.join(keyvault_backends)}"
-        )
-    else:
-        settings.KEYVAULT_BACKEND = getattr(
-            importlib.import_module("repo_worker.services"),
-            settings.KEYVAULT_BACKEND,
-        )
-
-        if missing := [
-            s.name
-            for s in settings.KEYVAULT_BACKEND.settings()
-            if s.required and s.name not in settings
-        ]:
-            raise AttributeError(
-                f"'Settings' object has not attribute(s) {', '.join(missing)}"
+        if type(settings.STORAGE_BACKEND) != str and issubclass(
+            settings.STORAGE_BACKEND, tuple(IStorage.__subclasses__())
+        ):
+            logging.debug(
+                f"STORAGE_BACKEND is defined as {settings.STORAGE_BACKEND}"
             )
 
-        settings.KEYVAULT_BACKEND.configure(settings)
-        keyvault_kwargs = {
-            s.argument: settings.store[s.name]
-            for s in settings.KEYVAULT_BACKEND.settings()
-        }
+        elif settings.STORAGE_BACKEND.upper() not in storage_backends:
+            raise ValueError(
+                f"Invalid Storage Backend {settings.STORAGE_BACKEND}."
+                f"Supported Storage Backends {', '.join(storage_backends)}"
+            )
+        else:
+            settings.STORAGE_BACKEND = getattr(
+                importlib.import_module("repo_worker.services"),
+                settings.STORAGE_BACKEND,
+            )
 
-        settings.KEYVAULT = settings.KEYVAULT_BACKEND(**keyvault_kwargs)
+            if missing := [
+                s.name
+                for s in settings.STORAGE_BACKEND.settings()
+                if s.required and s.name not in settings
+            ]:
+                raise AttributeError(
+                    "'Settings' object has not attribute(s) "
+                    f"{', '.join(missing)}"
+                )
 
-    repository = MetadataRepository(
-        settings.STORAGE, settings.KEYVAULT, settings
-    )
+            settings.STORAGE_BACKEND.configure(settings)
+            storage_kwargs = {
+                s.argument: settings.store[s.name]
+                for s in settings.STORAGE_BACKEND.settings()
+            }
+            settings.STORAGE = settings.STORAGE_BACKEND(**storage_kwargs)
 
-    return WorkerConfig(settings=settings, repository=repository)
+        keyvault_backends = [
+            keyvault.__name__.upper()
+            for keyvault in IKeyVault.__subclasses__()
+        ]
+
+        if type(settings.KEYVAULT_BACKEND) != str and issubclass(
+            settings.KEYVAULT_BACKEND, tuple(IKeyVault.__subclasses__())
+        ):
+            logging.debug(
+                f"KEYVAULT_BACKEND is defined as {settings.KEYVAULT_BACKEND}"
+            )
+
+        elif settings.KEYVAULT_BACKEND.upper() not in keyvault_backends:
+            raise ValueError(
+                f"Invalid Key Vault Backend {settings.KEYVAULT_BACKEND}. "
+                "Supported Key Vault Backends :"
+                f"{', '.join(keyvault_backends)}"
+            )
+        else:
+            settings.KEYVAULT_BACKEND = getattr(
+                importlib.import_module("repo_worker.services"),
+                settings.KEYVAULT_BACKEND,
+            )
+
+            if missing := [
+                s.name
+                for s in settings.KEYVAULT_BACKEND.settings()
+                if s.required and s.name not in settings
+            ]:
+                raise AttributeError(
+                    "'Settings' object has not attribute(s) "
+                    f"{', '.join(missing)}"
+                )
+
+            settings.KEYVAULT_BACKEND.configure(settings)
+            keyvault_kwargs = {
+                s.argument: settings.store[s.name]
+                for s in settings.KEYVAULT_BACKEND.settings()
+            }
+
+            settings.KEYVAULT = settings.KEYVAULT_BACKEND(**keyvault_kwargs)
+
+        repository = MetadataRepository(
+            settings.STORAGE, settings.KEYVAULT, settings
+        )
+
+        self.config = WorkerConfig(settings=settings, repository=repository)
+
+    @property
+    def get(self):
+        return self.config
+
+
+config = Configuration()

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,11 @@ commands =
 setenv =
     KAPRIEN_WORKER_ID = "dev"
     KAPRIEN_RABBITMQ_SERVER = "fakeserver"
+    KAPRIEN_REDIS_SERVER = "redis://fake-redis"
+    KAPRIEN_STORAGE_BACKEND = "LocalStorage"
+    KAPRIEN_LOCAL_STORAGE_BACKEND_PATH = "./data-test"
+    KAPRIEN_KEYVAULT_BACKEND = "LocalKeyVault"
+    DATA_DIR = "./data-test"
 
 commands =
     coverage run --omit='tests/*' -m pytest


### PR DESCRIPTION
On this commit, there are many different work.

- Improve the infrastructure: where the data is stored, how the auxiliary
  services are called (using settings entry) and general cleanup in the
  docker-compose
Closes #24

- Added tasks to the kaprien-repo-worker removing the overhead from
  kaprien-rest-api
Closes #14

- Improved how the Config is used, including the dynamic config passed
  by kaprien-rest-api



Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>