### PR TITLE
fix keyvault misspelled and Docker README

### DIFF
--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -43,7 +43,8 @@ For more information read the [Deployment documentation](https://repository-serv
 docker run --env="RSTUF_STORAGE_BACKEND=LocalStorage" \
     --env="RSTUF_LOCAL_STORAGE_BACKEND_PATH=storage" \
     --env="RSTUF_KEYVAULT_BACKEND=LocalKeyVault" \
-    --env="RSTUF_LOCAL_KEYVAULT_PASSWORD=mypass" \
+    --env="RSTUF_LOCAL_KEYVAULT_PATH=keyvault" \
+    --env="RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass" \
     --env="RSTUF_BROKER_SERVER=guest:guest@rabbitmq:5672" \
     --env="RSTUF_REDIS_SERVER=redis://redis" \
     --env="RSTUF_SQL_SERVER=postgresql://postgres:secret@postgres:5432" \

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -60,11 +60,11 @@ class LocalKeyVault(IKeyVault):
         """
         Decode a base64 key body and store it in a file using a unique hash
         file name (based in the data) in the `keyvault_path`
-        (`RSTUF_LOCAL_KEYVAYLT_PATH`) and return the key filename.
+        (`RSTUF_LOCAL_KEYVAULT_PATH`) and return the key filename.
 
         Args:
             keyvault_path: The key vault path defined in
-                `RSTUF_LOCAL_KEYVAYLT_PATH`.
+                `RSTUF_LOCAL_KEYVAULT_PATH`.
             base64_key_body: The key body on base64
 
         Returns:


### PR DESCRIPTION
- Fix keyvault misspelled `KEYVAYLT` in docstrings
- Fix LocalKeyVault example in the Docker readme using old environment settings