### PR TITLE
Simplify RSTUF Worker development environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,11 +40,8 @@ services:
     ports:
       - 80:80
     environment:
-      - RSTUF_BOOTSTRAP_NODE=true
       - RSTUF_BROKER_SERVER="amqp://guest:guest@rabbitmq:5672"
       - RSTUF_REDIS_SERVER="redis://redis"
-      - SECRETS_RSTUF_TOKEN_KEY="secret"
-      - SECRETS_RSTUF_ADMIN_PASSWORD="secret"
     depends_on:
       rabbitmq:
         condition: service_healthy


### PR DESCRIPTION
This simplifies the RSTUF Worker development enviornment for the RSTUF API container:
- Remove authentication
- Remove old required environment variable to enable bootstrap endpoint