### PR TITLE
Fix diagrams causing error in Umbrella Docs

### DIFF
--- a/docs/diagrams/repository-service-tuf-worker-C2.puml
+++ b/docs/diagrams/repository-service-tuf-worker-C2.puml
@@ -24,8 +24,8 @@
 !include <azure/Security/AzureKeyVault>
 
 !include <awslib/AWSCommon>
-!include <awslib/SecurityIdentityAndCompliance/KeyManagementService>
-!include <awslib/Storage/S3Bucket>
+!include <awslib/SecurityIdentityCompliance/KeyManagementService>
+!include <awslib/Storage/SimpleStorageService>
 
 sprite $rstuf [125x125/16z] {
 xC610000082W_QaNgG8009WTCz6QL8M1S585A8ha_T_sYavpCdYEtVwptUsRzNUX81N3yejHXZJDESzJ2b3vZI1cCq-EaD-2XiNCQYbRRRfrAwKs_I2_dbZC


### PR DESCRIPTION
Fix the diagrams that uses the plantuml awslib

The awslib changed some of their icons which is causing error in the plantuml build

```
plantuml -o ../source/_static/ -tpng docs/diagrams/*.puml
Error line 27 in file: docs/diagrams/repository-service-tuf-worker-C2.puml
Some diagram description contains errors
make: *** [Makefile:21: docs] Error 200
```