### PR TITLE
Improve the SQL worker container configuration

### DIFF
--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -73,13 +73,30 @@ Example: `redis://redis`
 
 #### (Required) `RSTUF_SQL_SERVER`
 
-SQL server address.
+RSTUF requires [PostgreSQL](https://www.postgresql.org).
 
-The SQL Server must to be compatible with
-[SQLAlchemy](https://www.sqlalchemy.org). RSTUF recomends
-[PostgreSQL](https://www.postgresql.org).
+Example: `postgres:secret@postgres:5432`
 
-Example: `postgresql://postgres:secret@postgres:5432`
+* Optional variables:
+
+  * `RSTUF_SQL_USER` optional information about the user name
+
+    If using this optional variable:
+    - Do not include user in the `RSTUF_SQL_SERVER`.
+    - The `RSTUF_SQL_PASSWORD` becomes required
+
+  * `RSTUF_SQL_PASSWORD` use this variable to inform the password separated.
+    - Do not include the password in the `RSTUF_SQL_SERVER`
+    - This environment variable supports container secrets when the `/run/secrets`
+      volume is added to the path.
+
+  Example:
+  ```
+  RSTUF_SQL_SERVER=sqlserver:5432
+  RSTUF_SQL_USER=postgres
+  RSTUF_SQL_PASSWORD=/run/secrets/POSTGRES_PASSWORD
+  ```
+
 
 #### (Optional) `RSTUF_REDIS_SERVER_PORT`
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -82,10 +82,10 @@ Example: `postgres:secret@postgres:5432`
   * `RSTUF_SQL_USER` optional information about the user name
 
     If using this optional variable:
-    - Do not include user in the `RSTUF_SQL_SERVER`.
+    - Do not include the user in the `RSTUF_SQL_SERVER`.
     - The `RSTUF_SQL_PASSWORD` becomes required
 
-  * `RSTUF_SQL_PASSWORD` use this variable to inform the password separated.
+  * `RSTUF_SQL_PASSWORD` use this variable to provide the password separately.
     - Do not include the password in the `RSTUF_SQL_SERVER`
     - This environment variable supports container secrets when the `/run/secrets`
       volume is added to the path.


### PR DESCRIPTION
This commit improves and gives users more flexibility to configure the SQL server on RSTUF Worker.

The user can now use secrets instead of plain text to configure the SQL server password.

The user is still able to use the previous configuration.

Closes #231