### PR TITLE
Exit the container if database is not ready

### DIFF
--- a/entrypoint-dev.sh
+++ b/entrypoint-dev.sh
@@ -2,5 +2,10 @@
 if [ -z $RSTUF_WORKER_ID ]; then
     export RSTUF_WORKER_ID=$(hostname)
 fi
+
 alembic upgrade head
+if [[ $? -ne 0 ]]; then
+    echo "Failed to initiate the database"
+    exit 1
+fi
 watchmedo auto-restart -d /opt/repository-service-tuf-worker -R -p '*.py' -- supervisord -c supervisor-dev.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,10 @@
 if [ -z $RSTUF_WORKER_ID ]; then
     export RSTUF_WORKER_ID=$(hostname)
 fi
+
 alembic upgrade head
+if [[ $? -ne 0 ]]; then
+    echo "Failed to initiate the database"
+    exit 1
+fi
 supervisord -c $DATA_DIR/supervisor.conf


### PR DESCRIPTION
This check fails the container start in case the Postgres has a misconfiguration or it is not healthy.

The current version of RSTUF will not handle it if the database migrations (`allambic`) fail, and the container will stay up and running.

The failure will be noticed only the user does one action, for example, bootstrap, add a target etc.

The RSTUF user/admin needs to ensure the container is running before use.

Example:
If the user configures the RSTUF Worker with the wrong credentials to Postgres and starts the RSTUF Worker, it will fail the database migrations -- not creating the initial database -- and the container will continue up and running.

When the user tries a bootstrap, it will fail due to the credential.

```shell
Starting online bootstrap
Bootstrap status: ACCEPTED (abc75745ab6b48d9a8acefe7e35dcf4a)
Bootstrap status: STARTED
..Bootstrap status: FAILURE
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Failed: {"data":{"task_id":"abc75745ab6b48d9a8acefe7e35dcf4a","state":"FAILURE","result":"<class                  │
│ 'sqlalchemy.exc.OperationalError'>(['(psycopg2.OperationalError) FATAL:  password authentication failed for user  │
│ \"postgres\"\\n'])"},"message":"Task state."}                                                                     │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

This commit make the container entrypoint fail early.