### PR TITLE
RSTUF_WORKER_ID as optional container parameter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,6 @@ services:
       - RSTUF_BROKER_SERVER=amqp://guest:guest@rabbitmq:5672
       - RSTUF_SQL_SERVER=postgresql://postgres:secret@postgres:5432
       - RSTUF_REDIS_SERVER=redis://redis
-      - RSTUF_WORKER_ID=dev1
     volumes:
       - ./:/opt/repository-service-tuf-worker:z
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -40,8 +40,7 @@ For more information read the [Deployment documentation](https://repository-serv
 ### Container Parameters
 
 ```shell
-docker run --env="RSTUF_WORKER_ID=worker1" \
-    --env="RSTUF_STORAGE_BACKEND=LocalStorage" \
+docker run --env="RSTUF_STORAGE_BACKEND=LocalStorage" \
     --env="RSTUF_LOCAL_STORAGE_BACKEND_PATH=storage" \
     --env="RSTUF_KEYVAULT_BACKEND=LocalKeyVault" \
     --env="RSTUF_LOCAL_KEYVAULT_PASSWORD=mypass" \
@@ -138,6 +137,10 @@ Available types:
       - cryptographic type of the online key, example: `ed25519`.
       - Default: `ed25519`
       - [Note: At the moment RSTUF Worker supports `ed25519`, `rsa`, `ecdsa`]
+
+#### (Optional) `RSTUF_WORKER_ID`
+
+Custom Worker ID.  Default: `hostname` (Container hostname)
 
 #### (Optional) `DATA_DIR`
 

--- a/entrypoint-dev.sh
+++ b/entrypoint-dev.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+if [ -z $RSTUF_WORKER_ID ]; then
+    export RSTUF_WORKER_ID=$(hostname)
+fi
 alembic upgrade head
 watchmedo auto-restart -d /opt/repository-service-tuf-worker -R -p '*.py' -- supervisord -c supervisor-dev.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+if [ -z $RSTUF_WORKER_ID ]; then
+    export RSTUF_WORKER_ID=$(hostname)
+fi
 alembic upgrade head
 supervisord -c $DATA_DIR/supervisor.conf

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ exclude = repository_service_tuf_worker/__init__.py,venv,.venv,settings.py,.git,
 
 [testenv]
 setenv =
+    RSTUF_WORKER_ID = "test"
     RSTUF_BROKER_SERVER = fakeserver
     RSTUF_REDIS_SERVER = redis://fake-redis
     RSTUF_SQL_SERVER = postgresql://fake-sql

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ exclude = repository_service_tuf_worker/__init__.py,venv,.venv,settings.py,.git,
 
 [testenv]
 setenv =
-    RSTUF_WORKER_ID = dev
     RSTUF_BROKER_SERVER = fakeserver
     RSTUF_REDIS_SERVER = redis://fake-redis
     RSTUF_SQL_SERVER = postgresql://fake-sql


### PR DESCRIPTION
This commit documents and move `RSTUF_WORKER_ID` environment variable as optional.

The `RSTUF_WORKER_ID` is now optional and by default uses the container hostname.

This enables RSTUF user spin multiple replicas using for example kubernetes without dealing to generate multiple environment variables.

Closes #260