### PR TITLE
Issue kaprien#issue17 was missing the changed docs

### DIFF
--- a/docs/diagrams/kaprien-repo-worker-C3.puml
+++ b/docs/diagrams/kaprien-repo-worker-C3.puml
@@ -59,7 +59,8 @@ System_Boundary(kaprien_repo_worker, "KAPRIEN-REPO-WORKER") #APPLICATION {
     ContainerDb(data_dir, "/data", "File System", "Service settings\nRepository settings\nUsers db", $tags="storage_service")
 }
 ' Container(kaprien_rest_api, "KAPRIEN-REST-API", $tags="rest_api")
-Container_Ext(broker, "Broker/Backend", "RabbitMQ, Redis, etc", $tags="queue") #Grey
+Container_Ext(broker, "Broker", "RabbitMQ, Redis, etc", $tags="queue") #Grey
+Container_Ext(redis, "Redis", "Redis Server", $tags="queue") #Grey
 Container_Ext(storage, "Metadata Storage", "specific technology", $tags="key_service") #Grey
 Container_Ext(key_storage, "Key Vault Storage", "specific technology", $tags="storage_service") #Grey
 
@@ -71,6 +72,7 @@ Rel(exceptions, services, " ")
 Rel(kaprien, config, " ")
 Rel(config, repository, " ")
 Rel(config, interfaces, " ")
+Rel_U(dynaconf, redis, "Write data")
 Rel_L(config, dynaconf, " ")
 Rel_U(kaprien, celery, " ")
 Rel_D(celery, broker, "Publisher")

--- a/docs/source/devel/design.rst
+++ b/docs/source/devel/design.rst
@@ -38,14 +38,19 @@ Current supported Key Vault Service types:
     - LocalKeyVault (File System)
     - KMS (AWS KMS -- to be implemented)
 
-The ``kaprien-repo-worker`` also stores configuration settings. These are the
-`service settings` and `task settings`.
-The `service settings`` are related to the operational configurations to run the
+The ``kaprien-repo-worker`` stores configuration settings. These are the
+**Worker Settings**.
+
+The ``kaprien-repo-worker``also uses the **Repository Settings**, from
+``KAPRIEN_REDIS_SERVER``.
+
+**Worker Settings**: are related to the operational configurations to run the
 ``kaprien-repo-worker`` such as worker id, Broker, type of Storage, Key
 Vault services and their sub-configurations, etc.
-The `task settings` are given by ``kaprien-rest-api`` inside the task and
-are stored temporarily to run routine tasks such as bumping snapshot and
-timestamp metadata.
+
+**Repository Settings** are given by ``kaprien-rest-api`` and
+are stored in ``KAPRIEN_REDIS_SERVER`` to run routine tasks such as bumping
+snapshot and timestamp metadata, etc.
 
 
 .. uml:: ../../diagrams/kaprien-repo-worker-C2.puml


### PR DESCRIPTION
The implementation of Kaprien Issue 17 (kaprien-repo-worker scalability) was missing the documentation that was updated.

Signed-off-by: Kairo Araujo <kairo@kairo.eti.br>