### PR TITLE
feature: Metadata/key rotation

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -889,7 +889,7 @@ class MetadataRepository:
 
         Args:
             payload: payload white the metadata to be rotate
-                {"metadata": "root": Any}
+                example: {"metadata": {"root": Any}}
             update_state: *not used* it is required argument by `app.py`
         """
         metadata = payload.get("metadata")

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -887,9 +887,9 @@ class MetadataRepository:
         Adds support for metadata rotation signed by offline root keys.
 
         Args:
-            payload: payload white the metadata to be rotate
+            payload: contains new metadata
                 example: {"metadata": {"root": Any}}
-            update_state: *not used* it is required argument by `app.py`
+            update_state: not used, but required argument by `app.py`
         """
         metadata = payload.get("metadata")
         if metadata is None:

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -846,7 +846,7 @@ class MetadataRepository:
         # Lock to avoid race conditions. See `LOCK_TIMEOUT` in the Worker guide
         # documentation.
         try:
-            with self._redis.lock(LOCK_TIMESTAMP, timeout=self._timeout):
+            with self._redis.lock(LOCK_TARGETS, timeout=self._timeout):
                 if self._settings.get_fresh("BOOTSTRAP") is None:
                     logging.info(
                         "[automatic_version_bump] No bootstrap, skipping..."

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -884,8 +884,7 @@ class MetadataRepository:
         """
         Rotate TUF metadata.
 
-        This support the rotation of metadata which is signed with offline keys
-        (root keys)
+        Adds support for metadata rotation signed by offline root keys.
 
         Args:
             payload: payload white the metadata to be rotate

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -711,9 +711,8 @@ class MetadataRepository:
 
     def _run_online_roles_bump(self, force: Optional[bool] = False) -> bool:
         """
-        Bumps version and expiration date of targets roles metadata
-        (`Targets` and `Succinct Delegated` targets roles). The function also
-        updates 'snapshot' and 'timestamp'.
+        Bumps version and expiration date of all online roles (`Targets`,
+        `Succinct Delegated` targets roles, `Timestamp` and `Snapshot`).
 
         ** It might require a lock context to avoid race conditions **
 

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -1552,7 +1552,7 @@ class TestMetadataRepository:
         test_repo._settings = pretend.stub(
             get_fresh=pretend.call_recorder(lambda *a: "fake_bootstrap_id")
         )
-        test_repo.bump_target_roles = pretend.call_recorder(lambda: None)
+        test_repo.bump_target_roles = pretend.call_recorder(lambda **kw: None)
 
         result = test_repo.bump_online_roles()
         assert result is True
@@ -1562,7 +1562,7 @@ class TestMetadataRepository:
         assert test_repo._settings.get_fresh.calls == [
             pretend.call("BOOTSTRAP")
         ]
-        assert test_repo.bump_target_roles.calls == [pretend.call()]
+        assert test_repo.bump_target_roles.calls == [pretend.call(force=False)]
 
     def test_bump_online_roles_when_no_bootstrap(self, test_repo):
         @contextmanager
@@ -1710,9 +1710,7 @@ class TestMetadataRepository:
         assert test_repo.bump_target_roles.calls == [pretend.call(force=True)]
         assert repository.datetime.now.calls == [pretend.call()]
 
-    def test_metadata_rotation_online_key_lock_timeout(
-        self, monkeypatch, test_repo
-    ):
+    def test_metadata_rotation_online_key_lock_timeout(self, test_repo):
         fake_new_root_md = pretend.stub(
             signed=pretend.stub(
                 roles={"timestamp": pretend.stub(keyids={"k1": "v1"})},

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -1557,7 +1557,7 @@ class TestMetadataRepository:
         result = test_repo.bump_online_roles()
         assert result is True
         assert test_repo._redis.lock.calls == [
-            pretend.call(repository.LOCK_TIMESTAMP, timeout=60)
+            pretend.call(repository.LOCK_TARGETS, timeout=60)
         ]
         assert test_repo._settings.get_fresh.calls == [
             pretend.call("BOOTSTRAP")
@@ -1579,7 +1579,7 @@ class TestMetadataRepository:
         result = test_repo.bump_online_roles()
         assert result is False
         assert test_repo._redis.lock.calls == [
-            pretend.call(repository.LOCK_TIMESTAMP, timeout=60)
+            pretend.call(repository.LOCK_TARGETS, timeout=60)
         ]
         assert test_repo._settings.get_fresh.calls == [
             pretend.call("BOOTSTRAP")
@@ -1598,7 +1598,7 @@ class TestMetadataRepository:
 
         assert "RSTUF: Task exceed `LOCK_TIMEOUT` (60 seconds)" in str(e)
         assert test_repo._redis.lock.calls == [
-            pretend.call(repository.LOCK_TIMESTAMP, timeout=60)
+            pretend.call(repository.LOCK_TARGETS, timeout=60)
         ]
 
     def test_metadata_rotation_only_root(self, monkeypatch, test_repo):


### PR DESCRIPTION
This commit implements the metadata rotation.

This feature allows RSTUF administrators to rotate the root metadata and the online keys, which requires signing with offline keys (root keys).

Closes #221