### PR TITLE
fix: move Key to SSlibKey

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -18,7 +18,7 @@ from celery.exceptions import ChordError
 from celery.result import AsyncResult, states
 from dynaconf.loaders import redis_loader
 from securesystemslib.exceptions import StorageError  # type: ignore
-from securesystemslib.signer import Key
+from securesystemslib.signer import SSlibKey
 from tuf.api.exceptions import BadVersionNumberError, RepositoryError
 from tuf.api.metadata import (  # noqa
     SPECIFICATION_VERSION,
@@ -560,7 +560,7 @@ class MetadataRepository:
         # service.
         for delegated_name in succinct_roles.get_roles():
             targets.signed.add_key(
-                Key.from_securesystemslib_key(
+                SSlibKey.from_securesystemslib_key(
                     self._key_storage_backend.get(public_key).key_dict
                 ),
                 delegated_name,

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -613,7 +613,7 @@ class TestMetadataRepository:
             lambda *a: fake_root_md
         )
         repository.Targets.add_key = pretend.call_recorder(lambda *a: None)
-        repository.Key.from_securesystemslib_key = pretend.call_recorder(
+        repository.SSlibKey.from_securesystemslib_key = pretend.call_recorder(
             lambda *a: "key"
         )
         monkeypatch.setattr(
@@ -652,7 +652,7 @@ class TestMetadataRepository:
         assert repository.Metadata.from_dict.calls == [
             pretend.call(payload["metadata"]["root"])
         ]
-        assert repository.Key.from_securesystemslib_key.calls == [
+        assert repository.SSlibKey.from_securesystemslib_key.calls == [
             pretend.call({"k": "v"}),
             pretend.call({"k": "v"}),
         ]


### PR DESCRIPTION
The change is required for python-tuf 3.0.0

`Key.from_securesystemslib_key()` was removed and requires to replace by the `SSlibKey.from_securesystemslib_key()`

https://github.com/theupdateframework/python-tuf/blob/v3.0.0/docs/CHANGELOG.md#v300

Closes #316