### PR TITLE
Fix the alembic parsing env var for SQL Server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,9 @@ services:
       - RSTUF_LOCAL_KEYVAULT_PATH=/opt/repository-service-tuf-worker/tests/files/key_storage
       - RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass:online-rsa.key,strongPass,rsa
       - RSTUF_BROKER_SERVER=amqp://guest:guest@rabbitmq:5672
-      - RSTUF_SQL_SERVER=postgresql://postgres:secret@postgres:5432
+      - RSTUF_SQL_SERVER=postgres:5432
+      - RSTUF_SQL_USER=postgres
+      - RSTUF_SQL_PASSWORD=secret
       - RSTUF_REDIS_SERVER=redis://redis
     volumes:
       - ./:/opt/repository-service-tuf-worker:z


### PR DESCRIPTION
The bug's root cause is because RSTUF Worker supports more detailed configuration for the SQL Server, allowing users to use the SQL password from secret vaults.

This commit
* Do a better parsing from the environment variables for the Alembic
* Change the development setup to use multiple environment variables for early detection in case of regression. Note that RSTUF API will use the simple configuration in one environment variable.

Closes #338