### PR TITLE
Standardized entrypoint.sh and celery tunning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ FROM pre-final
 WORKDIR /opt/kaprien-repo-worker
 RUN mkdir /data
 COPY app.py /opt/kaprien-repo-worker
-COPY supervisor.conf /data/
+COPY entrypoint.sh /opt/kaprien-repo-worker
+COPY supervisor.conf ${DATA_DIR}/
 COPY repo_worker /opt/kaprien-repo-worker/repo_worker
-ENTRYPOINT ["supervisord", "-c", "/data/supervisor.conf"]
+ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -33,7 +33,6 @@ docker run --env="KAPRIEN_WORKER_ID=worker1" \
     --env="KAPRIEN_BROKER_SERVER=guest:guest@rabbitmq:5672" \
     --env="KAPRIEN_REDIS_SERVER=redis://redis" \
     ghcr.io/kaprien/kaprien-repo-worker:latest \
-    celery -A app worker -B -l debug -Q metadata_repository -n kaprien@dev
 ```
 
 
@@ -97,6 +96,13 @@ Available types:
 
 Container data directory. Default: `/data`
 
-### Volumes
+### Persistent data
 
-* `/data` - File location
+* `$DATA_DIR`. Default: `/data`
+
+### Customization/Tuning
+
+The `kaprien-repo-worker` uses supervisord and uses a `supervisor.conf`
+from `$DATA_DIR`.
+
+It can be used to customize/tuning performance of Celery.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+supervisord -c $DATA_DIR/supervisor.conf

--- a/supervisor-dev.conf
+++ b/supervisor-dev.conf
@@ -1,4 +1,4 @@
-[program:celery]
+[program:kaprien_worker]
 command = celery -A app worker -l debug -Q metadata_repository -n kaprien_%(ENV_KAPRIEN_WORKER_ID)s@dev
 directory = %(here)s
 startsecs = 5
@@ -10,7 +10,7 @@ stderr_logfile_maxbytes = 0
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
-[program:celery_routings]
+[program:kaprien_worker_jobs]
 command = celery -A app worker -B -l debug -Q kaprien_internals -n kaprien_jobs_%(ENV_KAPRIEN_WORKER_ID)s@dev
 directory = %(here)s
 startsecs = 5

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,6 +1,6 @@
-[program:celery]
+[program:kaprien_worker]
 command = celery -A app worker -l info -Q metadata_repository -n kaprien_%(ENV_KAPRIEN_WORKER_ID)s@dev
-directory = %(here)s
+directory = /opt/kaprien-repo-worker
 startsecs = 5
 autostart = true
 autorestart = true
@@ -10,9 +10,9 @@ stderr_logfile_maxbytes = 0
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
-[program:celery_routings]
+[program:kaprien_worker_jobs]
 command = celery -A app worker -B -l info -Q kaprien_internals -n kaprien_jobs_%(ENV_KAPRIEN_WORKER_ID)s@dev
-directory = %(here)s
+directory = /opt/kaprien-repo-worker
 startsecs = 5
 autostart = true
 autorestart = true


### PR DESCRIPTION
- Add `entrypoint.sh` as a standard image ENTRYPOINT
- Add `supervisor.conf` to `$DATA_DIR` end gives to the user the possibility to customize the Celery worker.

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>