### PR TITLE
Refactoring metadata update

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -982,6 +982,13 @@ class MetadataRepository:
         self, current_root: Metadata[Root], new_root: Metadata[Root]
     ):
         """Verify if the new metadata is a trusted Root metadata"""
+
+        # Verify the Type
+        if new_root.signed.type != Root.type:
+            raise RepositoryError(
+                f"Expected 'root', got '{new_root.signed.type}'"
+            )
+
         # Verify that new root is signed by trusted root
         current_root.verify_delegate(Root.type, new_root)
 
@@ -993,12 +1000,6 @@ class MetadataRepository:
             raise BadVersionNumberError(
                 f"Expected root version {current_root.signed.version + 1}"
                 f" instead got version {new_root.signed.version}"
-            )
-
-        # Verify the Type
-        if new_root.signed.type != Root.type:
-            raise RepositoryError(
-                f"Expected 'root', got '{new_root.signed.type}'"
             )
 
     def _root_metadata_update(
@@ -1113,8 +1114,8 @@ class MetadataRepository:
         ] = None,  # It is required (see: app.py)
     ) -> Dict[str, Any]:
         deprecation_message = (
-            "Function `metadata_rotation` will be deprecated on version "
-            "1.0.0. Use `metadata_update`."
+            "`metadata_rotation` is deprecated, use `metadata_update` instead."
+            " It will be removed in version 1.0.0."
         )
         warnings.warn(deprecation_message, DeprecationWarning)
         logging.warn(deprecation_message)

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -1985,32 +1985,24 @@ class TestMetadataRepository:
             pretend.call(repository.Root.type, fake_new_root_md)
         ]
 
-    def test__trusted_root_update_bady_type(self, test_repo):
+    def test__trusted_root_update_bad_type(self, test_repo):
         fake_new_root_md = pretend.stub(
             signed=pretend.stub(
                 roles={"timestamp": pretend.stub(keyids={"k1": "v1"})},
                 version=2,
                 type=repository.Snapshot.type,
             ),
-            verify_delegate=pretend.call_recorder(lambda *a: None),
         )
         fake_old_root_md = pretend.stub(
             signed=pretend.stub(
-                roles={"timestamp": pretend.stub(keyids={"k1": "v1"})},
+                roles={"root": pretend.stub(keyids={"k1": "v1"})},
                 version=1,
             ),
-            verify_delegate=pretend.call_recorder(lambda *a: None),
         )
 
         with pytest.raises(repository.RepositoryError) as err:
             test_repo._trusted_root_update(fake_old_root_md, fake_new_root_md)
         assert "Expected 'root', got 'snapshot'" in str(err)
-        assert fake_new_root_md.verify_delegate.calls == [
-            pretend.call(repository.Root.type, fake_new_root_md)
-        ]
-        assert fake_old_root_md.verify_delegate.calls == [
-            pretend.call(repository.Root.type, fake_new_root_md)
-        ]
 
     def test__root_metadata_update(self, monkeypatch, test_repo):
         fake_new_root_md = pretend.stub(
@@ -2266,8 +2258,8 @@ class TestMetadataRepository:
                 "root",
                 30,
                 (
-                    "Function `metadata_rotation` will be deprecated on "
-                    "version 1.0.0. Use `metadata_update`."
+                    "`metadata_rotation` is deprecated, use `metadata_update` "
+                    "instead. It will be removed in version 1.0.0."
                 ),
             )
         ]


### PR DESCRIPTION
It aligns the process name with the function name of the other
components (API and CLI).

Renames the function from `metadata_rotation` to `metadata_update`.

Add the `metadata_rotation` function, which calls the
`metadata_update` but also gives a warning and warning logs.
It gives compatibility for users using the RSTUF API v2.3.0b1 with
RSTUF Worker until version >= v0.4.0b1 > v1.0.0.

Fix the unit tests and add an extra test to check the deprecation warning.

Add support to multiple metadata rotation types 
Even now, the RSTUF process uses Online Key only for Root Metadata; this
PR improves the Metadata Update process to support the future
multiple Metadata types.

This also makes more clear with the helper function, where all the Root
Metadata process.

Add/extend root check in a helper function 
Add some trust checks in the root metadata. It is based on python-tuf
checks.

Closes #302 