### PR TITLE
Fix twice bumping bins and no automatic bump

### DIFF
--- a/repository_service_tuf_worker/models/targets/crud.py
+++ b/repository_service_tuf_worker/models/targets/crud.py
@@ -88,6 +88,13 @@ def read_role_by_rolename(
     )
 
 
+def read_all_roles(db: Session) -> List[models.RSTUFTargetRoles]:
+    """
+    Read a all Target bin roles.
+    """
+    return db.query(models.RSTUFTargetRoles).all()
+
+
 def read_roles_joint_files(
     db: Session, rolenames: List[str]
 ) -> List[models.RSTUFTargetRoles]:

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -310,9 +310,7 @@ class MetadataRepository:
         if persist:
             self._persist(role, role_name)
 
-    def _update_timestamp(
-        self, snapshot_version: Optional[int] = None
-    ) -> Metadata[Timestamp]:
+    def _update_timestamp(self, snapshot_version: int) -> Metadata[Timestamp]:
         """
         Loads 'timestamp', updates meta info about passed 'snapshot'
         metadata, bumps version and expiration, signs and persists.
@@ -325,8 +323,7 @@ class MetadataRepository:
         timestamp: Metadata[Timestamp] = self._storage_backend.get(
             Timestamp.type, None
         )
-        if snapshot_version:
-            timestamp.signed.snapshot_meta = MetaFile(version=snapshot_version)
+        timestamp.signed.snapshot_meta = MetaFile(version=snapshot_version)
 
         self._bump_and_persist(timestamp, Timestamp.type)
 

--- a/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
+++ b/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
@@ -158,6 +158,20 @@ class TestCrud:
         assert mocked_filter.filter.calls == [pretend.call(True)]
         assert mocked_first.first.calls == [pretend.call()]
 
+    def test_read_all_roles(self):
+        mocked_all = pretend.stub(
+            all=pretend.call_recorder(lambda: [crud.models.RSTUFTargetRoles])
+        )
+        mocked_db = pretend.stub(
+            query=pretend.call_recorder(lambda *a: mocked_all)
+        )
+        test_result = crud.read_all_roles(mocked_db)
+        assert test_result == [crud.models.RSTUFTargetRoles]
+        assert mocked_db.query.calls == [
+            pretend.call(crud.models.RSTUFTargetRoles)
+        ]
+        assert mocked_all.all.calls == [pretend.call()]
+
     def test_read_roles_joint_files(self):
         crud.models.RSTUFTargetRoles = pretend.stub(
             rolename=pretend.stub(in_=pretend.call_recorder(lambda *a: True))


### PR DESCRIPTION
With this pr I fix two bugs:
- bug where two bin versions will be published on every bump_online_roles call or on every automatic bump of online roles because of expiry
- bug where a bin/bins doesn't contain target files and it couldn't be updated because of that in update_snapshot

Closes #328 #330

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>