### PR TITLE
Support 'metadata update' in 'sign_metadata' task

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1262,20 +1262,25 @@ class MetadataRepository:
         return self.metadata_update(payload, update_state)
 
     @staticmethod
-    def _validate_signature(metadata: Metadata, signature: Signature) -> bool:
+    def _validate_signature(
+        metadata: Metadata,
+        signature: Signature,
+        delegator: Optional[Metadata] = None,
+    ) -> bool:
         """
-        Validate  signature over metadata using appropriate delegator.
-
-        NOTE: In "metadata update" signing event, the public key and
-        authorization info is retrieved from "trusted root"
+        Validate signature over metadata using appropriate delegator.
+        If no delegator is passed, the metadata itself is used as delegator.
 
         """
+        if delegator is None:
+            delegator = metadata
+
         keyid = signature.keyid
-        if keyid not in metadata.signed.roles[Root.type].keyids:
+        if keyid not in delegator.signed.roles[Root.type].keyids:
             logging.info(f"signature '{keyid}' not authorized")
             return False
 
-        key = metadata.signed.keys.get(signature.keyid)
+        key = delegator.signed.keys.get(signature.keyid)
         if not key:
             logging.info(f"no key for signature '{keyid}'")
             return False
@@ -1292,25 +1297,19 @@ class MetadataRepository:
         return True
 
     @staticmethod
-    def _validate_threshold(metadata: Metadata) -> bool:
+    def _validate_threshold(
+        metadata: Metadata, delegator: Optional[Metadata] = None
+    ) -> bool:
         """
         Validate signature threshold using appropriate delegator(s).
+        If no delegator is passed, the metadata itself is used as delegator.
 
-        NOTE: In "metadata update" signing event, the threshold for:
-        -  root is validated with the passed metadata AND the trusted root;
-        -  top-level targets is validated with the trusted root;
-        -  delegated targets is validated with the delegating targets;
-        as delegator.
         """
+        if delegator is None:
+            delegator = metadata
 
         try:
-            # TODO: `verify_delegate` does not tell us if there are any
-            # superfluous valid or invalid signatures. Is this something we
-            # want to know, e.g. to detect mistakes? To detect superfluous
-            # signatures if verify_delegate succeeds, would be easy: `assert
-            # len(signatures) == threshold`. Anything, else would require a
-            # custom `verify_delegate` function.
-            metadata.verify_delegate(Root.type, metadata)
+            delegator.verify_delegate(Root.type, metadata)
 
         except UnsignedMetadataError as e:
             logging.info(e)
@@ -1327,100 +1326,87 @@ class MetadataRepository:
     ) -> Dict[str, Any]:
         """Add signature to metadata for pending signing event.
 
-        Add signature (from payload) to cached role metadata (from settings)
-        for the role that matches the passed rolename (from payload), if a
-        signing event exists for that role, and the signature is valid.
+        Add signature (from payload) to cached root metadata (from settings),
+        if a signing event exists, and the signature is valid.
 
-        If the signature threshold is reached, the signing event is finalized.
+        Signing event types are 'bootstrap' or 'metadata update'.
 
-        ** Signing event types (and details) **
-
-        BOOTSTRAP: Only root metadata can be updated in this event. To verify
-        the passed signature, the keys and threshold are read from the root
-        metadata to be updated itself. If the threshold is reached, the
-        bootstrap process is finalized.
-
-        METADATA UPDATE: Root, targets or delegated targets metadata can be
-        updated in this event. Depending on the metadata type, the authorized
-        public keys and threshold are read from different delegating metadata.
+        If the signature threshold is reached, the signing event is finalized,
+        otherwise it remains in pending state.
         """
-        rolename = payload["role"]
-        signature_dict = payload["signature"]
 
-        # Assert pending signing event
-        metadata_dict = self._settings.get_fresh(f"{rolename.upper()}_SIGNING")
+        def _result(status, error=None, bootstrap=None, update=None):
+            details = {}
+            if status:
+                details["message"] = "Signature Processed"
+            else:
+                details["message"] = "Signature Failed"
+            if error:
+                details["error"] = error
+            if bootstrap:
+                details["bootstrap"] = bootstrap
+            if update:
+                details["update"] = update
+            return self._task_result(TaskName.SIGN_METADATA, status, details)
+
+        signature = Signature.from_dict(payload["signature"])
+
+        # Assert pending signing event exists
+        metadata_dict = self._settings.get_fresh("ROOT_SIGNING")
         if metadata_dict is None:
-            return self._task_result(
-                TaskName.SIGN_METADATA,
-                False,
-                {
-                    "message": "Signature Failed",
-                    "error": f"No signatures pending for {rolename}",
-                },
-            )
+            msg = "No signatures pending for root"
+            return _result(False, error=msg)
 
-        # Assert signing event type (currently bootstrap only)
-        # TODO: repository-service-tuf/repository-service-tuf-worker#336
-        bootstrap_state = self._settings.get_fresh("BOOTSTRAP")
-        if "signing" not in bootstrap_state:
-            return self._task_result(
-                TaskName.SIGN_METADATA,
-                False,
-                {
-                    "message": "Signature Failed",
-                    "error": "No bootstrap available for signing",
-                },
-            )
-
-        # Assert metadata type is allowed for signing event
+        # Assert metadata type is root
         root = Metadata.from_dict(metadata_dict)
         if not isinstance(root.signed, Root):
-            return self._task_result(
-                TaskName.SIGN_METADATA,
-                False,
-                {
-                    "message": "Signature Failed",
-                    "error": f"Role {rolename} has wrong type",
-                },
-            )
+            msg = f"Expected 'root', got '{root.signed.type}'"
+            return _result(False, error=msg)
 
-        # Assert passed signature is valid for metadata
-        signature = Signature.from_dict(signature_dict)
-        if not self._validate_signature(root, signature):
-            return self._task_result(
-                TaskName.SIGN_METADATA,
-                False,
-                {
-                    "message": "Signature Failed",
-                    "error": "Invalid signature",
-                },
-            )
+        # If it isn't a "bootstrap" signing event, it must be "update metadata"
+        bootstrap_state = self._settings.get_fresh("BOOTSTRAP")
+        if "signing" in bootstrap_state:
+            # Signature and threshold of initial root can only self-validate,
+            # there is no "trusted root" at bootstrap time yet.
+            if not self._validate_signature(root, signature):
+                return _result(False, error="Invalid signature")
 
-        # Check threshold with new signature included
-        root.signatures[signature.keyid] = signature
-        if not self._validate_threshold(root):
-            self.write_repository_settings("ROOT_SIGNING", root.to_dict())
-            root_version = root.signed.version
-            return self._task_result(
-                TaskName.SIGN_METADATA,
-                True,
-                {
-                    "message": "Signature Processed",
-                    "bootstrap": f"Root v{root_version} is pending signatures",
-                },
-            )
+            root.signatures[signature.keyid] = signature
+            if not self._validate_threshold(root):
+                self.write_repository_settings("ROOT_SIGNING", root.to_dict())
+                msg = f"Root v{root.signed.version} is pending signatures"
+                return _result(True, bootstrap=msg)
 
-        # Finalize bootstrap
-        bootstrap_task_id = bootstrap_state.split("signing-")[1]
-        self._bootstrap_finalize(root, bootstrap_task_id)
-        return self._task_result(
-            TaskName.SIGN_METADATA,
-            True,
-            {
-                "message": "Signature Processed",
-                "bootstrap": "Bootstrap Finished",
-            },
-        )
+            bootstrap_task_id = bootstrap_state.split("signing-")[1]
+            self._bootstrap_finalize(root, bootstrap_task_id)
+            return _result(True, bootstrap="Bootstrap Finished")
+
+        else:
+            # Also consult with "trusted root" when updating a new root
+            # - Signature must validate with trusted OR new root
+            # - Threshold must validate with trusted AND new root
+            trusted_root = self._storage_backend.get("root")
+            trusted_signature = self._validate_signature(
+                root, signature, trusted_root
+            )
+            new_signature = self._validate_signature(root, signature)
+
+            if not (trusted_signature or new_signature):
+                return _result(False, error="Invalid signature")
+
+            root.signatures[signature.keyid] = signature
+            trusted_threshold = self._validate_threshold(root, trusted_root)
+            new_threshold = self._validate_threshold(root)
+            if not (trusted_threshold and new_threshold):
+                self.write_repository_settings("ROOT_SIGNING", root.to_dict())
+                msg = f"Root v{root.signed.version} is pending signatures"
+                return _result(True, update=msg)
+
+            # TODO: Refactor `_root_metadata_update` to de-duplicate validation
+            self._root_metadata_update(root)
+            # Update successful, root persisted -> finalize event...
+            self.write_repository_settings("ROOT_SIGNING", None)
+            return _result(True, update="Metadata update finished")
 
     def delete_sign_metadata(
         self,

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1349,6 +1349,12 @@ class MetadataRepository:
             return self._task_result(TaskName.SIGN_METADATA, status, details)
 
         signature = Signature.from_dict(payload["signature"])
+        rolename = payload["role"]
+
+        # Assert requested metadata type is root
+        if rolename != Root.type:
+            msg = f"Expected '{Root.type}', got '{rolename}'"
+            return _result(False, error=msg)
 
         # Assert pending signing event exists
         metadata_dict = self._settings.get_fresh("ROOT_SIGNING")

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1404,7 +1404,14 @@ class MetadataRepository:
                 return _result(True, update=msg)
 
             # TODO: Refactor `_root_metadata_update` to de-duplicate validation
-            self._root_metadata_update(root)
+            # and messaging. At this point, we know that root is valid and
+            # there can be only one message. (remove assert after refactor!)
+            result = self._root_metadata_update(root)
+            assert result == {  # nosec
+                "message": "Metadata Update Processed",
+                "role": "root",
+            }
+
             # Update successful, root persisted -> finalize event...
             self.write_repository_settings("ROOT_SIGNING", None)
             return _result(True, update="Metadata update finished")

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1414,12 +1414,12 @@ class MetadataRepository:
             # - threshold must validate with the threshold of keys as defined
             #   in the trusted root AND as defined in the new root
             trusted_root = self._storage_backend.get("root")
-            trusted_signature = self._validate_signature(
+            is_valid_trusted = self._validate_signature(
                 root, signature, trusted_root
             )
-            new_signature = self._validate_signature(root, signature)
+            is_valid_new = self._validate_signature(root, signature)
 
-            if not (trusted_signature or new_signature):
+            if not (is_valid_trusted or is_valid_new):
                 return _result(False, error="Invalid signature")
 
             root.signatures[signature.keyid] = signature

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1270,7 +1270,6 @@ class MetadataRepository:
         """
         Validate signature over metadata using appropriate delegator.
         If no delegator is passed, the metadata itself is used as delegator.
-
         """
         if delegator is None:
             delegator = metadata
@@ -1303,7 +1302,6 @@ class MetadataRepository:
         """
         Validate signature threshold using appropriate delegator(s).
         If no delegator is passed, the metadata itself is used as delegator.
-
         """
         if delegator is None:
             delegator = metadata
@@ -1343,10 +1341,11 @@ class MetadataRepository:
                 details["message"] = "Signature Failed"
             if error:
                 details["error"] = error
-            if bootstrap:
+            elif bootstrap:
                 details["bootstrap"] = bootstrap
-            if update:
+            elif update:
                 details["update"] = update
+
             return self._task_result(TaskName.SIGN_METADATA, status, details)
 
         signature = Signature.from_dict(payload["signature"])
@@ -1382,9 +1381,11 @@ class MetadataRepository:
             return _result(True, bootstrap="Bootstrap Finished")
 
         else:
-            # Also consult with "trusted root" when updating a new root
-            # - Signature must validate with trusted OR new root
-            # - Threshold must validate with trusted AND new root
+            # We need the "trusted root" when updating to a new root:
+            # - signature could come from a key, which is only in the trusted
+            #   root, OR from a key, which is only in the new root
+            # - threshold must validate with the threshold of keys as defined
+            #   in the trusted root AND as defined in the new root
             trusted_root = self._storage_backend.get("root")
             trusted_signature = self._validate_signature(
                 root, signature, trusted_root

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -3410,6 +3410,84 @@ class TestMetadataRepository:
             pretend.call("ROOT_SIGNING", "fake")
         ]
 
+    def test_sign_metadata__update__finalize(
+        self, test_repo, monkeypatch, mocked_datetime
+    ):
+        fake_datetime = mocked_datetime
+
+        def fake_get_fresh(key):
+            if key == "BOOTSTRAP":
+                return "<task-id>"
+            if key == "ROOT_SIGNING":
+                return {"metadata": "fake"}
+
+        fake_settings = pretend.stub(
+            get_fresh=pretend.call_recorder(fake_get_fresh),
+        )
+
+        monkeypatch.setattr(
+            repository,
+            "get_repository_settings",
+            lambda *a, **kw: fake_settings,
+        )
+
+        fake_signature = pretend.stub(keyid="fake_sig")
+        repository.Signature.from_dict = pretend.call_recorder(
+            lambda *a: fake_signature
+        )
+        test_repo._validate_signature = pretend.call_recorder(lambda *a: True)
+        test_repo._validate_threshold = pretend.call_recorder(lambda *a: True)
+        test_repo.write_repository_settings = pretend.call_recorder(
+            lambda *a: None
+        )
+        test_repo._root_metadata_update = pretend.call_recorder(
+            lambda *a: "fake_result"
+        )
+
+        fake_trusted_root = repository.Metadata(
+            signed=repository.Root(version=1)
+        )
+        test_repo._storage_backend.get = pretend.call_recorder(
+            lambda r: fake_trusted_root
+        )
+        fake_new_root = repository.Metadata(signed=repository.Root(version=2))
+        repository.Metadata.from_dict = pretend.call_recorder(
+            lambda *a: fake_new_root
+        )
+
+        payload = {
+            "role": "root",
+            "signature": {"keyid": "keyid2", "sig": "sig2"},
+        }
+        result = test_repo.sign_metadata(payload)
+
+        assert result == {
+            "task": "sign_metadata",
+            "status": True,
+            "last_update": fake_datetime.now(),
+            "details": {
+                "message": "Signature Processed",
+                "update": "Metadata update finished",
+            },
+        }
+        assert fake_settings.get_fresh.calls == [
+            pretend.call("ROOT_SIGNING"),
+            pretend.call("BOOTSTRAP"),
+        ]
+        assert repository.Metadata.from_dict.calls == [
+            pretend.call({"metadata": "fake"})
+        ]
+        assert test_repo._validate_signature.calls == [
+            pretend.call(fake_new_root, fake_signature, fake_trusted_root),
+            pretend.call(fake_new_root, fake_signature),
+        ]
+        assert test_repo._root_metadata_update.calls == [
+            pretend.call(fake_new_root)
+        ]
+        assert test_repo.write_repository_settings.calls == [
+            pretend.call("ROOT_SIGNING", None)
+        ]
+
     def test_delete_sign_metadata_bootstrap_signing_state(
         self, test_repo, monkeypatch, mocked_datetime
     ):

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -3272,14 +3272,25 @@ class TestMetadataRepository:
         ]
 
     @pytest.mark.parametrize(
-        "validation_results, details, status",
+        "payload_patch, validation_results, details, status",
         [
             (
+                {"role": "foo"},
+                {},
+                {
+                    "message": "Signature Failed",
+                    "error": "Expected 'root', got 'foo'",
+                },
+                False,
+            ),
+            (
+                {},
                 {"signature": iter((False, False))},
                 {"message": "Signature Failed", "error": "Invalid signature"},
                 False,
             ),
             (
+                {},
                 {
                     "signature": iter((True, False)),
                     "threshold": iter((False, False)),
@@ -3291,6 +3302,7 @@ class TestMetadataRepository:
                 True,
             ),
             (
+                {},
                 {
                     "signature": iter((False, True)),
                     "threshold": iter((False, True)),
@@ -3302,6 +3314,7 @@ class TestMetadataRepository:
                 True,
             ),
             (
+                {},
                 {
                     "signature": iter((True, False)),
                     "threshold": iter((True, False)),
@@ -3313,6 +3326,7 @@ class TestMetadataRepository:
                 True,
             ),
             (
+                {},
                 {
                     "signature": iter((True, True)),
                     "threshold": iter((True, True)),
@@ -3330,6 +3344,7 @@ class TestMetadataRepository:
         test_repo,
         monkeypatch,
         mocked_datetime,
+        payload_patch,
         validation_results,
         details,
         status,
@@ -3390,7 +3405,9 @@ class TestMetadataRepository:
 
         # Call sign_metadata with fake payload
         # All deserialization and validation is mocked
-        result = test_repo.sign_metadata({"signature": "fake"})
+        payload = {"signature": "fake", "role": "root"}
+        payload.update(payload_patch)
+        result = test_repo.sign_metadata(payload)
 
         assert result == {
             "task": "sign_metadata",

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -3367,6 +3367,13 @@ class TestMetadataRepository:
             lambda *a: "fake"
         )
 
+        test_repo._root_metadata_update = pretend.call_recorder(
+            lambda a: {
+                "message": "Metadata Update Processed",
+                "role": "root",
+            }
+        )
+
         # Mock return values of `_validate_{signature, threshold}`
         # By using ``next`` on the fixture values, we can get different results
         # in subsequent calls, and test the correct usage of AND/OR operators.

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -3271,6 +3271,72 @@ class TestMetadataRepository:
             pretend.call("ROOT_SIGNING", "fake_metadata")
         ]
 
+    def test_sign_metadata__update__invalid_signature(
+        self, test_repo, monkeypatch, mocked_datetime
+    ):
+        fake_datetime = mocked_datetime
+
+        def fake_get_fresh(key):
+            if key == "BOOTSTRAP":
+                return "<task-id>"
+            if key == "ROOT_SIGNING":
+                return {"metadata": "fake"}
+
+        fake_settings = pretend.stub(
+            get_fresh=pretend.call_recorder(fake_get_fresh),
+        )
+
+        monkeypatch.setattr(
+            repository,
+            "get_repository_settings",
+            lambda *a, **kw: fake_settings,
+        )
+
+        fake_signature = pretend.stub(keyid="fake_sig")
+        repository.Signature.from_dict = pretend.call_recorder(
+            lambda *a: fake_signature
+        )
+        test_repo._validate_signature = pretend.call_recorder(lambda *a: False)
+
+        fake_trusted_root = repository.Metadata(
+            signed=repository.Root(version=1)
+        )
+        test_repo._storage_backend.get = pretend.call_recorder(
+            lambda r: fake_trusted_root
+        )
+        fake_new_root = repository.Metadata(signed=repository.Root(version=2))
+        fake_new_root.to_dict = pretend.call_recorder(lambda: "fake")
+        repository.Metadata.from_dict = pretend.call_recorder(
+            lambda *a: fake_new_root
+        )
+
+        payload = {
+            "role": "root",
+            "signature": {"keyid": "keyid2", "sig": "sig2"},
+        }
+        result = test_repo.sign_metadata(payload)
+
+        assert result == {
+            "task": "sign_metadata",
+            "status": False,
+            "last_update": fake_datetime.now(),
+            "details": {
+                "message": "Signature Failed",
+                "error": "Invalid signature",
+            },
+        }
+        assert fake_settings.get_fresh.calls == [
+            pretend.call("ROOT_SIGNING"),
+            pretend.call("BOOTSTRAP"),
+        ]
+        assert repository.Metadata.from_dict.calls == [
+            pretend.call({"metadata": "fake"})
+        ]
+        assert test_repo._validate_signature.calls == [
+            pretend.call(fake_new_root, fake_signature, fake_trusted_root),
+            pretend.call(fake_new_root, fake_signature),
+        ]
+
     def test_delete_sign_metadata_bootstrap_signing_state(
         self, test_repo, monkeypatch, mocked_datetime
     ):

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -3313,46 +3313,10 @@ class TestMetadataRepository:
     def test_sign_metadata__update__bad_role_type(
         self, test_repo, monkeypatch, mocked_datetime
     ):
-        def fake_get_fresh(key):
-            if key == "BOOTSTRAP":
-                return "<task-id>"
-            if key == "ROOT_SIGNING":
-                return {"metadata": "fake"}
-
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(fake_get_fresh),
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
         fake_signature = pretend.stub(keyid="fake")
         repository.Signature.from_dict = pretend.call_recorder(
             lambda *a: fake_signature
         )
-        fake_trusted_root = repository.Metadata(
-            signed=repository.Root(version=1)
-        )
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda r: fake_trusted_root
-        )
-        fake_new_root = repository.Metadata(signed=repository.Root(version=2))
-        repository.Metadata.from_dict = pretend.call_recorder(
-            lambda *a: fake_new_root
-        )
-        fake_new_root.to_dict = pretend.call_recorder(lambda: "fake")
-        test_repo.write_repository_settings = pretend.call_recorder(
-            lambda *a: "fake"
-        )
-
-        test_repo._root_metadata_update = pretend.call_recorder(
-            lambda a: {
-                "message": "Metadata Update Processed",
-                "role": "root",
-            }
-        )
-
         payload = {"signature": "fake", "role": "foo"}
         result = test_repo.sign_metadata(payload)
 
@@ -3399,17 +3363,6 @@ class TestMetadataRepository:
         fake_new_root = repository.Metadata(signed=repository.Root(version=2))
         repository.Metadata.from_dict = pretend.call_recorder(
             lambda *a: fake_new_root
-        )
-        fake_new_root.to_dict = pretend.call_recorder(lambda: "fake")
-        test_repo.write_repository_settings = pretend.call_recorder(
-            lambda *a: "fake"
-        )
-
-        test_repo._root_metadata_update = pretend.call_recorder(
-            lambda a: {
-                "message": "Metadata Update Processed",
-                "role": "root",
-            }
         )
 
         # Use `next` below to mock subsequent calls
@@ -3468,13 +3421,6 @@ class TestMetadataRepository:
         fake_new_root.to_dict = pretend.call_recorder(lambda: "fake")
         test_repo.write_repository_settings = pretend.call_recorder(
             lambda *a: "fake"
-        )
-
-        test_repo._root_metadata_update = pretend.call_recorder(
-            lambda a: {
-                "message": "Metadata Update Processed",
-                "role": "root",
-            }
         )
 
         # Use `next` below to mock subsequent calls
@@ -3540,13 +3486,6 @@ class TestMetadataRepository:
         fake_new_root.to_dict = pretend.call_recorder(lambda: "fake")
         test_repo.write_repository_settings = pretend.call_recorder(
             lambda *a: "fake"
-        )
-
-        test_repo._root_metadata_update = pretend.call_recorder(
-            lambda a: {
-                "message": "Metadata Update Processed",
-                "role": "root",
-            }
         )
 
         # Use `next` below to mock subsequent calls
@@ -3616,13 +3555,6 @@ class TestMetadataRepository:
             lambda *a: "fake"
         )
 
-        test_repo._root_metadata_update = pretend.call_recorder(
-            lambda a: {
-                "message": "Metadata Update Processed",
-                "role": "root",
-            }
-        )
-
         # Use `next` below to mock subsequent calls
         fake_signature_result = iter((True, True))
         fake_threshold_result = iter((True, False))
@@ -3688,12 +3620,6 @@ class TestMetadataRepository:
             lambda *a: "fake"
         )
 
-        test_repo._root_metadata_update = pretend.call_recorder(
-            lambda a: {
-                "message": "Metadata Update Processed",
-                "role": "root",
-            }
-        )
         # Use `next` below to mock subsequent calls
         fake_signature_result = iter((True, True))
         fake_threshold_result = iter((True, True))


### PR DESCRIPTION
related to #336

Implement support for distributed asynchronous root metadata signging in the course of a "metadata update" event.

Other than the already supported "bootstrap" signing event, signatures added to root during "metadata update" must validate with keys from trusted OR new root, and meet the signature threshold of trusted AND new root.

*Related changes:*
- Refactor `_validate_{signature, threshold}` helpers to accept an optional delegator (e.g. trusted root).
- Add `_sign_result` helper to return a "sign metadata"-specific task result.