### PR TITLE
Move RSTUF to github.com/repository-service-tuf

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: I need help
-    url: https://github.com/vmware/repository-service-tuf
+    url: https://github.com/repository-service-tuf/repository-service-tuf
     about: If you have questions or need help

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,5 +83,5 @@ jobs:
       with:
         name: ${{ github.ref_name }}
         tag_name: ${{ github.ref }}
-        body: "docker pull [ghcr.io/vmware/repository-service-tuf-worker:${{ github.ref_name }}](https://github.com/vmware/repository-service-tuf-worker/pkgs/container/repository-service-tuf-worker)"
+        body: "docker pull [ghcr.io/vmware/repository-service-tuf-worker:${{ github.ref_name }}](https://github.com/repository-service-tuf/repository-service-tuf-worker/pkgs/container/repository-service-tuf-worker)"
         files: /tmp/repository-service-tuf-worker_${{ github.ref_name }}.tar

--- a/README.rst
+++ b/README.rst
@@ -9,16 +9,16 @@ Repository Service for TUF Worker
 
 |Test Docker Image build| |Tests and Lint| |Coverage|
 
-.. |Test Docker Image build| image:: https://github.com/vmware/repository-service-tuf-worker/actions/workflows/test_docker_build.yml/badge.svg
-  :target: https://github.com/vmware/repository-service-tuf-worker/actions/workflows/test_docker_build.yml
-.. |Tests and Lint| image:: https://github.com/vmware/repository-service-tuf-worker/actions/workflows/ci.yml/badge.svg
-  :target: https://github.com/vmware/repository-service-tuf-worker/actions/workflows/ci.yml
+.. |Test Docker Image build| image:: https://github.com/repository-service-tuf/repository-service-tuf-worker/actions/workflows/test_docker_build.yml/badge.svg
+  :target: https://github.com/repository-service-tuf/repository-service-tuf-worker/actions/workflows/test_docker_build.yml
+.. |Tests and Lint| image:: https://github.com/repository-service-tuf/repository-service-tuf-worker/actions/workflows/ci.yml/badge.svg
+  :target: https://github.com/repository-service-tuf/repository-service-tuf-worker/actions/workflows/ci.yml
 .. |Coverage| image:: https://codecov.io/gh/vmware/repository-service-tuf-worker/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/vmware/repository-service-tuf-worker
 
 
 Repository Service for TUF Worker is part of `Repository Service for TUF
-<https://github.com/vmware/repository-service-tuf>`_.
+<https://github.com/repository-service-tuf/repository-service-tuf>`_.
 
 
 Usage
@@ -43,7 +43,7 @@ Getting source code
 ===================
 
 `Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_ the
-repository on `GitHub <https://github.com/vmware/repository-service-tuf-worker>`_ and
+repository on `GitHub <https://github.com/repository-service-tuf/repository-service-tuf-worker>`_ and
 `clone <https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository>`_
 it to your local machine:
 
@@ -58,7 +58,7 @@ you stay up-to-date with our repository:
 
 .. code-block:: console
 
-    git remote add upstream https://github.com/vmware/repository-service-tuf-worker
+    git remote add upstream https://github.com/repository-service-tuf/repository-service-tuf-worker
     git checkout main
     git fetch upstream
     git merge upstream/main

--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ redis_backend = redis.StrictRedis.from_url(
     db=worker_settings.get("REDIS_SERVER_DB_RESULT", 0),
 )
 
-# TODO: Issue https://github.com/vmware/vmware/issues/6
+# TODO: Issue https://github.com/repository-service-tuf/vmware/issues/6
 # BROKER_USE_SSL = {
 #     "keyfile": "data/certs/engine_mq.pem",
 #     "certfile": "data/certs/engine_mq.crt",
@@ -66,7 +66,7 @@ app = Celery(
     task_track_started=True,
     broker_heartbeat=0,
     # broker_use_ssl=BROKER_USE_SSL
-    # (https://github.com/vmware/vmware/issues/6)
+    # (https://github.com/repository-service-tuf/vmware/issues/6)
 )
 
 

--- a/docs/source/devel/index.rst
+++ b/docs/source/devel/index.rst
@@ -36,7 +36,7 @@ We have two types of tasks:
 
 - First are tasks that Repository Work consumes from the Broker Server are
   tasks published by the `Repository Service for TUF API
-  <https://github.com/vmware/repository-service-tuf-api>`_ in the ``repository_metadata``
+  <https://github.com/repository-service-tuf/repository-service-tuf-api>`_ in the ``repository_metadata``
   queue, sent by an API User.
 - Second are tasks that Repository Work generates in the queue
   ``rstuf_internals``. Those are internal tasks for the Repository Worker

--- a/docs/source/devel/known_issues.rst
+++ b/docs/source/devel/known_issues.rst
@@ -2,7 +2,7 @@
 (Solved) Scalability
 ====================
 
- `[Issue 17] <https://github.com/vmware/vmware/issues/17>`_
+ `[Issue 17] <https://github.com/repository-service-tuf/vmware/issues/17>`_
 
 
 The problem
@@ -10,7 +10,7 @@ The problem
 
 The Issue is solved, but still open for improvement. Suggestions for this
 problem can be added to the `opened issue
-<https://github.com/vmware/vmware/issues/17>`_.
+<https://github.com/repository-service-tuf/vmware/issues/17>`_.
 
 
 The scalability works well for ``repository-service-tuf-api`` once you can scale
@@ -206,7 +206,7 @@ Exemple
     @enduml
 
 On one level, we optimize it `by grouping all changes for the same delegated hash
-role <https://github.com/vmware/repository-service-tuf-worker/blob/6ad68ec6d898315fcc42bcddd198619f07618d5e/repository_service_tuf_worker/tuf/repository.py#L173>`_
+role <https://github.com/repository-service-tuf/repository-service-tuf-worker/blob/6ad68ec6d898315fcc42bcddd198619f07618d5e/repository_service_tuf_worker/tuf/repository.py#L173>`_
 , avoiding multiple interactions in the same task.
 
 However we still have a problem with the snapshot and ``timestamp``.
@@ -337,4 +337,4 @@ The expected behavior
     & worker4 -> broker: finish <back:cyan>task 07</back>
     @enduml
 
-Suggestions for this problem can be added to the `opened issue <https://github.com/vmware/vmware/issues/17>`_.
+Suggestions for this problem can be added to the `opened issue <https://github.com/repository-service-tuf/vmware/issues/17>`_.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 setup(
     name="repository-service-tuf-worker",
     version="0.0.1",
-    url="https://github.com/vmware/repository-service-tuf-worker",
+    url="https://github.com/repository-service-tuf/repository-service-tuf-worker",
     author="Kairo de Araujo",
     author_email="kairo@dearaujo.nl",
     description="Repository Service for TUF Worker",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 setup(
     name="repository-service-tuf-worker",
     version="0.0.1",
-    url="https://github.com/repository-service-tuf/repository-service-tuf-worker",
+    url="https://github.com/repository-service-tuf/repository-service-tuf-worker",  # noqa
     author="Kairo de Araujo",
     author_email="kairo@dearaujo.nl",
     description="Repository Service for TUF Worker",


### PR DESCRIPTION
It is part of the process moving RSTUF to OpenSSF organization.