### PR TITLE
Repository Settings write implementation

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -428,9 +428,7 @@ class MetadataRepository:
             threshold = 1
             num_of_keys = 1
             if rolename == Roles.ROOT.value.upper():
-                # The key to the root role is the name of the root file which
-                # uses consistent snapshot or in the format:
-                # <VERSION_NUMBER>.root.json
+                # get treshold and number of keys from given root metadata
                 threshold = root.signed.roles[role.value].threshold
                 num_of_keys = len(root.signatures)
 

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -208,8 +208,10 @@ class MetadataRepository:
         """
         Writes repository settings.
 
-        Repository settings uses Dynaconf and it is persistent in the Redis
-        server. It stores as a dictionary with key and value.
+        Repository settings are stored in a dictionary like Dynaconf object
+        and each of them has its own key and value.
+        Additionally, repository settings are persisted in the Redis server
+        so that they can be reused by multiple RSTUF Worker instances.
 
         Args:
             key: key name


### PR DESCRIPTION
This commit implements two new functionalities in the Repository

* `write_repository_settings`

This method has the functionality to write settings values to the Repository settings. The repository settings uses Dynaconf configured to the Redis Server (`RSTUF_REDIS_SERVER`). This configuration is shared accross the Workers (if multiple).

This function receives a key and value and stores it to the Redis server

* `save_settings`

Uses the `write_repository_settings` to save all configuration from the Repository, which is a defined payload from the RSTUF API service. this function also requires the root TUF metadata.

settings payload:
```json
{
    "expiration": {
        "root": 365,
        "targets": 365,
        "snapshot": 1,
        "timestamp": 1,
        "bins": 1
    },
    "services": {
        "targets_base_url": "http://www.example.com/repository/",
        "number_of_delegated_bins": 4,
        "targets_online_key": True
    }
}
```