### PR TITLE
Update container docs about secrets

### DIFF
--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -130,8 +130,8 @@ Available types:
   - Required variables:
     - ``RSTUF_LOCAL_KEYVAULT_PASSWORD``
       - password used to load the online key
-      - This environment variable supports container secrets when the volume is
-        added to `/run/secrets` path.
+      - This environment variable supports container secrets when the `/run/secrets`
+        volume is added to the path.
         Example: `RSTUF_LOCAL_KEYVAULT_PASSWORD=/run/secrets/ONLINE_KEY_PASSWORD`
   - Optional variables:
     - ``RSTUF_LOCAL_KEYVAULT_PATH``

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -130,6 +130,9 @@ Available types:
   - Required variables:
     - ``RSTUF_LOCAL_KEYVAULT_PASSWORD``
       - password used to load the online key
+      - This environment variable supports container secrets when the volume is
+        added to `/run/secrets` path.
+        Example: `RSTUF_LOCAL_KEYVAULT_PASSWORD=/run/secrets/ONLINE_KEY_PASSWORD`
   - Optional variables:
     - ``RSTUF_LOCAL_KEYVAULT_PATH``
       - file name of the online key


### PR DESCRIPTION
Add the mention about the secrets standard adopted by RSTUF. RSTUF requires user to mount the secrets volume in `/run/secrets` path.