### PR TITLE
Rename enum values to follow convention

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -83,13 +83,13 @@ LOCK_TARGETS = "LOCK_TARGETS"
 
 
 class TaskName(str, enum.Enum):
-    add_targets = "add_targets"
-    remove_targets = "remove_targets"
-    bootstrap = "bootstrap"
-    update_settings = "update_settings"
-    publish_targets = "publish_targets"
-    metadata_update = "metadata_update"
-    sign_metadata = "sign_metadata"
+    ADD_TARGETS = "add_targets"
+    REMOVE_TARGETS = "remove_targets"
+    BOOTSTRAP = "bootstrap"
+    UPDATE_SETTINGS = "update_settings"
+    PUBLISH_TARGETS = "publish_targets"
+    METADATA_UPDATE = "metadata_update"
+    SIGN_METADATA = "sign_metadata"
 
 
 @dataclass
@@ -655,7 +655,7 @@ class MetadataRepository:
         tuf_settings = payload.get("settings")
         if tuf_settings is None:
             return self._task_result(
-                TaskName.bootstrap,
+                TaskName.BOOTSTRAP,
                 False,
                 {
                     "message": "Bootstrap Failed",
@@ -666,7 +666,7 @@ class MetadataRepository:
         root_metadata = payload.get("metadata")
         if root_metadata is None:
             return self._task_result(
-                TaskName.bootstrap,
+                TaskName.BOOTSTRAP,
                 False,
                 {
                     "message": "Bootstrap Failed",
@@ -677,7 +677,7 @@ class MetadataRepository:
         bootstrap_status = self._settings.get_fresh("BOOTSTRAP")
         if bootstrap_status is not None and "pre-" not in bootstrap_status:
             return self._task_result(
-                TaskName.bootstrap,
+                TaskName.BOOTSTRAP,
                 False,
                 {
                     "message": "Bootstrap Failed",
@@ -689,7 +689,7 @@ class MetadataRepository:
         if len(root.signatures) == 0:
             self.write_repository_settings("BOOTSTRAP", None)
             return self._task_result(
-                TaskName.bootstrap,
+                TaskName.BOOTSTRAP,
                 False,
                 {
                     "message": "Bootstrap Failed",
@@ -701,7 +701,7 @@ class MetadataRepository:
             if self._validate_signature(root, signature) is False:
                 self.write_repository_settings("BOOTSTRAP", None)
                 return self._task_result(
-                    TaskName.bootstrap,
+                    TaskName.BOOTSTRAP,
                     False,
                     {
                         "message": "Bootstrap Failed",
@@ -725,7 +725,7 @@ class MetadataRepository:
             logging.info(message)
 
         return self._task_result(
-            TaskName.bootstrap,
+            TaskName.BOOTSTRAP,
             True,
             {"message": "Bootstrap Processed", "bootstrap": message},
         )
@@ -788,7 +788,7 @@ class MetadataRepository:
                 "invalid_roles": invalid_roles,
             }
 
-        return self._task_result(TaskName.update_settings, status, details)
+        return self._task_result(TaskName.UPDATE_SETTINGS, status, details)
 
     def publish_targets(
         self,
@@ -822,7 +822,7 @@ class MetadataRepository:
                         "No new targets in delegated target roles. Finishing"
                     )
                     return self._task_result(
-                        TaskName.publish_targets,
+                        TaskName.PUBLISH_TARGETS,
                         True,
                         {
                             "message": "Publish Targets Processed",
@@ -852,7 +852,7 @@ class MetadataRepository:
 
         logging.debug("Targets published")
         return self._task_result(
-            TaskName.publish_targets,
+            TaskName.PUBLISH_TARGETS,
             True,
             {
                 "message": "Publish Targets Processed",
@@ -875,7 +875,7 @@ class MetadataRepository:
         targets = payload.get("targets")
         if targets is None:
             return self._task_result(
-                TaskName.add_targets,
+                TaskName.ADD_TARGETS,
                 False,
                 {
                     "message": "Adding target(s) Failed",
@@ -934,7 +934,7 @@ class MetadataRepository:
 
         logging.debug(f"Added targets: {add_targets} on Roles {update_roles}")
         return self._task_result(
-            TaskName.add_targets,
+            TaskName.ADD_TARGETS,
             True,
             {
                 "message": "Target(s) Added",
@@ -952,7 +952,7 @@ class MetadataRepository:
         targets = payload.get("targets")
         if targets is None:
             return self._task_result(
-                TaskName.remove_targets,
+                TaskName.REMOVE_TARGETS,
                 False,
                 {
                     "message": "Removing target(s) Failed",
@@ -963,7 +963,7 @@ class MetadataRepository:
 
         if len(targets) == 0:
             return self._task_result(
-                TaskName.remove_targets,
+                TaskName.REMOVE_TARGETS,
                 False,
                 {
                     "message": "Removing target(s) Failed",
@@ -1014,7 +1014,7 @@ class MetadataRepository:
         )
 
         return self._task_result(
-            TaskName.remove_targets,
+            TaskName.REMOVE_TARGETS,
             True,
             {
                 "message": "Target(s) removed",
@@ -1232,7 +1232,7 @@ class MetadataRepository:
             RepositoryError,
         ) as err:
             return self._task_result(
-                TaskName.metadata_update,
+                TaskName.METADATA_UPDATE,
                 False,
                 {
                     "message": "Metadata Update Failed",
@@ -1280,7 +1280,7 @@ class MetadataRepository:
                     )
 
         return self._task_result(
-            TaskName.metadata_update,
+            TaskName.METADATA_UPDATE,
             True,
             {"message": "Metadata Update Processed", "role": Root.type},
         )
@@ -1307,7 +1307,7 @@ class MetadataRepository:
         bootstrap = self._settings.get_fresh("BOOTSTRAP")
         if bootstrap is None or "pre-" in bootstrap:
             return self._task_result(
-                TaskName.metadata_update,
+                TaskName.METADATA_UPDATE,
                 False,
                 {
                     "message": "Metadata Update Failed",
@@ -1318,7 +1318,7 @@ class MetadataRepository:
         metadata = payload.get("metadata")
         if metadata is None:
             return self._task_result(
-                TaskName.metadata_update,
+                TaskName.METADATA_UPDATE,
                 False,
                 {
                     "message": "Metadata Update Failed",
@@ -1331,7 +1331,7 @@ class MetadataRepository:
             return self._root_metadata_update(new_root)
         else:
             return self._task_result(
-                TaskName.metadata_update,
+                TaskName.METADATA_UPDATE,
                 False,
                 {
                     "message": "Metadata Update Failed",
@@ -1445,7 +1445,7 @@ class MetadataRepository:
         metadata_dict = self._settings.get_fresh(f"{rolename.upper()}_SIGNING")
         if metadata_dict is None:
             return self._task_result(
-                TaskName.sign_metadata,
+                TaskName.SIGN_METADATA,
                 False,
                 {
                     "message": "Signature Failed",
@@ -1458,7 +1458,7 @@ class MetadataRepository:
         bootstrap_state = self._settings.get_fresh("BOOTSTRAP")
         if "signing" not in bootstrap_state:
             return self._task_result(
-                TaskName.sign_metadata,
+                TaskName.SIGN_METADATA,
                 False,
                 {
                     "message": "Signature Failed",
@@ -1470,7 +1470,7 @@ class MetadataRepository:
         root = Metadata.from_dict(metadata_dict)
         if not isinstance(root.signed, Root):
             return self._task_result(
-                TaskName.sign_metadata,
+                TaskName.SIGN_METADATA,
                 False,
                 {
                     "message": "Signature Failed",
@@ -1482,7 +1482,7 @@ class MetadataRepository:
         signature = Signature.from_dict(signature_dict)
         if not self._validate_signature(root, signature):
             return self._task_result(
-                TaskName.sign_metadata,
+                TaskName.SIGN_METADATA,
                 False,
                 {
                     "message": "Signature Failed",
@@ -1496,7 +1496,7 @@ class MetadataRepository:
             self.write_repository_settings("ROOT_SIGNING", root.to_dict())
             root_version = root.signed.version
             return self._task_result(
-                TaskName.sign_metadata,
+                TaskName.SIGN_METADATA,
                 True,
                 {
                     "message": "Signature Processed",
@@ -1508,7 +1508,7 @@ class MetadataRepository:
         bootstrap_task_id = bootstrap_state.split("signing-")[1]
         self._bootstrap_finalize(root, bootstrap_task_id)
         return self._task_result(
-            TaskName.sign_metadata,
+            TaskName.SIGN_METADATA,
             True,
             {
                 "message": "Signature Processed",


### PR DESCRIPTION
As we have discussed with Kairo we prefer if enum values are upper case the same way as constants are:
https://peps.python.org/pep-0008/#constants
and the same way all of our enums are until now.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>