### PR TITLE
fix: Automatic bump online roles, meta update

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -375,6 +375,7 @@ class MetadataRepository:
             if bump_all:
                 db_target_roles = targets_crud.read_all_roles(self._db)
                 for db_role in db_target_roles:
+                    rolename = db_role.rolename
                     bins_md: Metadata[Targets] = self._storage_backend.get(
                         db_role.rolename
                     )
@@ -382,6 +383,9 @@ class MetadataRepository:
                     self._bump_and_persist(bins_md, BINS, persist=False)
                     self._persist(bins_md, db_role.rolename)
 
+                    snapshot.signed.meta[f"{rolename}.json"] = MetaFile(
+                        version=bins_md.signed.version
+                    )
             else:
                 db_target_roles = targets_crud.read_roles_joint_files(
                     self._db, target_roles

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -341,8 +341,8 @@ class TestMetadataRepository:
 
         result = test_repo._update_snapshot()
 
-        assert result == 4
-        assert mocked_snapshot.signed.version == 4
+        assert result == snapshot_version + 1
+        assert mocked_snapshot.signed.version == snapshot_version + 1
         assert test_repo._storage_backend.get.calls == [
             pretend.call(repository.Roles.SNAPSHOT.value)
         ]
@@ -417,8 +417,8 @@ class TestMetadataRepository:
         targets = ["bins-e"]
         result = test_repo._update_snapshot(targets)
 
-        assert result == 4
-        assert mocked_snapshot.signed.version == 4
+        assert result == snapshot_version + 1
+        assert mocked_snapshot.signed.version == snapshot_version + 1
         assert mocked_snapshot.signed.meta == {"bins-e.json": 4}
         assert mocked_bins_md.signed.targets == {"k1": "f1"}
         assert repository.targets_crud.read_roles_joint_files.calls == [
@@ -502,8 +502,8 @@ class TestMetadataRepository:
         targets = ["bins-e", "bins-f"]
         result = test_repo._update_snapshot(targets, bump_all=True)
 
-        assert result == 4
-        assert mocked_snapshot.signed.version == 4
+        assert result == snapshot_version + 1
+        assert mocked_snapshot.signed.version == snapshot_version + 1
         assert mocked_snapshot.signed.meta == {
             "bins-e.json": 4,
             "bins-f.json": 4,

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -332,8 +332,7 @@ class TestMetadataRepository:
         )
 
         def fake__bump_and_persist(md, role, **kw):
-            if role == Snapshot.type:
-                md.signed.version += 1
+            md.signed.version += 1
 
         test_repo._bump_and_persist = pretend.call_recorder(
             fake__bump_and_persist
@@ -406,8 +405,7 @@ class TestMetadataRepository:
         )
 
         def fake__bump_and_persist(md, role, **kw):
-            if role == Snapshot.type:
-                md.signed.version += 1
+            md.signed.version += 1
 
         test_repo._bump_and_persist = pretend.call_recorder(
             fake__bump_and_persist
@@ -419,7 +417,9 @@ class TestMetadataRepository:
 
         assert result == snapshot_version + 1
         assert mocked_snapshot.signed.version == snapshot_version + 1
-        assert mocked_snapshot.signed.meta == {"bins-e.json": 4}
+        assert mocked_snapshot.signed.meta == {
+            "bins-e.json": mocked_bins_md.signed.version
+        }
         assert mocked_bins_md.signed.targets == {"k1": "f1"}
         assert repository.targets_crud.read_roles_joint_files.calls == [
             pretend.call(test_repo._db, targets)
@@ -486,8 +486,7 @@ class TestMetadataRepository:
         )
 
         def fake__bump_and_persist(md, role, **kw):
-            if role == Snapshot.type:
-                md.signed.version += 1
+            md.signed.version += 1
 
         test_repo._bump_and_persist = pretend.call_recorder(
             fake__bump_and_persist
@@ -505,8 +504,8 @@ class TestMetadataRepository:
         assert result == snapshot_version + 1
         assert mocked_snapshot.signed.version == snapshot_version + 1
         assert mocked_snapshot.signed.meta == {
-            "bins-e.json": 4,
-            "bins-f.json": 4,
+            "bins-e.json": 5,  # we hardcoded the values due incremental calls
+            "bins-f.json": 6,
         }
         assert fake_read_all_roles.calls == [pretend.call(test_repo._db)]
         assert test_repo._bump_and_persist.calls == [

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -330,11 +330,19 @@ class TestMetadataRepository:
         test_repo._storage_backend.get = pretend.call_recorder(
             lambda *a: mocked_snapshot
         )
-        test_repo._bump_and_persist = pretend.call_recorder(lambda *a: None)
+
+        def fake__bump_and_persist(md, role, **kw):
+            if role == Snapshot.type:
+                md.signed.version += 1
+
+        test_repo._bump_and_persist = pretend.call_recorder(
+            fake__bump_and_persist
+        )
 
         result = test_repo._update_snapshot()
 
-        assert result is snapshot_version
+        assert result == 4
+        assert mocked_snapshot.signed.version == 4
         assert test_repo._storage_backend.get.calls == [
             pretend.call(repository.Roles.SNAPSHOT.value)
         ]
@@ -350,7 +358,7 @@ class TestMetadataRepository:
         snapshot_version = 3
         mocked_snapshot = pretend.stub(
             signed=pretend.stub(
-                meta={},
+                meta={"bins-e.json": 5},
                 version=snapshot_version,
             )
         )
@@ -396,15 +404,23 @@ class TestMetadataRepository:
             "update_roles_version",
             pretend.call_recorder(lambda *a: None),
         )
+
+        def fake__bump_and_persist(md, role, **kw):
+            if role == Snapshot.type:
+                md.signed.version += 1
+
         test_repo._bump_and_persist = pretend.call_recorder(
-            lambda *a, **kw: None
+            fake__bump_and_persist
         )
         test_repo._persist = pretend.call_recorder(lambda *a: None)
 
         targets = ["bins-e"]
         result = test_repo._update_snapshot(targets)
 
-        assert result is snapshot_version
+        assert result == 4
+        assert mocked_snapshot.signed.version == 4
+        assert mocked_snapshot.signed.meta == {"bins-e.json": 4}
+        assert mocked_bins_md.signed.targets == {"k1": "f1"}
         assert repository.targets_crud.read_roles_joint_files.calls == [
             pretend.call(test_repo._db, targets)
         ]
@@ -438,11 +454,11 @@ class TestMetadataRepository:
             pretend.call(mocked_bins_md, "bins-e"),
         ]
 
-    def test_update_snapshot_bump_all(self, test_repo, monkeypatch):
+    def test__update_snapshot_bump_all(self, test_repo, monkeypatch):
         snapshot_version = 3
         mocked_snapshot = pretend.stub(
             signed=pretend.stub(
-                meta={},
+                meta={"bins-e.json": 3, "bins-f.json": 3},
                 version=snapshot_version,
             )
         )
@@ -468,8 +484,13 @@ class TestMetadataRepository:
             "read_all_roles",
             fake_read_all_roles,
         )
+
+        def fake__bump_and_persist(md, role, **kw):
+            if role == Snapshot.type:
+                md.signed.version += 1
+
         test_repo._bump_and_persist = pretend.call_recorder(
-            lambda *a, **kw: None
+            fake__bump_and_persist
         )
         test_repo._persist = pretend.call_recorder(lambda *a: None)
         fake_update_roles_version = pretend.call_recorder(lambda *a: None)
@@ -481,7 +502,12 @@ class TestMetadataRepository:
         targets = ["bins-e", "bins-f"]
         result = test_repo._update_snapshot(targets, bump_all=True)
 
-        assert result == snapshot_version
+        assert result == 4
+        assert mocked_snapshot.signed.version == 4
+        assert mocked_snapshot.signed.meta == {
+            "bins-e.json": 4,
+            "bins-f.json": 4,
+        }
         assert fake_read_all_roles.calls == [pretend.call(test_repo._db)]
         assert test_repo._bump_and_persist.calls == [
             pretend.call(mocked_bins_md, "bins", persist=False),

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -355,14 +355,19 @@ class TestMetadataRepository:
             lambda *a: a[0]
         )
         snapshot_version = 3
+        bins_a_version = 4
+        bins_e_version = 4
         mocked_snapshot = pretend.stub(
             signed=pretend.stub(
-                meta={"bins-a.json": 3, "bins-e.json": 3},
+                meta={
+                    "bins-a.json": bins_a_version,
+                    "bins-e.json": bins_e_version,
+                },
                 version=snapshot_version,
             )
         )
         mocked_bins_md = pretend.stub(
-            signed=pretend.stub(targets={"k": "v"}, version=4)
+            signed=pretend.stub(targets={"k": "v"}, version=bins_e_version)
         )
         test_repo._storage_backend.get = pretend.call_recorder(
             lambda rolename: mocked_snapshot
@@ -418,8 +423,8 @@ class TestMetadataRepository:
         assert result == snapshot_version + 1
         assert mocked_snapshot.signed.version == snapshot_version + 1
         assert mocked_snapshot.signed.meta == {
-            "bins-a.json": mocked_snapshot.signed.meta["bins-a.json"],
-            "bins-e.json": mocked_bins_md.signed.version,
+            "bins-a.json": bins_a_version,
+            "bins-e.json": bins_a_version + 1,
         }
         assert mocked_bins_md.signed.targets == {"k1": "f1"}
         assert repository.targets_crud.read_roles_joint_files.calls == [


### PR DESCRIPTION
It fixes the `_update_snapshot` to update the Snapshot Meta with the latest versions.

It was missing in the loop to add the latest role json version. It also improves the UT to check the changes in the snapshot version and the meta updates to avoid regression.

Closes #353