### PR TITLE
Fix bump_online_roles retrieving fresh from Redis

### DIFF
--- a/repo_worker/repository.py
+++ b/repo_worker/repository.py
@@ -504,7 +504,7 @@ class MetadataRepository:
     def bump_online_roles(self) -> bool:
         """Bump online Roles (Snapshot, Timestamp, BINS)."""
         with self._redis.lock("TUF_SNAPSHOT_TIMESTAMP"):
-            if self._settings.get("BOOTSTRAP") is None:
+            if self._settings.get_fresh("BOOTSTRAP") is None:
                 logging.info(
                     "[automatic_version_bump] No bootstrap, skipping..."
                 )


### PR DESCRIPTION
To avoid missing the bootstrap status from the Redis in different threads it retrieves fresh from the Redis.

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>