### PR TITLE
Add intermediate state for add/remove_targets

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,8 +58,10 @@ app = Celery(
 )
 
 
-@app.task(serializer="json")
-def kaprien_repo_worker(action: str, payload: Optional[Dict[str, Any]] = None):
+@app.task(serializer="json", bind=True)
+def kaprien_repo_worker(
+    self, action: str, payload: Optional[Dict[str, Any]] = None
+):
     """
     Kaprien Metadata Repository Worker
     """
@@ -69,7 +71,7 @@ def kaprien_repo_worker(action: str, payload: Optional[Dict[str, Any]] = None):
     if payload is None:
         result = repository_action()
     else:
-        result = repository_action(payload)
+        result = repository_action(payload, update_state=self.update_state)
 
     return result
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -31,7 +31,9 @@ class TestApp:
         )
         assert result is True
         assert app.repository.test_action.calls == [
-            pretend.call({"k": "v"}),
+            pretend.call(
+                {"k": "v"}, update_state=app.kaprien_repo_worker.update_state
+            ),
         ]
 
     def test_kaprien_repo_worker_no_payload(self):


### PR DESCRIPTION
This adds to the add/remove_targets an intermediate state as "PUBLISHING".
This states means that the Roles were edited and submitted to "unpublised_metas" in the Redis.

The function _publish_meta_state will wait and send the state back to the Backend Service, until it is published by the job `publish_targets_meta` publishes it.

Closes #8

Improves https://github.com/kaprien/kaprien/issues/17

Signed-off-by: Kairo de Araujo <kairo@kairo.eti.br>