### PR TITLE
Fix issue not bumping snapshot and timestamp

### DIFF
--- a/repo_worker/config.py
+++ b/repo_worker/config.py
@@ -41,6 +41,8 @@ class Configuration:
                 last_task_settings.SETTINGS_FILE_FOR_DYNACONF[0],
                 last_task_settings.to_dict(),
             )
+        else:
+            worker_settings.update(last_task_settings)
 
         settings = worker_settings
 

--- a/repo_worker/kaprien.py
+++ b/repo_worker/kaprien.py
@@ -50,6 +50,7 @@ def main(
     elif action == "automatic_version_bump":
         r = redis.StrictRedis.from_url(runner.get.settings.REDIS_SERVER)
         with r.lock("TUF_REPO_LOCK"):
+            runner.update(worker_settings)
             logging.debug(
                 f"[{action}] starting with settings "
                 f"{runner.get.settings.to_dict()}"


### PR DESCRIPTION
If the repository worker is rebooted it has not anymore the last task settings in the memory.
During the execution of `automatic_version_bump` by kaprien the runner is not calling the update.

Even calling the update, the `config.runner.update` doesn't call try to load the `last_task_settings`.

Closes #37

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>