### PR TITLE
LocalKeyVault KeyVault Service Enhancement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,8 +70,8 @@ services:
       - RSTUF_STORAGE_BACKEND=LocalStorage
       - RSTUF_KEYVAULT_BACKEND=LocalKeyVault
       - RSTUF_LOCAL_STORAGE_BACKEND_PATH=/var/opt/repository-service-tuf/storage
-      - RSTUF_LOCAL_KEYVAULT_PATH=/opt/repository-service-tuf-worker/tests/files/key_storage/online.key
-      - RSTUF_LOCAL_KEYVAULT_PASSWORD=strongPass
+      - RSTUF_LOCAL_KEYVAULT_PATH=/opt/repository-service-tuf-worker/tests/files/key_storage
+      - RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass:online-rsa.key,strongPass,rsa
       - RSTUF_BROKER_SERVER=amqp://guest:guest@rabbitmq:5672
       - RSTUF_SQL_SERVER=postgresql://postgres:secret@postgres:5432
       - RSTUF_REDIS_SERVER=redis://redis

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -144,19 +144,32 @@ Available types:
 
 * LocalKeyVault (local file system)
   - Required variables:
-    - ``RSTUF_LOCAL_KEYVAULT_PASSWORD``
-      - password used to load the online key
-      - This environment variable supports container secrets when the `/run/secrets`
-        volume is added to the path.
-        Example: `RSTUF_LOCAL_KEYVAULT_PASSWORD=/run/secrets/ONLINE_KEY_PASSWORD`
-  - Optional variables:
     - ``RSTUF_LOCAL_KEYVAULT_PATH``
-      - file name of the online key
-      - Default: `online.key`
-    - ``RSTUF_LOCAL_KEYVAULT_TYPE``
-      - cryptographic type of the online key, example: `ed25519`.
-      - Default: `ed25519`
-      - [Note: At the moment RSTUF Worker supports `ed25519`, `rsa`, `ecdsa`]
+      - Define the path for the container volume mounted
+        Example: ``RSTUF_LOCAL_KEYVAULT_PATH=/var/opt/repository-service-tuf/key_storage``
+
+    - ``RSTUF_LOCAL_KEYVAULT_KEYS``
+      - Define the key(s) with format ``<file name>,<password>,<(optional) type>``
+        - file name: defines the key file name.
+        - password: credential used to load the key
+        - (optional) type: The key type. Default: `ed25519`
+
+          [Note: At the moment RSTUF Worker supports `ed25519`, `rsa`, `ecdsa`]
+
+        Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass,rsa``
+
+      - Support multiple keys with separator ``:``.
+
+        **It is used in case of metadata/online key rotation.**
+
+        Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass:online-rsa.key,newStrongPass,rsa``
+
+      - This environment variable supports container secrets when the
+        ``/run/secrets`` volume is added to the path. The content must to be
+        the standard format ``<file name>,<password>,<(optional) type>``
+
+        Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=/run/secrets/ONLINE_KEY_1:/run/secrets/ONLINE_KEY_2``
+
 
 #### (Optional) `RSTUF_WORKER_ID`
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -149,8 +149,16 @@ Available types:
         Example: ``RSTUF_LOCAL_KEYVAULT_PATH=/var/opt/repository-service-tuf/key_storage``
 
     - ``RSTUF_LOCAL_KEYVAULT_KEYS``
-      - Define the key(s) with format ``<file name>,<password>,<(optional) type>``
-        - file name: defines the key file name.
+      - Define the key(s) with format ``<file>,<password>,<(optional) type>``
+        - file: defines the key file
+          - `base64|<key content in base64>` allows to inform directly the key content.
+            It will dynamically manage the file in the
+            ``RSTUF_LOCAL_KEYVAULT_PATH``
+
+            Requires content as base64.
+
+            Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=base64|LnRveC8KdmVudi8KLmlkZWEvCi52c2NvZGUvC...,strongPass,rsa``
+
         - password: credential used to load the key
         - (optional) type: The key type. Default: `ed25519`
 
@@ -166,7 +174,7 @@ Available types:
 
       - This environment variable supports container secrets when the
         ``/run/secrets`` volume is added to the path. The content must to be
-        the standard format ``<file name>,<password>,<(optional) type>``
+        the standard format ``<file>,<password>,<(optional) type>``
 
         Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=/run/secrets/ONLINE_KEY_1:/run/secrets/ONLINE_KEY_2``
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -152,8 +152,8 @@ Available types:
       - Define the key(s) with format ``<file>,<password>,<(optional) type>``
         - file: defines the key file
           - `base64|<key content in base64>` allows to inform directly the key content.
-            It will dynamically manage the file in the
-            ``RSTUF_LOCAL_KEYVAULT_PATH``
+            It will dynamically manage the file and write a key file in
+            ``RSTUF_LOCAL_KEYVAULT_PATH`` (write permissions required).
 
             Requires content as base64.
 
@@ -168,7 +168,11 @@ Available types:
 
       - Support multiple keys with separator ``:``.
 
-        **It is used in case of metadata/online key rotation.**
+        It accepts multiple keys, but RSTUF supports only one online key.
+
+        The Local Key Vault will find the key that matches the online key
+        defined in the Root metadata. It is helpful for metadata/key rotation
+        for cases without disruption.
 
         Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass:online-rsa.key,newStrongPass,rsa``
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -152,7 +152,7 @@ Available types:
       - Define the key(s) with format ``<file>,<password>,<(optional) type>``
         - file: defines the key file
           - `base64|<key content in base64>` allows to inform directly the key content.
-            It will dynamically manage the file and write a key file in
+            It will dynamically manage and write a key file in
             ``RSTUF_LOCAL_KEYVAULT_PATH`` (write permissions required).
 
             Requires content as base64.
@@ -166,19 +166,21 @@ Available types:
 
         Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass,rsa``
 
-      - Support multiple keys with separator ``:``.
+      - Accepts multiple keys separated by ``:``.
 
-        It accepts multiple keys, but RSTUF supports only one online key.
+        It accepts multiple keys, but RSTUF supports the usage of only one
+        online key for signing.
 
         The Local Key Vault will find the key that matches the online key
-        defined in the Root metadata. It is helpful for metadata/key rotation
-        for cases without disruption.
+        defined in the root metadata.
+        Allowing multiple keys is helpful for performing metadata/key
+        rotation without disruption.
 
         Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass:online-rsa.key,newStrongPass,rsa``
 
       - This environment variable supports container secrets when the
-        ``/run/secrets`` volume is added to the path. The content must to be
-        the standard format ``<file>,<password>,<(optional) type>``
+        ``/run/secrets`` volume is added to the path. The content must be
+        in the standard format ``<file>,<password>,<(optional) type>``
 
         Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=/run/secrets/ONLINE_KEY_1:/run/secrets/ONLINE_KEY_2``
 

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -35,11 +35,7 @@ class KeyVaultError(Exception):
 class LocalKeyVault(IKeyVault):
     """Local KeyVault type"""
 
-    def __init__(
-        self,
-        path: str,
-        keys: str,
-    ):
+    def __init__(self, path: str, keys: str):
         """Configuration class for RSTUF Worker LocalKeyVault service.
         Manages all settings related to the usage of the online key(s).
 

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+import os
+from dataclasses import dataclass
 from typing import Callable, List, Optional
 
 from securesystemslib.exceptions import (
+    CryptoError,
     Error,
     FormatError,
     StorageError,
@@ -17,6 +20,13 @@ from securesystemslib.signer import Key, SSlibKey, SSlibSigner
 from repository_service_tuf_worker.interfaces import IKeyVault, ServiceSettings
 
 
+@dataclass
+class LocalKey:
+    filename: str
+    password: str
+    type: Optional[str] = "ed25519"
+
+
 class KeyVaultError(Exception):
     pass
 
@@ -26,30 +36,63 @@ class LocalKeyVault(IKeyVault):
 
     def __init__(
         self,
-        key_pass: str,
-        key_path: Optional[str] = "online.key",
-        key_type: Optional[str] = "ed25519",
+        path: str,
+        keys: str,
     ):
         """Configuration class for RSTUF Worker LocalKeyVault service.
-        Manages all settings related to the usage of the online key.
+        Manages all settings related to the usage of the online key(s).
 
         Args:
-            key_pass: password to load the online key.
-            key_path: file path of the online key.
-            key_type: cryptography type of the online key.
+            path: path for key vault (used to define the volume)
+            keys: list of online keys to be used. String uses two separators
+               `:` to separate the keys and `,` to separate the field.
+               `<filename>,<password>,<type>`
+               filename: the filename
+               password: the key password
+               type: optional, default=ed25519
+               Example:`key1.key,pass1:key2.key,pass2,rsa`
         """
-        self._password: str = key_pass
-        self._path: str = key_path
-        self._type: str = key_type
+        self._path: str = path
+        self._keys: str = keys
 
-        if self._password.startswith("/run/secrets/"):
-            # The user has stored their password using container secrets.
-            with open(self._password) as f:
-                secrets_password = f.read().rstrip("\n")
+    @classmethod
+    def _raw_key_parser(cls, keys: str) -> List[LocalKey]:
+        parsed_keys: List[LocalKey] = []
+        for raw_key in keys.split(":"):
+            if raw_key.startswith("/run/secrets/"):
+                # The user has stored their keys using container secrets.
+                with open(raw_key) as f:
+                    key_data = f.read().rstrip("\n").split(",")
+            else:
+                key_data = raw_key.split(",")
 
-            self._password = secrets_password
+            if len(key_data) == 1:
+                logging.error(f"Key {keys.index(raw_key)} is invalid")
+                pass
 
-        self._secrets_handler: Callable = lambda *a: self._password
+            if len(key_data) == 2:  # filename and password
+                parsed_keys.append(
+                    LocalKey(filename=key_data[0], password=key_data[1])
+                )
+
+            elif len(key_data) == 3:  # filename, type, password
+                parsed_keys.append(
+                    LocalKey(
+                        filename=key_data[0],
+                        password=key_data[1],
+                        type=key_data[2],
+                    )
+                )
+            else:
+                logging.error(f"Key {keys.index(raw_key)} is invalid")
+                pass
+
+        if len(parsed_keys) == 0:
+            raise KeyVaultError(
+                "No valid keys in configuration 'RSTUF_LOCAL_KEYVAULT_KEYS'"
+            )
+
+        return parsed_keys
 
     @classmethod
     def configure(cls, settings) -> None:
@@ -57,28 +100,32 @@ class LocalKeyVault(IKeyVault):
         Run actions to check and configure the service using the settings.
         """
         # Check that the online key can be loaded without an error.
-        try:
-            path = settings.LOCAL_KEYVAULT_PATH
-            password: str
-            if settings.LOCAL_KEYVAULT_PASSWORD.startswith("/run/secrets/"):
-                # The user has stored their password using container secrets.
-                with open(settings.LOCAL_KEYVAULT_PASSWORD) as f:
-                    password = f.read().rstrip("\n")
-            else:
-                password = settings.LOCAL_KEYVAULT_PASSWORD
+        path = settings.LOCAL_KEYVAULT_PATH
+        local_keys = cls._raw_key_parser(settings.LOCAL_KEYVAULT_KEYS)
+        valid_key_found = False  # we look for at least one key is load
+        for local_key in local_keys:
+            local_key_path = os.path.join(path, local_key.filename)
+            try:
+                import_privatekey_from_file(
+                    local_key_path, local_key.type, local_key.password
+                )
+                valid_key_found = True
+            except (
+                FormatError,
+                ValueError,
+                UnsupportedLibraryError,
+                StorageError,
+                Error,
+            ) as e:
+                logging.error(str(e))
+                logging.warning(
+                    f"Failed to load {local_key.filename} LocalKeyVault key"
+                )
 
-            import_privatekey_from_file(
-                path, settings.LOCAL_KEYVAULT_TYPE, password
-            )
-        except (
-            FormatError,
-            ValueError,
-            UnsupportedLibraryError,
-            StorageError,
-            Error,
-        ) as e:
-            logging.error(str(e))
-            raise KeyVaultError(f"Cannot read private key file {path}") from e
+        if valid_key_found is False:
+            error = KeyVaultError("No valid keys found in the LocalKeyVault")
+            logging.error("No valid keys found in the LocalKeyVault")
+            raise error
 
     @classmethod
     def settings(cls) -> List[ServiceSettings]:
@@ -86,34 +133,52 @@ class LocalKeyVault(IKeyVault):
         return [
             ServiceSettings(
                 name="LOCAL_KEYVAULT_PATH",
-                argument="key_path",
-                required=False,
-                default="online.key",
-            ),
-            ServiceSettings(
-                name="LOCAL_KEYVAULT_PASSWORD",
-                argument="key_pass",
+                argument="path",
                 required=True,
             ),
             ServiceSettings(
-                name="LOCAL_KEYVAULT_TYPE",
-                argument="key_type",
-                required=False,
-                default="ed25519",
+                name="LOCAL_KEYVAULT_KEYS",
+                argument="keys",
+                required=True,
             ),
         ]
 
+    def _secrets_handler(self, password: str) -> Callable:
+        """Generates simple Callable with password - required by SSLibSigner"""
+        return lambda *a: password
+
     def get(self, public_key: Key) -> SSlibSigner:
         """Return a signer using the online key."""
-        try:
-            priv_key_uri = f"file:{self._path}?encrypted=true"
-            sslib_public_key = SSlibKey.from_dict(
-                public_key.keyid, public_key.to_dict()
-            )
-            return SSlibSigner.from_priv_key_uri(
-                priv_key_uri, sslib_public_key, self._secrets_handler
-            )
-        except ValueError as e:
-            raise KeyVaultError("Cannot load the online key") from e
-        except OSError:
-            raise KeyVaultError(f"Cannot read private key file {self._path}")
+        keys = self._raw_key_parser(self._keys)
+        valid_key = False
+        for key in keys:
+            key_path = os.path.join(self._path, key.filename)
+            priv_key_uri = f"file:{key_path}?encrypted=true"
+            try:
+                sslib_public_key = SSlibKey.from_dict(
+                    public_key.keyid, public_key.to_dict()
+                )
+            except ValueError:
+                logging.error(f"Cannot load the online key {key.filename}")
+                continue
+            except OSError:
+                logging.error(f"Cannot read private key file {key.filename}")
+                continue
+
+            try:
+                sslib_signer = SSlibSigner.from_priv_key_uri(
+                    priv_key_uri,
+                    sslib_public_key,
+                    self._secrets_handler(key.password),
+                )
+                valid_key = True
+            except CryptoError:
+                logging.error(f"Key {key.filename} didn't match")
+                continue
+
+            return sslib_signer
+
+        # if no valid keys found, raise a error to fail the task
+        if valid_key is False:
+            logging.critical("Cannot load a valid online key.")
+            raise KeyVaultError("Cannot load a valid online key")

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -42,12 +42,14 @@ class LocalKeyVault(IKeyVault):
         Args:
             path: path for key vault (used to define the volume)
             keys: list of online keys to be used. String uses two separators
-               `:` to separate the keys and `,` to separate the field.
-               `<file>,<password>,<type>`
-               file: the file or base64 content (base64|<key body in base64>)
-               password: the key password
-               type: optional, default=ed25519
-               Example:`key1.key,pass1:key2.key,pass2,rsa`
+                `:` to separate the keys and `,` to separate the field.
+                `<file>,<password>,<type>`
+                Where:
+                    file: the file name or base64 content in the format:
+                        (base64|<key body in base64>)
+                    password: the key password
+                    type: optional, default=ed25519
+                    Example:`key1.key,pass1:key2.key,pass2,rsa`
         """
         self._path: str = path
         self._keys: str = keys

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
-
+import base64
+import hashlib
 import logging
 import os
 from dataclasses import dataclass
@@ -22,7 +23,7 @@ from repository_service_tuf_worker.interfaces import IKeyVault, ServiceSettings
 
 @dataclass
 class LocalKey:
-    filename: str
+    file: str
     password: str
     type: Optional[str] = "ed25519"
 
@@ -46,14 +47,28 @@ class LocalKeyVault(IKeyVault):
             path: path for key vault (used to define the volume)
             keys: list of online keys to be used. String uses two separators
                `:` to separate the keys and `,` to separate the field.
-               `<filename>,<password>,<type>`
-               filename: the filename
+               `<file>,<password>,<type>`
+               file: the file or base64 content (base64|<key body in base64>)
                password: the key password
                type: optional, default=ed25519
                Example:`key1.key,pass1:key2.key,pass2,rsa`
         """
         self._path: str = path
         self._keys: str = keys
+
+    @classmethod
+    def _base64_key(cls, keyvault_path, base64_key) -> str:
+        key_content = base64_key.split("base64|")[1]
+        hash_key = hashlib.blake2b(key_content.encode("utf-8"), digest_size=16)
+        file_name = hash_key.hexdigest()
+        key_path = os.path.join(keyvault_path, file_name)
+        if os.path.isfile(key_path):
+            return key_path
+        else:
+            with open(key_path, "w") as f:
+                f.write(base64.b64decode(key_content).decode())
+
+            return key_path
 
     @classmethod
     def _raw_key_parser(cls, keys: str) -> List[LocalKey]:
@@ -67,24 +82,24 @@ class LocalKeyVault(IKeyVault):
                 key_data = raw_key.split(",")
 
             if len(key_data) == 1:
-                logging.error(f"Key {keys.index(raw_key)} is invalid")
+                logging.error("Key is invalid")
                 pass
 
             if len(key_data) == 2:  # filename and password
                 parsed_keys.append(
-                    LocalKey(filename=key_data[0], password=key_data[1])
+                    LocalKey(file=key_data[0], password=key_data[1])
                 )
 
             elif len(key_data) == 3:  # filename, type, password
                 parsed_keys.append(
                     LocalKey(
-                        filename=key_data[0],
+                        file=key_data[0],
                         password=key_data[1],
                         type=key_data[2],
                     )
                 )
             else:
-                logging.error(f"Key {keys.index(raw_key)} is invalid")
+                logging.error("Key is invalid")
                 pass
 
         if len(parsed_keys) == 0:
@@ -104,7 +119,10 @@ class LocalKeyVault(IKeyVault):
         local_keys = cls._raw_key_parser(settings.LOCAL_KEYVAULT_KEYS)
         valid_key_found = False  # we look for at least one key is load
         for local_key in local_keys:
-            local_key_path = os.path.join(path, local_key.filename)
+            if local_key.file.startswith("base64|"):
+                local_key_path = cls._base64_key(path, local_key.file)
+            else:
+                local_key_path = os.path.join(path, local_key.file)
             try:
                 import_privatekey_from_file(
                     local_key_path, local_key.type, local_key.password
@@ -118,9 +136,7 @@ class LocalKeyVault(IKeyVault):
                 Error,
             ) as e:
                 logging.error(str(e))
-                logging.warning(
-                    f"Failed to load {local_key.filename} LocalKeyVault key"
-                )
+                logging.warning("Failed to load LocalKeyVault key")
 
         if valid_key_found is False:
             error = KeyVaultError("No valid keys found in the LocalKeyVault")
@@ -152,17 +168,20 @@ class LocalKeyVault(IKeyVault):
         keys = self._raw_key_parser(self._keys)
         valid_key = False
         for key in keys:
-            key_path = os.path.join(self._path, key.filename)
+            if key.file.startswith("base64|"):
+                key_path = self._base64_key(self._path, key.file)
+            else:
+                key_path = os.path.join(self._path, key.file)
             priv_key_uri = f"file:{key_path}?encrypted=true"
             try:
                 sslib_public_key = SSlibKey.from_dict(
                     public_key.keyid, public_key.to_dict()
                 )
             except ValueError:
-                logging.error(f"Cannot load the online key {key.filename}")
+                logging.error("Cannot load the online key")
                 continue
             except OSError:
-                logging.error(f"Cannot read private key file {key.filename}")
+                logging.error("Cannot read private key")
                 continue
 
             try:
@@ -173,7 +192,7 @@ class LocalKeyVault(IKeyVault):
                 )
                 valid_key = True
             except CryptoError:
-                logging.error(f"Key {key.filename} didn't match")
+                logging.error("Key didn't match")
                 continue
 
             return sslib_signer

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -57,14 +57,17 @@ class LocalKeyVault(IKeyVault):
     @classmethod
     def _base64_key(cls, keyvault_path: str, base64_key_body: str) -> str:
         """
-        Decode a base64 key body and store in a file using unique hash file
-        name (based in the data) in the `keyvault_path`
+        Decode a base64 key body and store it in a file using a unique hash
+        file name (based in the data) in the `keyvault_path`
         (`RSTUF_LOCAL_KEYVAYLT_PATH`) and return the key filename.
+
         Args:
             keyvault_path: The key vault path defined in
                 `RSTUF_LOCAL_KEYVAYLT_PATH`.
             base64_key_body: The key body on base64
-        Returns: key file_name as str
+
+        Returns:
+            key file_name as str
         """
         hash_key = hashlib.blake2b(
             base64_key_body.encode("utf-8"), digest_size=16

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -49,6 +49,7 @@ class LocalKeyVault(IKeyVault):
                         (base64|<key body in base64>)
                     password: the key password
                     type: optional, default=ed25519
+
                     Example:`key1.key,pass1:key2.key,pass2,rsa`
         """
         self._path: str = path

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -55,7 +55,7 @@ class LocalKeyVault(IKeyVault):
         self._keys: str = keys
 
     @classmethod
-    def _base64_key(cls, keyvault_path, base64_key_body) -> str:
+    def _base64_key(cls, keyvault_path: str, base64_key_body: str) -> str:
         """
         Decode a base64 key body and store in a file using unique hash file
         name (based in the data) in the `keyvault_path`
@@ -66,15 +66,16 @@ class LocalKeyVault(IKeyVault):
             base64_key_body: The key body on base64
         Returns: key file_name as str
         """
-        key_content = base64_key_body
-        hash_key = hashlib.blake2b(key_content.encode("utf-8"), digest_size=16)
+        hash_key = hashlib.blake2b(
+            base64_key_body.encode("utf-8"), digest_size=16
+        )
         file_name = hash_key.hexdigest()
         key_path = os.path.join(keyvault_path, file_name)
         if os.path.isfile(key_path):
             return file_name
         else:
             with open(key_path, "w") as f:
-                f.write(base64.b64decode(key_content).decode())
+                f.write(base64.b64decode(base64_key_body).decode())
 
             return file_name
 
@@ -104,7 +105,7 @@ class LocalKeyVault(IKeyVault):
                     file = cls._base64_key(path, file.split("base64|")[1])
                 parsed_keys.append(LocalKey(file=file, password=password))
 
-            elif len(key_data) == 3:  # filename, type, password
+            elif len(key_data) == 3:  # filename, password, type
                 file = key_data[0]
                 password = key_data[1]
                 key_type = key_data[2]

--- a/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
@@ -78,13 +78,13 @@ class TestLocalStorageService:
             lambda *a: pretend.stub(decode=pretend.call_recorder(lambda: "k"))
         )
         result = service._base64_key(
-            "/test/key_vault", "base64|fakebase64keybody"
+            "/test/key_vault", "fakebase64keybody"
         )
 
         assert result == "fake_hash"
         assert local.hashlib.blake2b.calls == [
             pretend.call(
-                "base64|fakebase64keybody".encode("utf-8"), digest_size=16
+                "fakebase64keybody".encode("utf-8"), digest_size=16
             )
         ]
         assert local.os.path.isfile.calls == [
@@ -92,7 +92,7 @@ class TestLocalStorageService:
         ]
         assert fake_data.write.calls == [pretend.call("k")]
         assert local.base64.b64decode.calls == [
-            pretend.call("base64|fakebase64keybody")
+            pretend.call("fakebase64keybody")
         ]
 
     def test__raw_key_parser(self):

--- a/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
+from unittest.mock import MagicMock
 
 import pretend
 import pytest
-from securesystemslib.signer import Key, SSlibSigner
 
 from repository_service_tuf_worker.services.keyvault import local
 
@@ -12,23 +12,87 @@ from repository_service_tuf_worker.services.keyvault import local
 class TestLocalStorageService:
     def test_basic_init(self):
         service = local.LocalKeyVault(
-            "password", "custom_online.key", "rsassa-pss-sha256"
+            "/test/key_vault", "custom_online.key,rsassa-pss-sha256"
         )
-        assert service._path == "custom_online.key"
-        assert service._password == "password"
-        assert service._type == "rsassa-pss-sha256"
 
-    def test_basic_init_minimum_settings(self):
-        service = local.LocalKeyVault("password")
-        assert service._path == "online.key"
-        assert service._password == "password"
-        assert service._type == "ed25519"
+        assert service._path == "/test/key_vault"
+        assert service._keys == "custom_online.key,rsassa-pss-sha256"
+
+    def test_basic_init_with_secrets(self):
+        service = local.LocalKeyVault(
+            "/test/key_vault",
+            "/run/secrets/ONLINE_KEY_1:/run/secrets/ONLINE_KEY_2",
+        )
+
+        assert service._path == "/test/key_vault"
+        assert (
+            service._keys
+            == "/run/secrets/ONLINE_KEY_1:/run/secrets/ONLINE_KEY_2"
+        )
+
+    def test__raw_key_parser(self):
+        service = local.LocalKeyVault(
+            "/test/key_vault", "key1.key,pass1:key2.key,pass2,rsa"
+        )
+        parsed_keys = service._raw_key_parser(service._keys)
+
+        assert parsed_keys == [
+            local.LocalKey(
+                filename="key1.key", password="pass1", type="ed25519"
+            ),
+            local.LocalKey(filename="key2.key", password="pass2", type="rsa"),
+        ]
+
+    def test__raw_key_parser_with_secrets(self, monkeypatch):
+        service = local.LocalKeyVault("/test/key_vault", "/run/secrets/KEY1")
+
+        fake_data = pretend.stub(
+            read=pretend.call_recorder(lambda: "key1.key,pass1\n")
+        )
+        fake_file_obj = pretend.stub(
+            __enter__=pretend.call_recorder(lambda: fake_data),
+            __exit__=pretend.call_recorder(lambda *a: None),
+            close=pretend.call_recorder(lambda: None),
+        )
+        monkeypatch.setitem(
+            local.__builtins__, "open", lambda *a: fake_file_obj
+        )
+
+        parsed_keys = service._raw_key_parser(service._keys)
+
+        assert parsed_keys == [
+            local.LocalKey(
+                filename="key1.key", password="pass1", type="ed25519"
+            )
+        ]
+
+    def test__raw_key_parser_with_one_invalid_configuration(self, caplog):
+        service = local.LocalKeyVault(
+            "/test/key_vault", "key1.key:key2.key,pass2,rsa"
+        )
+        caplog.set_level(local.logging.ERROR)
+        parsed_keys = service._raw_key_parser(service._keys)
+
+        assert parsed_keys == [
+            local.LocalKey(filename="key2.key", password="pass2", type="rsa")
+        ]
+        assert "Key 0 is invalid" in caplog.record_tuples[0]
+
+    def test__raw_key_parser_with_invalid_configuration(self):
+        service = local.LocalKeyVault("/test/key_vault", "key1.key:pass2")
+
+        with pytest.raises(local.KeyVaultError) as err:
+            service._raw_key_parser(service._keys)
+
+        assert (
+            "No valid keys in configuration 'RSTUF_LOCAL_KEYVAULT_KEYS'"
+            in str(err)
+        )
 
     def test_configure(self):
         test_settings = pretend.stub(
-            LOCAL_KEYVAULT_PATH="/path/online.key",
-            LOCAL_KEYVAULT_TYPE="ed25519",
-            LOCAL_KEYVAULT_PASSWORD="strongPass",
+            LOCAL_KEYVAULT_PATH="/path/key_vault/",
+            LOCAL_KEYVAULT_KEYS="key1.key,pass1:key2.key,pass2,rsa",
         )
         local.import_privatekey_from_file = pretend.call_recorder(
             lambda *a: {}
@@ -36,81 +100,193 @@ class TestLocalStorageService:
 
         local.LocalKeyVault.configure(test_settings)
         assert local.import_privatekey_from_file.calls == [
-            pretend.call("/path/online.key", "ed25519", "strongPass")
+            pretend.call("/path/key_vault/key1.key", "ed25519", "pass1"),
+            pretend.call("/path/key_vault/key2.key", "rsa", "pass2"),
         ]
 
-    def test_configure_ValueError(self):
+    def test_configure_no_valid_keys(self):
         test_settings = pretend.stub(
-            LOCAL_KEYVAULT_PATH="/path/online.key",
-            LOCAL_KEYVAULT_TYPE="ed25519",
-            LOCAL_KEYVAULT_PASSWORD="strongPass",
+            LOCAL_KEYVAULT_PATH="/path/key_vault/",
+            LOCAL_KEYVAULT_KEYS="key1.key:key2.key",
         )
-        local.import_privatekey_from_file = pretend.raiser(ValueError("error"))
+
+        local.LocalKeyVault._raw_key_parser = pretend.call_recorder(
+            lambda *a: []
+        )
+        with pytest.raises(local.KeyVaultError) as err:
+            local.LocalKeyVault.configure(test_settings)
+
+        assert "No valid keys found in the LocalKeyVault" in str(err)
+        assert local.LocalKeyVault._raw_key_parser.calls == [
+            pretend.call(test_settings.LOCAL_KEYVAULT_KEYS)
+        ]
+
+    def test_configure_sslib_fail_one_key(self, caplog):
+        test_settings = pretend.stub(
+            LOCAL_KEYVAULT_PATH="/path/key_vault/",
+            LOCAL_KEYVAULT_KEYS="key1,pass1:key2,pass2,rsa",
+        )
+        caplog.set_level(local.logging.WARNING)
+        local.LocalKeyVault._raw_key_parser = pretend.call_recorder(
+            lambda *a: [
+                local.LocalKey(filename="key1", password="pass1"),
+                local.LocalKey(filename="key2", password="pass2", type="rsa"),
+            ]
+        )
+        mocked_import_pk_from_file = MagicMock()
+        mocked_import_pk_from_file.side_effect = [
+            local.FormatError("Invalid format"),
+            None,
+        ]
+        local.import_privatekey_from_file = mocked_import_pk_from_file
+
+        local.LocalKeyVault.configure(test_settings)
+
+        assert caplog.record_tuples == [
+            ("root", 40, "Invalid format"),
+            ("root", 30, "Failed to load key1 LocalKeyVault key"),
+        ]
+        assert local.LocalKeyVault._raw_key_parser.calls == [
+            pretend.call(test_settings.LOCAL_KEYVAULT_KEYS)
+        ]
+
+    def test_configure_sslib_fail_all_keys(self, caplog):
+        test_settings = pretend.stub(
+            LOCAL_KEYVAULT_PATH="/path/key_vault/",
+            LOCAL_KEYVAULT_KEYS="key1,pass1:key2,rsa,pass2",
+        )
+        caplog.set_level(local.logging.WARNING)
+        local.LocalKeyVault._raw_key_parser = pretend.call_recorder(
+            lambda *a: [
+                local.LocalKey(filename="key1", password="pass1"),
+                local.LocalKey(filename="key2", password="pass2", type="rsa"),
+            ]
+        )
+        local.import_privatekey_from_file = pretend.raiser(
+            local.FormatError("Invalid format")
+        )
 
         with pytest.raises(local.KeyVaultError) as err:
             local.LocalKeyVault.configure(test_settings)
 
-        assert "Cannot read private key file" in str(err)
+        assert "No valid keys found in the LocalKeyVault" in str(err)
+
+        assert caplog.record_tuples == [
+            ("root", 40, "Invalid format"),
+            ("root", 30, "Failed to load key1 LocalKeyVault key"),
+            ("root", 40, "Invalid format"),
+            ("root", 30, "Failed to load key2 LocalKeyVault key"),
+            ("root", 40, "No valid keys found in the LocalKeyVault"),
+        ]
+        assert local.LocalKeyVault._raw_key_parser.calls == [
+            pretend.call(test_settings.LOCAL_KEYVAULT_KEYS)
+        ]
 
     def test_settings(self):
-        service = local.LocalKeyVault("password", "online.key", "ed25519")
+        service = local.LocalKeyVault(
+            "/test/key_vault", "key1.key,pass1:key2.key,rsa,pass2"
+        )
         service_settings = service.settings()
 
         assert service_settings == [
             local.ServiceSettings(
                 name="LOCAL_KEYVAULT_PATH",
-                argument="key_path",
-                required=False,
-                default="online.key",
-            ),
-            local.ServiceSettings(
-                name="LOCAL_KEYVAULT_PASSWORD",
-                argument="key_pass",
+                argument="path",
                 required=True,
             ),
             local.ServiceSettings(
-                name="LOCAL_KEYVAULT_TYPE",
-                argument="key_type",
-                required=False,
-                default="ed25519",
+                name="LOCAL_KEYVAULT_KEYS",
+                argument="keys",
+                required=True,
             ),
         ]
 
     def test_get(self):
-        service = local.LocalKeyVault("key_password", "online.key", "ed25519")
-        key_dict = {
-            "keytype": "ed25519",
-            "scheme": "ed25519",
-            "keyval": {
-                "public": "abc",
-            },
-        }
-        key = Key.from_dict("keyid", key_dict)
-        signer = SSlibSigner(key_dict)
-        local.SSlibSigner = pretend.stub(
-            from_priv_key_uri=pretend.call_recorder(lambda *a: signer)
+        service = local.LocalKeyVault(
+            "/test/key_vault", "key1.key,pass1:key2.key,pass2,rsa"
         )
-        result = service.get(key)
-        assert result == signer
-        private_key_uri = "file:online.key?encrypted=true"
+        fake_key = pretend.stub(
+            keyid="keyid", to_dict=pretend.call_recorder(lambda: {"k": "v"})
+        )
+        local.SSlibKey.from_dict = pretend.call_recorder(
+            lambda *a: "fake_public_key"
+        )
+        local.SSlibSigner.from_priv_key_uri = pretend.call_recorder(
+            lambda *a: "fake_signer"
+        )
+        service._secrets_handler = pretend.call_recorder(lambda pwd: pwd)
+        result = service.get(fake_key)
+
+        assert result == "fake_signer"
         assert local.SSlibSigner.from_priv_key_uri.calls == [
-            pretend.call(private_key_uri, key, service._secrets_handler)
+            pretend.call(
+                "file:/test/key_vault/key1?encrypted=true",
+                "fake_public_key",
+                "pass1",
+            )
+        ]
+        assert local.SSlibKey.from_dict.calls == [
+            pretend.call("keyid", {"k": "v"})
+        ]
+        assert service._secrets_handler.calls == [pretend.call("pass1")]
+
+    def test_get_fail_first_key(self, caplog):
+        caplog.set_level(local.logging.ERROR)
+        service = local.LocalKeyVault(
+            "/test/key_vault", "key1.key,pass1:key2.key,pass2,rsa"
+        )
+        fake_key = pretend.stub(
+            keyid="keyid", to_dict=pretend.call_recorder(lambda: {"k": "v"})
+        )
+        mocked_sslibkey_from_dict = MagicMock()
+        mocked_sslibkey_from_dict.side_effect = [
+            ValueError("Failed load online key"),
+            "fake_public_key",
+        ]
+        local.SSlibKey.from_dict = mocked_sslibkey_from_dict
+        local.SSlibSigner.from_priv_key_uri = pretend.call_recorder(
+            lambda *a: "fake_signer"
+        )
+        service._secrets_handler = pretend.call_recorder(lambda pwd: pwd)
+
+        result = service.get(fake_key)
+
+        assert result == "fake_signer"
+        assert local.SSlibSigner.from_priv_key_uri.calls == [
+            pretend.call(
+                "file:/test/key_vault/key2?encrypted=true",
+                "fake_public_key",
+                "pass2",
+            )
+        ]
+        assert service._secrets_handler.calls == [pretend.call("pass2")]
+        assert caplog.record_tuples == [
+            ("root", 40, "Cannot load the online key key1")
         ]
 
-    def test_get_securesystemslib_error(self):
-        service = local.LocalKeyVault("key_password", "online.key", "ed25519")
-        key_dict = {
-            "keytype": "ed25519",
-            "scheme": "ed25519",
-            "keyval": {
-                "public": "abc",
-            },
-        }
-        key = Key.from_dict("keyid", key_dict)
-        local.SSlibSigner = pretend.stub(
-            from_priv_key_uri=pretend.raiser(ValueError("problem"))
+    def test_get_fail_all_configured_keys(self, caplog):
+        caplog.set_level(local.logging.ERROR)
+        service = local.LocalKeyVault(
+            "/test/key_vault", "key1.key,pass1:key2.key,pass2,rsa"
+        )
+        fake_key = pretend.stub(
+            keyid="keyid", to_dict=pretend.call_recorder(lambda: {"k": "v"})
+        )
+        mocked_sslibkey_from_dict = MagicMock()
+        mocked_sslibkey_from_dict.side_effect = [
+            FileNotFoundError("Cannot find file"),
+            None,
+        ]
+        local.SSlibKey.from_dict = mocked_sslibkey_from_dict
+        local.SSlibSigner.from_priv_key_uri = pretend.raiser(
+            local.CryptoError("Wrong password")
         )
         with pytest.raises(local.KeyVaultError) as err:
-            service.get(key)
+            service.get(fake_key)
 
-        assert "Cannot load the online key" in str(err)
+        assert "Cannot load a valid online key" in str(err)
+        assert caplog.record_tuples == [
+            ("root", 40, "Cannot read private key file key1"),
+            ("root", 40, "Key key2 didn't match"),
+            ("root", 50, "Cannot load a valid online key."),
+        ]

--- a/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
@@ -77,15 +77,11 @@ class TestLocalStorageService:
         local.base64.b64decode = pretend.call_recorder(
             lambda *a: pretend.stub(decode=pretend.call_recorder(lambda: "k"))
         )
-        result = service._base64_key(
-            "/test/key_vault", "fakebase64keybody"
-        )
+        result = service._base64_key("/test/key_vault", "fakebase64keybody")
 
         assert result == "fake_hash"
         assert local.hashlib.blake2b.calls == [
-            pretend.call(
-                "fakebase64keybody".encode("utf-8"), digest_size=16
-            )
+            pretend.call("fakebase64keybody".encode("utf-8"), digest_size=16)
         ]
         assert local.os.path.isfile.calls == [
             pretend.call("/test/key_vault/fake_hash")

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,8 @@ setenv =
     RSTUF_STORAGE_BACKEND = LocalStorage
     RSTUF_LOCAL_STORAGE_BACKEND_PATH = ./data-test/s
     RSTUF_KEYVAULT_BACKEND = LocalKeyVault
-    RSTUF_LOCAL_KEYVAULT_PASSWORD = "strongPass"
+    RSTUF_LOCAL_KEYVAULT_PATH = ./data-test/kv
+    RSTUF_LOCAL_KEYVAULT_KEYS = "online.key,strongPass"
     DATA_DIR = ./data-test
 
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This commit proposes a new design to the LocalKeyVaul, a KeyVault service.

This commit gives the flexibility to the user to configure multiple online keys.
RSTUF supports a single online key. However, multiple online keys configuration must be required during RSTUF operation to reduce service disruption.

The most common use case is Online Key rotation.

A user who wants to rotate the key must update all the RSTUF Workers with the current and new keys. In that way, the RSTUF Workers will always find out which key matches the online key configured in the TUF root metadata.

This proposal will change the LocalKeyVault to use two environment variables:

`RSTUF_LOCAL_KEYVAULT_PATH`, which maps to the container volume mapped to the container running. This will also be used to support the key as a string content (such as GitHub secrets).

`RSTUF_LOCAL_KEYVAULT_KEYS` to declare the online keys. It uses a similar syntax used by the PATH on Unix systems. It has a separator `:` which allows the user use multiple keys.

The syntax is `<filename>,<password>,<(Optional)type>` where:
 - file name: defines the key file name.
 - password: credential used to load the key.
 - (optional) type: The key type. Default: `ed25519`

Example: `RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass,rsa`

Multiple keys are supported as
`RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass:online-rsa.key,newStrongPass,rsa`

The new `RSTUF_LOCAL_KEYVAULT_KEYS` also supports secrets containers when mounted in `/run/secrets`.

Closes #271 
Closes #253 