### PR TITLE
Fix RSTUF Worker container image release tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,11 +16,6 @@ on:
         default: "latest"
         type: string
         required: False
-      latest_tag:
-         description: "Publish release as 'latest'"
-         default: True
-         type: boolean
-         required: False
 
 jobs:
   publish-container-image:
@@ -71,13 +66,8 @@ jobs:
       run: |
         docker pull ghcr.io/repository-service-tuf/repository-service-tuf-worker:${{ github.sha }}
         docker tag ghcr.io/repository-service-tuf/repository-service-tuf-worker:${{ github.sha }} ghcr.io/repository-service-tuf/repository-service-tuf-worker:${{ github.ref_name }}
-        docker push ghcr.io/repository-service-tuf/repository-service-tuf-worker:${{ github.ref_name }}
-
-    # The workflow triggered by push tag v* will be empty, because that we check != False
-    - name: Add release latest tag
-      if: ${{ inputs.latest_tag != false }}
-      run: |
         docker tag ghcr.io/repository-service-tuf/repository-service-tuf-worker:${{ github.sha }} ghcr.io/repository-service-tuf/repository-service-tuf-worker:latest
+        docker push ghcr.io/repository-service-tuf/repository-service-tuf-worker:${{ github.ref_name }}
         docker push ghcr.io/repository-service-tuf/repository-service-tuf-worker:latest
 
     - name: Publish GitHub Release


### PR DESCRIPTION
Fix the RSTUF Worker container image release tag.

The tag `latest` wasn't being added to the releases confusing the users running old versions.