### PR TITLE
Standardize RSTUF Worker tasks result

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
-
+import datetime
 from types import ModuleType
 
 import pretend
@@ -27,3 +27,14 @@ def app(test_repo: MetadataRepository) -> ModuleType:
 
     app.repository = test_repo
     return app
+
+
+@pytest.fixture()
+def mocked_datetime(monkeypatch):
+    fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+    fake_datetime = pretend.stub(now=pretend.call_recorder(lambda: fake_time))
+    monkeypatch.setattr(
+        "repository_service_tuf_worker.repository.datetime", fake_datetime
+    )
+
+    return fake_datetime


### PR DESCRIPTION
This commit implements a standardized task result for RSTUF Worker.

This implementation gives the user a more consistent task result, making it easy to parse the tasks and implement flows using the RSTUF in general. For example, to create call back and task management for RSTUF Operations such as adding artifacts, removing, publishing, signing metadata, etc.

The task results have the following standard.

```python
{
    "task_id": "be930844ee0f4396b86a08de90117680",
    "state": "SUCCESS",    # Celery Task State
    "result": {  # Task Result
      "task": "update_settings",  # Task requested
      "status": True,  # Task status
      "last_update": "2023-08-10T08:11:32.477608",
      "details": {
        "message": "Update settings succeeded",  # General message
        "error":  "Error detail"  # In case of state `False`
        "Any": "Any  # Any kind of relevant extra details
      }
   }
}
```

Note: If the `result` `status` is `False` it doesn't force the `error` field in the  "details", but it is an excellent future improvement.

Note: This implementation also added a new test fixture for mocking datetime. It was replaced in the tests for the functions that return the new result. An issue will be filed to also replace in other uses cases (good first issue)

Closes: #315