### PR TITLE
AWS S3 Storage Backend Service implementation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
     name: FT Deploy AWS Services
     uses: ./.github/workflows/functional-aws.yml
     with:
-      docker_compose: docker-compose-redis.yml
+      docker_compose: docker-compose-aws.yml
       api_version: ${{ inputs.api_version }}
       cli_version: ${{ inputs.cli_version }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,6 @@ jobs:
 
   functional-tests-local:
     name: FT Deploy Local Services
-    needs: build-pre-dev
     uses: ./.github/workflows/functional-tests.yml
     with:
       api_version: ${{ inputs.api_version }}
@@ -33,8 +32,15 @@ jobs:
 
   functional-tests-local-redis:
     name: FT Deploy Local Services with Redis as Broker
-    needs: build-pre-dev
     uses: ./.github/workflows/functional-tests.yml
+    with:
+      docker_compose: docker-compose-redis.yml
+      api_version: ${{ inputs.api_version }}
+      cli_version: ${{ inputs.cli_version }}
+
+  functional-tests-aws:
+    name: FT Deploy AWS Services
+    uses: ./.github/workflows/functional-aws.yml
     with:
       docker_compose: docker-compose-redis.yml
       api_version: ${{ inputs.api_version }}

--- a/.github/workflows/review-approved.yml
+++ b/.github/workflows/review-approved.yml
@@ -21,3 +21,12 @@ jobs:
       docker_compose: docker-compose-redis.yml
       api_version: dev
       cli_version: dev
+
+  functional-tests-aws:
+    name: Deploy AWS Services
+    if: github.event.review.state == 'approved'
+    uses: ./.github/workflows/functional-tests.yml
+    with:
+      docker_compose: docker-compose-aws.yml
+      api_version: dev
+      cli_version: dev

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 build-dev:
 	docker build -t repository-service-tuf-worker:dev .
 
-
 run-dev: export API_VERSION = dev
 run-dev:
 	$(MAKE) build-dev
@@ -14,9 +13,6 @@ else
 	docker compose -f docker-compose.yml up --remove-orphans
 endif
 
-
-localstack-init:
-	awslocal s3api create-bucket --bucket tuf-metadata --region us-east-1
 
 db-migration:
 	if [ -z "$(M)" ]; then echo "Use: make db-migration M=\'message here\'"; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ stop:
 clean:
 	$(MAKE) stop
 	docker compose rm --force
+	docker rm repository-service-tuf-worker-localstack-1 -f
 	rm -rf ./data
 	rm -rf ./data_test
 
@@ -73,11 +74,11 @@ ft-das:
 ifeq ($(GITHUB_ACTION),)
 	$(MAKE) clone-umbrella
 endif
-	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash rstuf-umbrella/tests/functional/scripts/run-ft-das.sh $(CLI_VERSION)' --rm repository-service-tuf-worker
+	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash tests/functional/scripts/run-ft-das.sh $(CLI_VERSION)' --rm repository-service-tuf-worker
 
 ft-signed:
 # Use "GITHUB_ACTION" to identify if we are running from a GitHub action.
 ifeq ($(GITHUB_ACTION),)
 	$(MAKE) clone-umbrella
 endif
-	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash rstuf-umbrella/tests/functional/scripts/run-ft-signed.sh $(CLI_VERSION)' --rm repository-service-tuf-worker
+	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash tests/functional/scripts/run-ft-signed.sh $(CLI_VERSION)' --rm repository-service-tuf-worker

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ else
 endif
 
 
+localstack-init:
+	awslocal s3api create-bucket --bucket tuf-metadata --region us-east-1
+
 db-migration:
 	if [ -z "$(M)" ]; then echo "Use: make db-migration M=\'message here\'"; exit 1; fi
 	docker compose run --rm --entrypoint='alembic revision --autogenerate -m "$(M)"' repository-service-tuf-worker

--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,8 @@ psycopg2 = "*"
 alembic = "*"
 pydantic = "*"
 celery = "*"
+boto3 = "*"
+awswrangler = "*"
 
 [dev-packages]
 tox = "*"
@@ -38,6 +40,8 @@ sphinxcontrib-serializinghtml = "*"
 pre-commit = "*"
 bandit = "*"
 myst-parser = "*"
+awscli-local = "*"
+awscli = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "50aac49a0f107bb483fb9de8fb9f604584f5358bf8ad9db397af4a9aa03b9440"
+            "sha256": "7847fcd2851abcf713eb159e4f372562b58eef89bd3be40d655d21bf94e2f057"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,7 +22,6 @@
                 "sha256:8e7645c32e4f200675e69f0745415335eb59a3663f5feb487abfa0b30c45888b"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==1.12.0"
         },
         "amqp": {
@@ -49,6 +48,14 @@
             "markers": "python_full_version <= '3.11.2'",
             "version": "==4.0.3"
         },
+        "awswrangler": {
+            "hashes": [
+                "sha256:0cd15ce0d5bad4e001f687af312054199b3245a4b7d9504b375962f77bca79e4",
+                "sha256:9fb10d8bea5b1e500ba17c930638eeca074b628a128e201b5774f1a9c0db831b"
+            ],
+            "index": "pypi",
+            "version": "==3.4.0"
+        },
         "billiard": {
             "hashes": [
                 "sha256:0f50d6be051c6b2b75bfbc8bfd85af195c5739c281d3f5b86a5640c65563614a",
@@ -57,13 +64,28 @@
             "markers": "python_version >= '3.7'",
             "version": "==4.1.0"
         },
+        "boto3": {
+            "hashes": [
+                "sha256:2f18d2dac5d9229e8485b556eb58b7b95fca91bbf002f63bf9c39209f513f6e6",
+                "sha256:71dcd596a82b5341c6941117b9228897bfb1e2b58f73e60e1fdda1b02a847cc8"
+            ],
+            "index": "pypi",
+            "version": "==1.28.58"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:002f8bdca8efde50ae7267f342bc1d03a71d76024ce3949e4ffdd1151581c53e",
+                "sha256:83a3ca4d9247fdbde76c654137e6ab648bd976f652ce2354def1715c838af505"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.31.58"
+        },
         "celery": {
             "hashes": [
                 "sha256:1e6ed40af72695464ce98ca2c201ad0ef8fd192246f6c9eac8bba343b980ad34",
                 "sha256:9023df6a8962da79eb30c0c84d5f4863d9793a466354cc931d7f72423996de28"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==5.3.4"
         },
         "certifi": {
@@ -303,7 +325,7 @@
                 "sha256:8a37ba3b16df64cb1db383eaad9c733aece218413be0fad5d785f7a907612106",
                 "sha256:df4af8d0f3b068cc6419ceceaae572070a6b8fec38fa51a1f5eb8ea4883e53de"
             ],
-            "markers": "python_version >= '3.8'",
+            "index": "pypi",
             "version": "==3.2.3"
         },
         "greenlet": {
@@ -381,6 +403,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.1"
         },
         "kombu": {
             "hashes": [
@@ -464,6 +494,83 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.1.3"
         },
+        "numpy": {
+            "hashes": [
+                "sha256:020cdbee66ed46b671429c7265cf00d8ac91c046901c55684954c3958525dab2",
+                "sha256:0621f7daf973d34d18b4e4bafb210bbaf1ef5e0100b5fa750bd9cde84c7ac292",
+                "sha256:0792824ce2f7ea0c82ed2e4fecc29bb86bee0567a080dacaf2e0a01fe7654369",
+                "sha256:09aaee96c2cbdea95de76ecb8a586cb687d281c881f5f17bfc0fb7f5890f6b91",
+                "sha256:166b36197e9debc4e384e9c652ba60c0bacc216d0fc89e78f973a9760b503388",
+                "sha256:186ba67fad3c60dbe8a3abff3b67a91351100f2661c8e2a80364ae6279720299",
+                "sha256:306545e234503a24fe9ae95ebf84d25cba1fdc27db971aa2d9f1ab6bba19a9dd",
+                "sha256:436c8e9a4bdeeee84e3e59614d38c3dbd3235838a877af8c211cfcac8a80b8d3",
+                "sha256:4a873a8180479bc829313e8d9798d5234dfacfc2e8a7ac188418189bb8eafbd2",
+                "sha256:4acc65dd65da28060e206c8f27a573455ed724e6179941edb19f97e58161bb69",
+                "sha256:51be5f8c349fdd1a5568e72713a21f518e7d6707bcf8503b528b88d33b57dc68",
+                "sha256:546b7dd7e22f3c6861463bebb000646fa730e55df5ee4a0224408b5694cc6148",
+                "sha256:5671338034b820c8d58c81ad1dafc0ed5a00771a82fccc71d6438df00302094b",
+                "sha256:637c58b468a69869258b8ae26f4a4c6ff8abffd4a8334c830ffb63e0feefe99a",
+                "sha256:767254ad364991ccfc4d81b8152912e53e103ec192d1bb4ea6b1f5a7117040be",
+                "sha256:7d484292eaeb3e84a51432a94f53578689ffdea3f90e10c8b203a99be5af57d8",
+                "sha256:7f6bad22a791226d0a5c7c27a80a20e11cfe09ad5ef9084d4d3fc4a299cca505",
+                "sha256:86f737708b366c36b76e953c46ba5827d8c27b7a8c9d0f471810728e5a2fe57c",
+                "sha256:8c6adc33561bd1d46f81131d5352348350fc23df4d742bb246cdfca606ea1208",
+                "sha256:914b28d3215e0c721dc75db3ad6d62f51f630cb0c277e6b3bcb39519bed10bd8",
+                "sha256:b44e6a09afc12952a7d2a58ca0a2429ee0d49a4f89d83a0a11052da696440e49",
+                "sha256:bb0d9a1aaf5f1cb7967320e80690a1d7ff69f1d47ebc5a9bea013e3a21faec95",
+                "sha256:c0b45c8b65b79337dee5134d038346d30e109e9e2e9d43464a2970e5c0e93229",
+                "sha256:c2e698cb0c6dda9372ea98a0344245ee65bdc1c9dd939cceed6bb91256837896",
+                "sha256:c78a22e95182fb2e7874712433eaa610478a3caf86f28c621708d35fa4fd6e7f",
+                "sha256:e062aa24638bb5018b7841977c360d2f5917268d125c833a686b7cbabbec496c",
+                "sha256:e5e18e5b14a7560d8acf1c596688f4dfd19b4f2945b245a71e5af4ddb7422feb",
+                "sha256:eae430ecf5794cb7ae7fa3808740b015aa80747e5266153128ef055975a72b99",
+                "sha256:ee84ca3c58fe48b8ddafdeb1db87388dce2c3c3f701bf447b05e4cfcc3679112",
+                "sha256:f042f66d0b4ae6d48e70e28d487376204d3cbf43b84c03bac57e28dac6151581",
+                "sha256:f8db2f125746e44dce707dd44d4f4efeea8d7e2b43aace3f8d1f235cfa2733dd",
+                "sha256:f93fc78fe8bf15afe2b8d6b6499f1c73953169fad1e9a8dd086cdff3190e7fdf"
+            ],
+            "markers": "python_version < '3.13' and python_version >= '3.9'",
+            "version": "==1.26.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
+                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.2"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:02304e11582c5d090e5a52aec726f31fe3f42895d6bfc1f28738f9b64b6f0614",
+                "sha256:0489b0e6aa3d907e909aef92975edae89b1ee1654db5eafb9be633b0124abe97",
+                "sha256:05674536bd477af36aa2effd4ec8f71b92234ce0cc174de34fd21e2ee99adbc2",
+                "sha256:25e8474a8eb258e391e30c288eecec565bfed3e026f312b0cbd709a63906b6f8",
+                "sha256:29deb61de5a8a93bdd033df328441a79fcf8dd3c12d5ed0b41a395eef9cd76f0",
+                "sha256:366da7b0e540d1b908886d4feb3d951f2f1e572e655c1160f5fde28ad4abb750",
+                "sha256:3bcad1e6fb34b727b016775bea407311f7721db87e5b409e6542f4546a4951ea",
+                "sha256:4c3f32fd7c4dccd035f71734df39231ac1a6ff95e8bdab8d891167197b7018d2",
+                "sha256:4cdb0fab0400c2cb46dafcf1a0fe084c8bb2480a1fa8d81e19d15e12e6d4ded2",
+                "sha256:4f99bebf19b7e03cf80a4e770a3e65eee9dd4e2679039f542d7c1ace7b7b1daa",
+                "sha256:58d997dbee0d4b64f3cb881a24f918b5f25dd64ddf31f467bb9b67ae4c63a1e4",
+                "sha256:75ce97667d06d69396d72be074f0556698c7f662029322027c226fd7a26965cb",
+                "sha256:84e7e910096416adec68075dc87b986ff202920fb8704e6d9c8c9897fe7332d6",
+                "sha256:9e2959720b70e106bb1d8b6eadd8ecd7c8e99ccdbe03ee03260877184bb2877d",
+                "sha256:9e50e72b667415a816ac27dfcfe686dc5a0b02202e06196b943d54c4f9c7693e",
+                "sha256:a0dbfea0dd3901ad4ce2306575c54348d98499c95be01b8d885a2737fe4d7a98",
+                "sha256:b407381258a667df49d58a1b637be33e514b07f9285feb27769cedb3ab3d0b3a",
+                "sha256:b8bd1685556f3374520466998929bade3076aeae77c3e67ada5ed2b90b4de7f0",
+                "sha256:c1f84c144dee086fe4f04a472b5cd51e680f061adf75c1ae4fc3a9275560f8f4",
+                "sha256:c747793c4e9dcece7bb20156179529898abf505fe32cb40c4052107a3c620b49",
+                "sha256:cc1ab6a25da197f03ebe6d8fa17273126120874386b4ac11c1d687df288542dd",
+                "sha256:dc3657869c7902810f32bd072f0740487f9e030c1a3ab03e0af093db35a9d14e",
+                "sha256:f5ec7740f9ccb90aec64edd71434711f58ee0ea7f5ed4ac48be11cfa9abf7317",
+                "sha256:fecb198dc389429be557cde50a2d46da8434a17fe37d7d41ff102e3987fd947b",
+                "sha256:ffa8f0966de2c22de408d0e322db2faed6f6e74265aa0856f3824813cf124363"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.1.1"
+        },
         "prompt-toolkit": {
             "hashes": [
                 "sha256:04505ade687dc26dc4284b1ad19a83be2f2afe83e7a828ace0c72f3a1df72aac",
@@ -487,8 +594,42 @@
                 "sha256:f9ecbf504c4eaff90139d5c9b95d47275f2b2651e14eba56392b4041fbf4c2b3"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==2.9.8"
+        },
+        "pyarrow": {
+            "hashes": [
+                "sha256:09552dad5cf3de2dc0aba1c7c4b470754c69bd821f5faafc3d774bedc3b04bb7",
+                "sha256:0f6eff839a9e40e9c5610d3ff8c5bdd2f10303408312caf4c8003285d0b49565",
+                "sha256:1afcc2c33f31f6fb25c92d50a86b7a9f076d38acbcb6f9e74349636109550148",
+                "sha256:3896ae6c205d73ad192d2fc1489cd0edfab9f12867c85b4c277af4d37383c18c",
+                "sha256:47663efc9c395e31d09c6aacfa860f4473815ad6804311c5433f7085415d62a7",
+                "sha256:51be67e29f3cfcde263a113c28e96aa04362ed8229cb7c6e5f5c719003659d33",
+                "sha256:588f0d2da6cf1b1680974d63be09a6530fd1bd825dc87f76e162404779a157dc",
+                "sha256:6241afd72b628787b4abea39e238e3ff9f34165273fad306c7acf780dd850956",
+                "sha256:6647444b21cb5e68b593b970b2a9a07748dd74ea457c7dadaa15fd469c48ada1",
+                "sha256:68fcd2dc1b7d9310b29a15949cdd0cb9bc34b6de767aff979ebf546020bf0ba0",
+                "sha256:69b6f9a089d116a82c3ed819eea8fe67dae6105f0d81eaf0fdd5e60d0c6e0944",
+                "sha256:70fa38cdc66b2fc1349a082987f2b499d51d072faaa6b600f71931150de2e0e3",
+                "sha256:83333726e83ed44b0ac94d8d7a21bbdee4a05029c3b1e8db58a863eec8fd8a33",
+                "sha256:868a073fd0ff6468ae7d869b5fc1f54de5c4255b37f44fb890385eb68b68f95d",
+                "sha256:8b30a27f1cddf5c6efcb67e598d7823a1e253d743d92ac32ec1eb4b6a1417867",
+                "sha256:aac0ae0146a9bfa5e12d87dda89d9ef7c57a96210b899459fc2f785303dcbb67",
+                "sha256:ab1268db81aeb241200e321e220e7cd769762f386f92f61b898352dd27e402ce",
+                "sha256:b9ba6b6d34bd2563345488cf444510588ea42ad5613df3b3509f48eb80250afd",
+                "sha256:c51afd87c35c8331b56f796eff954b9c7f8d4b7fef5903daf4e05fcf017d23a8",
+                "sha256:cd57b13a6466822498238877892a9b287b0a58c2e81e4bdb0b596dbb151cbb73",
+                "sha256:d00d374a5625beeb448a7fa23060df79adb596074beb3ddc1838adb647b6ef09",
+                "sha256:d1b4e7176443d12610874bb84d0060bf080f000ea9ed7c84b2801df851320295",
+                "sha256:d7759994217c86c161c6a8060509cfdf782b952163569606bb373828afdd82e8",
+                "sha256:dc6fd330fd574c51d10638e63c0d00ab456498fc804c9d01f2a61b9264f2c5b2",
+                "sha256:e3ad79455c197a36eefbd90ad4aa832bece7f830a64396c15c61a0985e337287",
+                "sha256:e66442e084979a97bb66939e18f7b8709e4ac5f887e636aba29486ffbf373763",
+                "sha256:ee7490f0f3f16a6c38f8c680949551053c8194e68de5046e6c288e396dccee80",
+                "sha256:f8ce69f7bf01de2e2764e14df45b8404fc6f1a5ed9871e8e08a12169f87b7a26",
+                "sha256:fda7857e35993673fcda603c07d43889fca60a5b254052a462653f8656c64f44"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==13.0.0"
         },
         "pycparser": {
             "hashes": [
@@ -503,7 +644,6 @@
                 "sha256:bc3ddf669d234f4220e6e1c4d96b061abe0998185a8d7855c0126782b7abc8c1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==2.4.2"
         },
         "pydantic-core": {
@@ -641,13 +781,19 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
+        "pytz": {
+            "hashes": [
+                "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b",
+                "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"
+            ],
+            "version": "==2023.3.post1"
+        },
         "redis": {
             "hashes": [
                 "sha256:0dab495cd5753069d3bc650a0dde8a8f9edde16fc5691b689a566eda58100d0f",
                 "sha256:ed4802971884ae19d640775ba3b03aa2e7bd5e8fb8dfaed2decce4d0fc48391f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==5.0.1"
         },
         "requests": {
@@ -658,6 +804,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
         },
+        "s3transfer": {
+            "hashes": [
+                "sha256:10d6923c6359175f264811ef4bf6161a3156ce8e350e705396a7557d6293c33a",
+                "sha256:fd3889a66f5fe17299fe75b82eae6cf722554edca744ca5d5fe308b104883d2e"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.7.0"
+        },
         "securesystemslib": {
             "extras": [
                 "crypto",
@@ -667,7 +821,7 @@
                 "sha256:658ea4d41bbe6bc574758f91ba809812e08a22fddebb6ee4ea837f72591f136a",
                 "sha256:dcfcb70562ad76069f71da9916a3cb7bc85fbf6cd51216c741a00096cf58dc6c"
             ],
-            "markers": "python_version ~= '3.7'",
+            "index": "pypi",
             "version": "==0.29.0"
         },
         "setuptools": {
@@ -731,7 +885,6 @@
                 "sha256:fc6b15465fabccc94bf7e38777d665b6a4f95efd1725049d6184b3a39fd54880"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==2.0.21"
         },
         "supervisor": {
@@ -748,7 +901,6 @@
                 "sha256:e8fb94cb38f472530d591c59e87f22698355a673231f5bf50d7d1da4842c0007"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==3.0.0"
         },
         "typing-extensions": {
@@ -769,11 +921,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2",
-                "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"
+                "sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21",
+                "sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.6"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.17"
         },
         "vine": {
             "hashes": [
@@ -814,7 +966,6 @@
                 "sha256:d429c2430c93b7903914e4db9a966c7f2b068dd2ebdd2fa9b9ce094c7d459f33"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==3.0.0"
         },
         "wcwidth": {
@@ -834,6 +985,21 @@
             "markers": "python_version >= '3.6'",
             "version": "==0.7.13"
         },
+        "awscli": {
+            "hashes": [
+                "sha256:1c1df34b4bd68b853b37fab9bad153852820769e0fa0664988cfe6cf379c3e49",
+                "sha256:eb795bfbe27997b4acc7501d261334e5aa2f01b82ed85f2ae724d0c843dc4e75"
+            ],
+            "index": "pypi",
+            "version": "==1.29.58"
+        },
+        "awscli-local": {
+            "hashes": [
+                "sha256:99aad6b8e0cfefb2093453866cbcd24e710d7e6a1523cac0969ed0f64442ea7c"
+            ],
+            "index": "pypi",
+            "version": "==0.21"
+        },
         "babel": {
             "hashes": [
                 "sha256:04c3e2d28d2b7681644508f836be388ae49e0cfe91465095340395b60d00f210",
@@ -848,7 +1014,6 @@
                 "sha256:bdfc739baa03b880c2d15d0431b31c658ffc348e907fe197e54e0389dd59e11e"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==1.7.5"
         },
         "black": {
@@ -877,16 +1042,23 @@
                 "sha256:d6bc09188020c9ac2555a498949401ab35bb6bf76d4e0f8ee251694664df6301"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==23.9.1"
         },
-        "cachetools": {
+        "boto3": {
             "hashes": [
-                "sha256:95ef631eeaea14ba2e36f06437f36463aac3a096799e876ee55e5cdccb102590",
-                "sha256:dce83f2d9b4e1f732a8cd44af8e8fab2dbe46201467fc98b3ef8f269092bf62b"
+                "sha256:2f18d2dac5d9229e8485b556eb58b7b95fca91bbf002f63bf9c39209f513f6e6",
+                "sha256:71dcd596a82b5341c6941117b9228897bfb1e2b58f73e60e1fdda1b02a847cc8"
+            ],
+            "index": "pypi",
+            "version": "==1.28.58"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:002f8bdca8efde50ae7267f342bc1d03a71d76024ce3949e4ffdd1151581c53e",
+                "sha256:83a3ca4d9247fdbde76c654137e6ab648bd976f652ce2354def1715c838af505"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.3.1"
+            "version": "==1.31.58"
         },
         "certifi": {
             "hashes": [
@@ -903,14 +1075,6 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==3.4.0"
-        },
-        "chardet": {
-            "hashes": [
-                "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7",
-                "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==5.2.0"
         },
         "charset-normalizer": {
             "hashes": [
@@ -1018,11 +1182,11 @@
         },
         "colorama": {
             "hashes": [
-                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
-                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
-            "version": "==0.4.6"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.4.4"
         },
         "coverage": {
             "hashes": [
@@ -1080,7 +1244,6 @@
                 "sha256:fe494faa90ce6381770746077243231e0b83ff3f17069d748f645617cefe19d4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==7.3.2"
         },
         "distlib": {
@@ -1092,11 +1255,11 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c",
-                "sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"
+                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
+                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.18.1"
+            "version": "==0.16"
         },
         "exceptiongroup": {
             "hashes": [
@@ -1120,7 +1283,6 @@
                 "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.8.1'",
             "version": "==6.1.0"
         },
         "gitdb": {
@@ -1177,7 +1339,6 @@
                 "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.8.0'",
             "version": "==5.12.0"
         },
         "jinja2": {
@@ -1188,13 +1349,27 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.1.2"
         },
+        "jmespath": {
+            "hashes": [
+                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.1"
+        },
+        "localstack-client": {
+            "hashes": [
+                "sha256:377ed05e7854eb476dc73b0ab992c433c683bd1026aa84755eaa29f7561757c1"
+            ],
+            "version": "==2.3"
+        },
         "markdown-it-py": {
             "hashes": [
-                "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
-                "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"
+                "sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30",
+                "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.0.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.2.0"
         },
         "markupsafe": {
             "hashes": [
@@ -1272,11 +1447,11 @@
         },
         "mdit-py-plugins": {
             "hashes": [
-                "sha256:b51b3bb70691f57f974e257e367107857a93b36f322a9e6d44ca5bf28ec2def9",
-                "sha256:d8ab27e9aed6c38aa716819fedfde15ca275715955f8a185a8e1cf90fb1d2c1b"
+                "sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e",
+                "sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==0.4.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.3.5"
         },
         "mdurl": {
             "hashes": [
@@ -1317,7 +1492,6 @@
                 "sha256:ff0cedc84184115202475bbb46dd99f8dcb87fe24d5d0ddfc0fe6b8575c88d2f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.5.1"
         },
         "mypy-extensions": {
@@ -1330,12 +1504,11 @@
         },
         "myst-parser": {
             "hashes": [
-                "sha256:7c36344ae39c8e740dad7fdabf5aa6fc4897a813083c6cc9990044eb93656b14",
-                "sha256:ea929a67a6a0b1683cdbe19b8d2e724cd7643f8aa3e7bb18dd65beac3483bead"
+                "sha256:502845659313099542bd38a2ae62f01360e7dd4b1310f025dd014dfc0439cdae",
+                "sha256:69fb40a586c6fa68995e6521ac0a525793935db7e724ca9bac1d33be51be9a4c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==2.0.0"
+            "version": "==1.0.0"
         },
         "nodeenv": {
             "hashes": [
@@ -1391,7 +1564,6 @@
                 "sha256:96d529a951f8b677f730a7212442027e8ba53f9b04d217c4c67dc56c393ad945"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==3.4.0"
         },
         "pretend": {
@@ -1401,6 +1573,22 @@
             ],
             "index": "pypi",
             "version": "==1.0.9"
+        },
+        "py": {
+            "hashes": [
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
+        },
+        "pyasn1": {
+            "hashes": [
+                "sha256:87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57",
+                "sha256:97b7290ca68e62a832558ec3976f15cbf911bf5d7c7039d8b861c2a0ece69fde"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==0.5.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -1426,22 +1614,21 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.16.1"
         },
-        "pyproject-api": {
-            "hashes": [
-                "sha256:1817dc018adc0d1ff9ca1ed8c60e1623d5aaca40814b953af14a9cf9a5cae538",
-                "sha256:4c0116d60476b0786c88692cf4e325a9814965e2469c5998b830bba16b183675"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.6.1"
-        },
         "pytest": {
             "hashes": [
                 "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002",
                 "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==7.4.2"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
         },
         "pyyaml": {
             "hashes": [
@@ -1515,6 +1702,22 @@
             "markers": "python_full_version >= '3.7.0'",
             "version": "==13.6.0"
         },
+        "rsa": {
+            "hashes": [
+                "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2",
+                "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"
+            ],
+            "markers": "python_version >= '3.5' and python_version < '4'",
+            "version": "==4.7.2"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:10d6923c6359175f264811ef4bf6161a3156ce8e350e705396a7557d6293c33a",
+                "sha256:fd3889a66f5fe17299fe75b82eae6cf722554edca744ca5d5fe308b104883d2e"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.7.0"
+        },
         "setuptools": {
             "hashes": [
                 "sha256:4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87",
@@ -1522,6 +1725,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==68.2.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
         },
         "smmap": {
             "hashes": [
@@ -1540,12 +1751,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:1e09160a40b956dc623c910118fa636da93bd3ca0b9876a7b3df90f07d691560",
-                "sha256:9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5"
+                "sha256:060ca5c9f7ba57a08a1219e547b269fadf125ae25b06b9fa7f66768efb652d6d",
+                "sha256:51026de0a9ff9fc13c05d74913ad66047e104f56a129ff73e174eb5c3ee794b5"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==7.2.6"
+            "version": "==5.3.0"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -1553,7 +1763,6 @@
                 "sha256:590b030c7abb9cf038ec053b95e5380b5c70d61591eb0b552063fbe7c41f0931"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.3.0"
         },
         "sphinxcontrib-applehelp": {
@@ -1562,7 +1771,6 @@
                 "sha256:39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.0.7"
         },
         "sphinxcontrib-devhelp": {
@@ -1571,7 +1779,6 @@
                 "sha256:fe8009aed765188f08fcaadbb3ea0d90ce8ae2d76710b7e29ea7d047177dae2f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.0.5"
         },
         "sphinxcontrib-htmlhelp": {
@@ -1580,7 +1787,6 @@
                 "sha256:8001661c077a73c29beaf4a79968d0726103c5605e27db92b9ebed8bab1359e9"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==2.0.4"
         },
         "sphinxcontrib-jquery": {
@@ -1597,7 +1803,6 @@
                 "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.1"
         },
         "sphinxcontrib-plantuml": {
@@ -1613,7 +1818,6 @@
                 "sha256:bf76886ee7470b934e363da7a954ea2825650013d367728588732c7350f49ea4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.0.6"
         },
         "sphinxcontrib-serializinghtml": {
@@ -1622,7 +1826,6 @@
                 "sha256:9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.1.9"
         },
         "stevedore": {
@@ -1643,12 +1846,11 @@
         },
         "tox": {
             "hashes": [
-                "sha256:5039f68276461fae6a9452a3b2c7295798f00a0e92edcd9a3b78ba1a73577951",
-                "sha256:599af5e5bb0cad0148ac1558a0b66f8fff219ef88363483b8d92a81e4246f28f"
+                "sha256:57b5ab7e8bb3074edc3c0c0b4b192a4f3799d3723b2c5b76f1fa9f2d40316eea",
+                "sha256:d0d28f3fe6d6d7195c27f8b054c3e99d5451952b54abdae673b71609a581f640"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==4.11.3"
+            "version": "==3.28.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -1660,11 +1862,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2",
-                "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"
+                "sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21",
+                "sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.6"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.17"
         },
         "virtualenv": {
             "hashes": [
@@ -1672,7 +1874,6 @@
                 "sha256:e8361967f6da6fbdf1426483bfe9fca8287c242ac0bc30429905721cefbff752"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==20.24.5"
         }
     }

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -1,30 +1,16 @@
-# Default development deployment
+# Development deployment using AWS RSTUF Services
 version: "3.9"
 
 volumes:
   repository-service-tuf-storage:
   repository-service-tuf-api-data:
-  repository-service-tuf-mq-data:
-  repository-service-tuf-settings:
   repository-service-tuf-redis-data:
   repository-service-tuf-pgsql-data:
 
 services:
-  rabbitmq:
-    image: rabbitmq:3.10.7-management-alpine
-    volumes:
-     - "repository-service-tuf-mq-data:/var/lib/rabbitmq"
-    ports:
-      - 5672:5672
-      - 15672:15672
-    healthcheck:
-      test: "exit 0"
-    restart: always
-
   postgres:
     image: postgres:15.1
     ports:
-      # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"
     environment:
       - POSTGRES_PASSWORD=secret
@@ -41,10 +27,10 @@ services:
     ports:
       - 80:80
     environment:
-      - RSTUF_BROKER_SERVER="amqp://guest:guest@rabbitmq:5672"
-      - RSTUF_REDIS_SERVER="redis://redis"
+      - RSTUF_BROKER_SERVER=redis://redis
+      - RSTUF_REDIS_SERVER=redis://redis
     depends_on:
-      rabbitmq:
+      redis:
         condition: service_healthy
 
   web:
@@ -61,6 +47,20 @@ services:
       - repository-service-tuf-redis-data:/data
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+
+  localstack:
+    image: localstack/localstack:2.2
+    environment:
+      HOSTNAME: "localstack"
+      LOCALSTACK_HOST: "localstack"
+      LS_LOG: "error"
+    ports:
+      - "4566:4566"
+    volumes:
+      - "./tests/files/aws/init-services.sh:/etc/localstack/init/ready.d/init-services.sh"
 
   repository-service-tuf-worker:
     build:
@@ -68,23 +68,27 @@ services:
     entrypoint: "bash entrypoint-dev.sh"
     environment:
       - DATA_DIR=./data
-      - RSTUF_STORAGE_BACKEND=LocalStorage
-      - RSTUF_LOCAL_STORAGE_BACKEND_PATH=/var/opt/repository-service-tuf/storage
+      - RSTUF_STORAGE_BACKEND=AWSS3
+      - RSTUF_AWSS3_STORAGE_BUCKET=tuf-metadata
+      - RSTUF_AWSS3_STORAGE_ACCESS_KEY=access_key
+      - RSTUF_AWSS3_STORAGE_SECRET_KEY=secret_key
+      - RSTUF_AWSS3_STORAGE_REGION=us-east-1
+      - RSTUF_AWSS3_STORAGE_ENDPOINT_URL=http://localstack:4566
       - RSTUF_KEYVAULT_BACKEND=LocalKeyVault
       - RSTUF_LOCAL_KEYVAULT_PATH=/opt/repository-service-tuf-worker/tests/files/key_storage
       - RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass:online-rsa.key,strongPass,rsa
-      - RSTUF_BROKER_SERVER=amqp://guest:guest@rabbitmq:5672
-      - RSTUF_SQL_SERVER=postgres:5432
-      - RSTUF_SQL_USER=postgres
-      - RSTUF_SQL_PASSWORD=secret
+      - RSTUF_BROKER_SERVER=redis://redis
       - RSTUF_REDIS_SERVER=redis://redis
+      - RSTUF_SQL_SERVER=postgres:secret@postgres:5432
     volumes:
       - ./:/opt/repository-service-tuf-worker:z
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
     depends_on:
-      rabbitmq:
+      redis:
         condition: service_healthy
       postgres:
+        condition: service_healthy
+      localstack:
         condition: service_healthy
     tty: true
     stdin_open: true

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -33,14 +33,6 @@ services:
       redis:
         condition: service_healthy
 
-  web:
-    image: python:3.10-slim-buster
-    command: python -m http.server -d /var/opt/repository-service-tuf/storage 8080
-    volumes:
-      - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
-    ports:
-      - "8080:8080"
-
   redis:
     image: redis:4.0
     volumes:
@@ -83,7 +75,6 @@ services:
       - RSTUF_SQL_SERVER=postgres:secret@postgres:5432
     volumes:
       - ./:/opt/repository-service-tuf-worker:z
-      - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -73,6 +73,7 @@ services:
       - RSTUF_BROKER_SERVER=redis://redis
       - RSTUF_REDIS_SERVER=redis://redis
       - RSTUF_SQL_SERVER=postgres:secret@postgres:5432
+      - METADATA_BASE_URL="http://localstack:4566/tuf-metadata/"
     volumes:
       - ./:/opt/repository-service-tuf-worker:z
     depends_on:

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -72,7 +72,7 @@ services:
       - RSTUF_AWSS3_STORAGE_BUCKET=tuf-metadata
       - RSTUF_AWSS3_STORAGE_ACCESS_KEY=access_key
       - RSTUF_AWSS3_STORAGE_SECRET_KEY=secret_key
-      # region and endpoint_url are required to use localstack
+      # region and endpoint_url are required by localstack
       - RSTUF_AWSS3_STORAGE_REGION=us-east-1
       - RSTUF_AWSS3_STORAGE_ENDPOINT_URL=http://localstack:4566
       - RSTUF_KEYVAULT_BACKEND=LocalKeyVault

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -72,6 +72,7 @@ services:
       - RSTUF_AWSS3_STORAGE_BUCKET=tuf-metadata
       - RSTUF_AWSS3_STORAGE_ACCESS_KEY=access_key
       - RSTUF_AWSS3_STORAGE_SECRET_KEY=secret_key
+      # region and endpoint_url are required to use localstack
       - RSTUF_AWSS3_STORAGE_REGION=us-east-1
       - RSTUF_AWSS3_STORAGE_ENDPOINT_URL=http://localstack:4566
       - RSTUF_KEYVAULT_BACKEND=LocalKeyVault

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,15 @@ services:
       rabbitmq:
         condition: service_healthy
 
+  localstack:
+    image: localstack/localstack:2.2
+    environment:
+      HOSTNAME: "localstack"
+      LOCALSTACK_HOST: "localstack"
+      LS_LOG: "error"
+    ports:
+      - "4566:4566"
+
   web:
     image: python:3.10-slim-buster
     command: python -m http.server -d /var/opt/repository-service-tuf/storage 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,9 @@ services:
     ports:
       - 80:80
     environment:
+      ##############################
+      ### INFRASTRUCURE SERVICES ###
+      ##############################
       - RSTUF_BROKER_SERVER="amqp://guest:guest@rabbitmq:5672"
       - RSTUF_REDIS_SERVER="redis://redis"
     depends_on:
@@ -77,11 +80,31 @@ services:
     entrypoint: "bash entrypoint-dev.sh"
     environment:
       - DATA_DIR=./data
+      ###############################
+      ### STORAGE BACKEND SERVICE ###
+      ###############################
       - RSTUF_STORAGE_BACKEND=LocalStorage
-      - RSTUF_KEYVAULT_BACKEND=LocalKeyVault
+      # LOCAL STORAGE
+      # =============
       - RSTUF_LOCAL_STORAGE_BACKEND_PATH=/var/opt/repository-service-tuf/storage
+      # AWS S3 STORAGE
+      # ==============
+      # - RSTUF_AWSS3_STORAGE_BUCKET=tuf-metadata
+      # - RSTUF_AWSS3_STORAGE_ACCESS_KEY=access_key
+      # - RSTUF_AWSS3_STORAGE_SECRET_KEY=secret_key
+      # - RSTUF_AWSS3_STORAGE_REGION=us-east-1
+      # - RSTUF_AWSS3_STORAGE_ENDPOINT_URL=http://localstack:4566
+      ################################
+      ### KEYVAULT BACKEND SERVICE ###
+      ################################
+      - RSTUF_KEYVAULT_BACKEND=LocalKeyVault
+      # LOCAL KEYVAULT
+      # ==============
       - RSTUF_LOCAL_KEYVAULT_PATH=/opt/repository-service-tuf-worker/tests/files/key_storage
       - RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass:online-rsa.key,strongPass,rsa
+      ##############################
+      ### INFRASTRUCURE SERVICES ###
+      ##############################
       - RSTUF_BROKER_SERVER=amqp://guest:guest@rabbitmq:5672
       - RSTUF_SQL_SERVER=postgres:5432
       - RSTUF_SQL_USER=postgres

--- a/docs/source/devel/index.rst
+++ b/docs/source/devel/index.rst
@@ -200,7 +200,6 @@ locks [#f1]_ . It will  will do:
    ?highlight=Task%20cookbook#ensuring-a-task-is-only-executed-one-at-a-time>`_
    . I avoid that two tasks write the same metadata, causing a race condition.
 
-
 RSTUF Worker Backend Services Development
 #########################################
 
@@ -209,28 +208,19 @@ Storage
 
 The default RSTUF Worker source code is configured to use  `LocalStorage`.
 
+1. Initiate the local development environment ``make run-dev``
+
 AWSS3
 -----
 
-1. Initiate the local development environment ``make run-dev``
-
-2. Initiate the localstack configuration ``make localstack-init``
-
-3. Update ``docker-compose.yml`` to use ``AWSS3``
-
-   * Set ``RSTUF_STORAGE_BACKEND`` as ``AWSS3``
-   * Uncomment the ``RSTUF_AWSS3_STORAGE*`` environment variables
-   * Comment the ``RSTUF_LOCAL_STORAGE*``
-
-4. In another shell run `docker compose up -d`
-
+1. Initiate the aws development environment ``make run-dev DC=aws``
 
 KeyVault
 ========
 
 The default RSTUF Worker source code is configured to use  `LocalKeyVault`.
 
-
+1. Initiate the local development environment ``make run-dev``
 
 Important issues/problems
 #########################

--- a/docs/source/devel/index.rst
+++ b/docs/source/devel/index.rst
@@ -207,20 +207,22 @@ RSTUF Worker Backend Services Development
 Storage
 =======
 
-The default RSTUF Worker source code is configured to use  `LocalKeyVault`.
+The default RSTUF Worker source code is configured to use  `LocalStorage`.
 
 AWSS3
 -----
 
-1. Update ``docker-compose.yml`` to use ``AWSS3``
+1. Initiate the local development environment ``make run-dev``
+
+2. Initiate the localstack configuration ``make localstack-init``
+
+3. Update ``docker-compose.yml`` to use ``AWSS3``
 
    * Set ``RSTUF_STORAGE_BACKEND`` as ``AWSS3``
    * Uncomment the ``RSTUF_AWSS3_STORAGE*`` environment variables
    * Comment the ``RSTUF_LOCAL_STORAGE*``
 
-2. Initiate the local development environment ``make run-dev``
-
-3. Initiate the localstack configuration ``make localstack-init``
+4. In another shell run `docker compose up -d`
 
 
 KeyVault

--- a/docs/source/devel/index.rst
+++ b/docs/source/devel/index.rst
@@ -200,6 +200,36 @@ locks [#f1]_ . It will  will do:
    ?highlight=Task%20cookbook#ensuring-a-task-is-only-executed-one-at-a-time>`_
    . I avoid that two tasks write the same metadata, causing a race condition.
 
+
+RSTUF Worker Backend Services Development
+#########################################
+
+Storage
+=======
+
+The default RSTUF Worker source code is configured to use  `LocalKeyVault`.
+
+AWSS3
+-----
+
+1. Update ``docker-compose.yml`` to use ``AWSS3``
+
+   * Set ``RSTUF_STORAGE_BACKEND`` as ``AWSS3``
+   * Uncomment the ``RSTUF_AWSS3_STORAGE*`` environment variables
+   * Comment the ``RSTUF_LOCAL_STORAGE*``
+
+2. Initiate the local development environment ``make run-dev``
+
+3. Initiate the localstack configuration ``make localstack-init``
+
+
+KeyVault
+========
+
+The default RSTUF Worker source code is configured to use  `LocalKeyVault`.
+
+
+
 Important issues/problems
 #########################
 

--- a/docs/source/devel/repository_service_tuf_worker.services.storage.rst
+++ b/docs/source/devel/repository_service_tuf_worker.services.storage.rst
@@ -4,6 +4,14 @@ repository\_service\_tuf\_worker.services.storage package
 Submodules
 ----------
 
+repository\_service\_tuf\_worker.services.storage.awss3 module
+--------------------------------------------------------------
+
+.. automodule:: repository_service_tuf_worker.services.storage.awss3
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 repository\_service\_tuf\_worker.services.storage.local module
 --------------------------------------------------------------
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -132,9 +132,6 @@ Available types:
 
 ##### `AWSS3` (AWS S3)
 
-* (Required) ``RSTUF_AWSS3_STORAGE_REGION``
-
-  The name of the region associated with the S3.
 
 * (Required) ``RSTUF_AWSS3_STORAGE_BUCKET``
 
@@ -154,12 +151,21 @@ Available types:
 
   This environment variable supports container secrets when the ``/run/secrets``
   volume is added to the path.
-  Example: `RSTUF_AWSS3_STORAGE_ACCESS_KEY=/run/secrets/S3_SECRET_KEY`
+  Example: ``RSTUF_AWSS3_STORAGE_ACCESS_KEY=/run/secrets/S3_SECRET_KEY``
 
+* (Optional) ``RSTUF_AWSS3_STORAGE_REGION``
+
+  The name of the region associated with the S3.
 
 * (Optional) ``RSTUF_AWSS3_STORAGE_ENDPOINT_URL``
 
-  The complete URL to use for the constructed
+  The complete URL to use for the constructed client. Normally, it is
+  automatically construct the appropriate URL to use when communicating with a
+  service.
+
+**_NOTE:_**  The AWS3 supports all `boto3`
+[environment variables](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables).
+
 
 
 #### (Optional) `RSTUF_LOCK_TIMEOUT`

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -132,7 +132,6 @@ Available types:
 
 ##### `AWSS3` (AWS S3)
 
-
 * (Required) ``RSTUF_AWSS3_STORAGE_BUCKET``
 
   The name of the region associated with the S3.
@@ -159,14 +158,12 @@ Available types:
 
 * (Optional) ``RSTUF_AWSS3_STORAGE_ENDPOINT_URL``
 
-  The complete URL to use for the constructed client. Normally, it is
-  automatically construct the appropriate URL to use when communicating with a
-  service.
+  The complete URL to use for the constructed client. Normally, the
+  client automatically constructs the appropriate URL to use when
+  communicating with a service.
 
 **_NOTE:_**  The AWS3 supports all `boto3`
 [environment variables](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables).
-
-
 
 #### (Optional) `RSTUF_LOCK_TIMEOUT`
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -98,7 +98,6 @@ Example: `postgres:secret@postgres:5432`
   RSTUF_SQL_PASSWORD=/run/secrets/POSTGRES_PASSWORD
   ```
 
-
 #### (Optional) `RSTUF_REDIS_SERVER_PORT`
 
 Redis Server port number. Default: 6379
@@ -122,9 +121,46 @@ Select a supported type of Storage Service.
 
 Available types:
 
-* LocalStorage (local file system)
-    - Requires variable ``RSTUF_LOCAL_STORAGE_BACKEND_PATH``
-      - Define the directory where the data will be saved, example: `storage`
+* `LocalStorage` (container volume)
+* `AWSS3` (AWS S3)
+
+##### `LocalStorage` (container volume)
+
+* (Required) ``RSTUF_LOCAL_STORAGE_BACKEND_PATH``
+
+  - Define the directory where the data will be saved, example: `storage`
+
+##### `AWSS3` (AWS S3)
+
+* (Required) ``RSTUF_AWSS3_STORAGE_REGION``
+
+  The name of the region associated with the S3.
+
+* (Required) ``RSTUF_AWSS3_STORAGE_BUCKET``
+
+  The name of the region associated with the S3.
+
+* (Required) ``RSTUF_AWSS3_STORAGE_ACCESS_KEY``
+
+  The access key to use when creating the client session to the S3.
+
+  This environment variable supports container secrets when the ``/run/secrets``
+  volume is added to the path.
+  Example: `RSTUF_AWSS3_STORAGE_ACCESS_KEY=/run/secrets/S3_ACCESS_KEY`
+
+* (Required) ``RSTUF_AWSS3_STORAGE_SECRET_KEY``
+
+  The secret key to use when creating the client session to the S3.
+
+  This environment variable supports container secrets when the ``/run/secrets``
+  volume is added to the path.
+  Example: `RSTUF_AWSS3_STORAGE_ACCESS_KEY=/run/secrets/S3_SECRET_KEY`
+
+
+* (Optional) ``RSTUF_AWSS3_STORAGE_ENDPOINT_URL``
+
+  The complete URL to use for the constructed
+
 
 #### (Optional) `RSTUF_LOCK_TIMEOUT`
 
@@ -134,7 +170,6 @@ This timeout avoids race conditions leading to publishing JSON metadata files by
 Worker's services. It guarantees that the metadata is consistent in the backend
 storage service (`RSTUF_STORAGE_BACKEND`).
 
-
 In most use cases, the timeout of 60.0 seconds is sufficient.
 
 #### (Required) `RSTUF_KEYVAULT_BACKEND`
@@ -143,47 +178,53 @@ Select a supported type of Key Vault Service.
 
 Available types:
 
-* LocalKeyVault (local file system)
-  - Required variables:
-    - ``RSTUF_LOCAL_KEYVAULT_PATH``
-      - Define the path for the container volume mounted
-        Example: ``RSTUF_LOCAL_KEYVAULT_PATH=/var/opt/repository-service-tuf/key_storage``
+* `LocalKeyVault` (container volume)
 
-    - ``RSTUF_LOCAL_KEYVAULT_KEYS``
-      - Define the key(s) with format ``<file>,<password>,<(optional) type>``
-        - file: defines the key file
-          - `base64|<key content in base64>` allows to inform directly the key content.
-            It will dynamically manage and write a key file in
-            ``RSTUF_LOCAL_KEYVAULT_PATH`` (write permissions required).
+##### `LocalKeyVault` (container volume)
 
-            Requires content as base64.
+* (Required) ``RSTUF_LOCAL_KEYVAULT_PATH``
 
-            Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=base64|LnRveC8KdmVudi8KLmlkZWEvCi52c2NvZGUvC...,strongPass,rsa``
+  Define the path for the container volume mounted
+  Example: ``RSTUF_LOCAL_KEYVAULT_PATH=/var/opt/repository-service-tuf/key_storage``
 
-        - password: credential used to load the key
-        - (optional) type: The key type. Default: `ed25519`
+* (Required) ``RSTUF_LOCAL_KEYVAULT_KEYS``
 
-          [Note: At the moment RSTUF Worker supports `ed25519`, `rsa`, `ecdsa`]
+  Define the key(s) with format ``<file>,<password>,<(optional) type>``
 
-        Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass,rsa``
+  - `file`: defines the key file
+    + `base64|<key content in base64>` allows to inform directly the key content.
+      It will dynamically manage and write a key file in
+      ``RSTUF_LOCAL_KEYVAULT_PATH`` (write permissions required).
 
-      - Accepts multiple keys separated by ``:``.
+      Requires content as base64.
 
-        It accepts multiple keys, but RSTUF supports the usage of only one
-        online key for signing.
+      Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=base64|LnRveC8KdmVudi8KLmlkZWEvCi52c2NvZGUvC...,strongPass,rsa``
 
-        The Local Key Vault will find the key that matches the online key
-        defined in the root metadata.
-        Allowing multiple keys is helpful for performing metadata/key
-        rotation without disruption.
+  - `password`: credential used to load the key
+  - (optional) `type`: The key type. Default: `ed25519`
 
-        Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass:online-rsa.key,newStrongPass,rsa``
+    [Note: At the moment RSTUF Worker supports `ed25519`, `rsa`, `ecdsa`]
 
-      - This environment variable supports container secrets when the
-        ``/run/secrets`` volume is added to the path. The content must be
-        in the standard format ``<file>,<password>,<(optional) type>``
+    Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass,rsa``
 
-        Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=/run/secrets/ONLINE_KEY_1:/run/secrets/ONLINE_KEY_2``
+  Accepts multiple keys separated by "``:``".
+
+  It accepts multiple keys, but RSTUF supports the usage of only one
+  online key for signing.
+
+  The Local Key Vault will find the key that matches the online key
+  defined in the root metadata.
+
+  Allowing multiple keys is helpful for performing metadata/key
+  rotation without disruption.
+
+  Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass:online-rsa.key,newStrongPass,rsa``
+
+  This environment variable supports container secrets when the
+  ``/run/secrets`` volume is added to the path. The content must be
+  in the standard format ``<file>,<password>,<(optional) type>``
+
+  Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=/run/secrets/ONLINE_KEY_1:/run/secrets/ONLINE_KEY_2``
 
 
 #### (Optional) `RSTUF_WORKER_ID`

--- a/repository_service_tuf_worker/__init__.py
+++ b/repository_service_tuf_worker/__init__.py
@@ -10,6 +10,17 @@ DATA_DIR = os.getenv("DATA_DIR", "/data")
 os.makedirs(DATA_DIR, exist_ok=True)
 
 
+def parse_if_secret(env_var: str) -> str:
+    if env_var.startswith("/run/secrets/"):
+        # The user has stored their variable using container secrets.
+        with open(env_var) as f:
+            content = f.read().rstrip("\n")
+    else:
+        content = env_var
+
+    return content
+
+
 def get_worker_settings() -> Dynaconf:
     SETTINGS_FILE = os.path.join(DATA_DIR, "settings.ini")
     return Dynaconf(

--- a/repository_service_tuf_worker/services/__init__.py
+++ b/repository_service_tuf_worker/services/__init__.py
@@ -10,6 +10,7 @@ from repository_service_tuf_worker.interfaces import (  # noqa
 from repository_service_tuf_worker.services.keyvault.local import (  # noqa
     LocalKeyVault,
 )
-from repository_service_tuf_worker.services.storage.local import (  # noqa
+from repository_service_tuf_worker.services.storage import (  # noqa
+    AWSS3,
     LocalStorage,
 )

--- a/repository_service_tuf_worker/services/storage/__init__.py
+++ b/repository_service_tuf_worker/services/storage/__init__.py
@@ -1,3 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
+from repository_service_tuf_worker.services.storage.awss3 import AWSS3  # noqa
+from repository_service_tuf_worker.services.storage.local import (  # noqa
+    LocalStorage,
+)

--- a/repository_service_tuf_worker/services/storage/awss3.py
+++ b/repository_service_tuf_worker/services/storage/awss3.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
+#
+# SPDX-License-Identifier: MIT
+
+from io import BytesIO
+from typing import List, Optional
+
+import awswrangler
+import boto3
+from botocore.exceptions import ClientError
+from securesystemslib.exceptions import StorageError  # noqa
+from tuf.api.metadata import Metadata, T, Timestamp
+from tuf.api.serialization import DeserializationError
+
+from repository_service_tuf_worker import parse_if_secret
+from repository_service_tuf_worker.interfaces import IStorage, ServiceSettings
+
+
+class AWSS3(IStorage):
+    def __init__(
+        self,
+        bucket: str,
+        access_key: str,
+        secret_key: str,
+        region: str,
+        endpoint_url: Optional[str] = None,
+    ) -> None:
+        self._bucket: str = bucket
+        self._region: str = region
+        self._access_key: str = parse_if_secret(access_key)
+        self._secret_key: str = parse_if_secret(secret_key)
+        self._endpoint_url: Optional[str] = endpoint_url
+
+        self._s3_session = boto3.Session(
+            aws_access_key_id=self._access_key,
+            aws_secret_access_key=self._secret_key,
+            region_name=self._region,
+        )
+
+        self._s3 = self._s3_session.client(
+            "s3",
+            aws_access_key_id=self._access_key,
+            aws_secret_access_key=self._secret_key,
+            region_name=self._region,
+            endpoint_url=self._endpoint_url,
+        )
+
+        self._s3_resource = self._s3_session.resource(
+            "s3",
+            aws_access_key_id=self._access_key,
+            aws_secret_access_key=self._secret_key,
+            region_name=self._region,
+            endpoint_url=self._endpoint_url,
+        )
+
+    @classmethod
+    def configure(cls, settings) -> None:
+        s3_resource = boto3.resource(
+            "s3",
+            aws_access_key_id=settings.AWSS3_STORAGE_ACCESS_KEY,
+            aws_secret_access_key=settings.AWSS3_STORAGE_SECRET_KEY,
+            region_name=settings.AWSS3_STORAGE_REGION,
+            endpoint_url=settings.get("AWSS3_STORAGE_ENDPOINT_URL"),
+        )
+        buckets = [bucket.name for bucket in s3_resource.buckets.all()]
+        if settings.AWSS3_STORAGE_BUCKET not in buckets:
+            raise ValueError(
+                f"Bucket '{settings.AWSS3_STORAGE_BUCKET}' not found."
+            )
+
+    @classmethod
+    def settings(cls) -> List[ServiceSettings]:
+        return [
+            ServiceSettings(
+                name="AWSS3_STORAGE_BUCKET",
+                argument="bucket",
+                required=True,
+            ),
+            ServiceSettings(
+                name="AWSS3_STORAGE_ACCESS_KEY",
+                argument="access_key",
+                required=True,
+            ),
+            ServiceSettings(
+                name="AWSS3_STORAGE_SECRET_KEY",
+                argument="secret_key",
+                required=True,
+            ),
+            ServiceSettings(
+                name="AWSS3_STORAGE_REGION",
+                argument="region",
+                required=True,
+            ),
+            ServiceSettings(
+                name="AWSS3_STORAGE_ENDPOINT_URL",
+                argument="endpoint_url",
+                required=False,
+            ),
+        ]
+
+    def get(self, role: str, version: Optional[int] = None) -> Metadata[T]:
+        """
+        Returns TUF role metadata object for the passed role name,
+        optionally at the passed version (latest if None).
+        """
+        if self._endpoint_url is not None:
+            awswrangler.config.s3_endpoint_url = self._endpoint_url
+
+        if role == Timestamp.type:
+            filename = f"{role}.json"
+        else:
+            if version is None:
+                s3_path = f"s3://{self._bucket}/"
+                filenames = awswrangler.s3.list_objects(
+                    path=f"{s3_path}*.{role}.json",
+                    boto3_session=self._s3_session,
+                )
+                versions = [
+                    int(name.split(s3_path)[-1].split(".", 1)[0])
+                    for name in filenames
+                ]
+                try:
+                    version = max(versions)
+                except ValueError:
+                    version = 1
+
+            filename = f"{version}.{role}.json"
+
+        file_object = BytesIO()
+        try:
+            s3_object = self._s3.get_object(Bucket=self._bucket, Key=filename)
+            file_object = s3_object.get("Body")
+            return Metadata.from_bytes(file_object.read())
+        except DeserializationError as e:
+            raise StorageError(f"Can't open Role '{role}'") from e
+        finally:
+            if file_object is not None:
+                file_object.close()
+
+    def put(
+        self,
+        data: bytes,
+        filename: str,
+    ) -> None:
+        """
+        Writes passed file object to configured TUF S3 bucked.
+        """
+        try:
+            self._s3.put_object(Body=data, Bucket=self._bucket, Key=filename)
+        except ClientError:
+            raise StorageError(f"Can't write role file '{filename}'")

--- a/repository_service_tuf_worker/services/storage/awss3.py
+++ b/repository_service_tuf_worker/services/storage/awss3.py
@@ -55,12 +55,16 @@ class AWSS3(IStorage):
 
     @classmethod
     def configure(cls, settings) -> None:
+        aws_access_key_id = settings.AWSS3_STORAGE_ACCESS_KEY
+        aws_secret_access_key = settings.AWSS3_STORAGE_SECRET_KEY
+        region_name = settings.AWSS3_STORAGE_REGION
+        endpoint_url = settings.get("AWSS3_STORAGE_ENDPOINT_URL")
         s3_resource = boto3.resource(
             "s3",
-            aws_access_key_id=settings.AWSS3_STORAGE_ACCESS_KEY,
-            aws_secret_access_key=settings.AWSS3_STORAGE_SECRET_KEY,
-            region_name=settings.AWSS3_STORAGE_REGION,
-            endpoint_url=settings.get("AWSS3_STORAGE_ENDPOINT_URL"),
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            region_name=region_name,
+            endpoint_url=endpoint_url,
         )
         buckets = [bucket.name for bucket in s3_resource.buckets.all()]
         if settings.AWSS3_STORAGE_BUCKET not in buckets:
@@ -72,27 +76,27 @@ class AWSS3(IStorage):
     def settings(cls) -> List[ServiceSettings]:
         return [
             ServiceSettings(
-                name="AWSS3_STORAGE_BUCKET",
+                names=["AWSS3_STORAGE_BUCKET"],
                 argument="bucket",
                 required=True,
             ),
             ServiceSettings(
-                name="AWSS3_STORAGE_ACCESS_KEY",
+                names=["AWSS3_STORAGE_ACCESS_KEY"],
                 argument="access_key",
                 required=True,
             ),
             ServiceSettings(
-                name="AWSS3_STORAGE_SECRET_KEY",
+                names=["AWSS3_STORAGE_SECRET_KEY"],
                 argument="secret_key",
                 required=True,
             ),
             ServiceSettings(
-                name="AWSS3_STORAGE_REGION",
+                names=["AWSS3_STORAGE_REGION"],
                 argument="region",
-                required=True,
+                required=False,
             ),
             ServiceSettings(
-                name="AWSS3_STORAGE_ENDPOINT_URL",
+                names=["AWSS3_STORAGE_ENDPOINT_URL"],
                 argument="endpoint_url",
                 required=False,
             ),

--- a/repository_service_tuf_worker/services/storage/awss3.py
+++ b/repository_service_tuf_worker/services/storage/awss3.py
@@ -22,11 +22,11 @@ class AWSS3(IStorage):
         bucket: str,
         access_key: str,
         secret_key: str,
-        region: str,
+        region: Optional[str] = None,
         endpoint_url: Optional[str] = None,
     ) -> None:
-        self._bucket: str = bucket
-        self._region: str = region
+        self._bucket: Optional[str] = bucket
+        self._region: Optional[str] = region
         self._access_key: str = parse_if_secret(access_key)
         self._secret_key: str = parse_if_secret(secret_key)
         self._endpoint_url: Optional[str] = endpoint_url
@@ -57,7 +57,7 @@ class AWSS3(IStorage):
     def configure(cls, settings) -> None:
         aws_access_key_id = settings.AWSS3_STORAGE_ACCESS_KEY
         aws_secret_access_key = settings.AWSS3_STORAGE_SECRET_KEY
-        region_name = settings.AWSS3_STORAGE_REGION
+        region_name = settings.get("AWSS3_STORAGE_REGION")
         endpoint_url = settings.get("AWSS3_STORAGE_ENDPOINT_URL")
         s3_resource = boto3.resource(
             "s3",

--- a/repository_service_tuf_worker/services/storage/awss3.py
+++ b/repository_service_tuf_worker/services/storage/awss3.py
@@ -25,10 +25,10 @@ class AWSS3(IStorage):
         region: Optional[str] = None,
         endpoint_url: Optional[str] = None,
     ) -> None:
-        self._bucket: Optional[str] = bucket
-        self._region: Optional[str] = region
         self._access_key: str = parse_if_secret(access_key)
         self._secret_key: str = parse_if_secret(secret_key)
+        self._bucket: str = bucket
+        self._region: Optional[str] = region
         self._endpoint_url: Optional[str] = endpoint_url
 
         self._s3_session = boto3.Session(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,102 +1,114 @@
 -i https://pypi.org/simple
 alabaster==0.7.13; python_version >= '3.6'
+awscli==1.29.58
+awscli-local==0.21
 babel==2.13.0; python_version >= '3.7'
-bandit==1.7.5; python_version >= '3.7'
-black==23.9.1; python_version >= '3.8'
-cachetools==5.3.1; python_version >= '3.7'
+bandit==1.7.5
+black==23.9.1
+boto3==1.28.58
+botocore==1.31.58; python_version >= '3.7'
 certifi==2023.7.22; python_version >= '3.6'
 cfgv==3.4.0; python_version >= '3.8'
-chardet==5.2.0; python_version >= '3.7'
 charset-normalizer==3.3.0; python_full_version >= '3.7.0'
 click==8.1.7; python_version >= '3.7'
-colorama==0.4.6; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-coverage==7.3.2; python_version >= '3.8'
+colorama==0.4.4; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+coverage==7.3.2
 distlib==0.3.7
-docutils==0.18.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+docutils==0.16; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 exceptiongroup==1.1.3; python_version < '3.11'
 filelock==3.12.4; python_version >= '3.8'
-flake8==6.1.0; python_full_version >= '3.8.1'
+flake8==6.1.0
 gitdb==4.0.10; python_version >= '3.7'
 gitpython==3.1.37; python_version >= '3.7'
 identify==2.5.30; python_version >= '3.8'
 idna==3.4; python_version >= '3.5'
 imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 iniconfig==2.0.0; python_version >= '3.7'
-isort==5.12.0; python_full_version >= '3.8.0'
+isort==5.12.0
 jinja2==3.1.2; python_version >= '3.7'
-markdown-it-py==3.0.0; python_version >= '3.8'
+jmespath==1.0.1; python_version >= '3.7'
+localstack-client==2.3
+markdown-it-py==2.2.0; python_version >= '3.7'
 markupsafe==2.1.3; python_version >= '3.7'
 mccabe==0.7.0; python_version >= '3.6'
-mdit-py-plugins==0.4.0; python_version >= '3.8'
+mdit-py-plugins==0.3.5; python_version >= '3.7'
 mdurl==0.1.2; python_version >= '3.7'
-mypy==1.5.1; python_version >= '3.8'
+mypy==1.5.1
 mypy-extensions==1.0.0; python_version >= '3.5'
-myst-parser==2.0.0; python_version >= '3.8'
+myst-parser==1.0.0
 nodeenv==1.8.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 packaging==23.2; python_version >= '3.7'
 pathspec==0.11.2; python_version >= '3.7'
 pbr==5.11.1; python_version >= '2.6'
 platformdirs==3.11.0; python_version >= '3.7'
 pluggy==1.3.0; python_version >= '3.8'
-pre-commit==3.4.0; python_version >= '3.8'
+pre-commit==3.4.0
 pretend==1.0.9
+py==1.11.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+pyasn1==0.5.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 pycodestyle==2.11.0; python_version >= '3.8'
 pyflakes==3.1.0; python_version >= '3.8'
 pygments==2.16.1; python_version >= '3.7'
-pyproject-api==1.6.1; python_version >= '3.8'
-pytest==7.4.2; python_version >= '3.7'
+pytest==7.4.2
+python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pyyaml==6.0.1; python_version >= '3.6'
 requests==2.31.0; python_version >= '3.7'
 rich==13.6.0; python_full_version >= '3.7.0'
+rsa==4.7.2; python_version >= '3.5' and python_version < '4'
+s3transfer==0.7.0; python_version >= '3.7'
 setuptools==68.2.2; python_version >= '3.8'
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 smmap==5.0.1; python_version >= '3.7'
 snowballstemmer==2.2.0
-sphinx==7.2.6; python_version >= '3.9'
-sphinx-rtd-theme==1.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-sphinxcontrib-applehelp==1.0.7; python_version >= '3.9'
-sphinxcontrib-devhelp==1.0.5; python_version >= '3.9'
-sphinxcontrib-htmlhelp==2.0.4; python_version >= '3.9'
+sphinx==5.3.0
+sphinx-rtd-theme==1.3.0
+sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-htmlhelp==2.0.4
 sphinxcontrib-jquery==4.1; python_version >= '2.7'
-sphinxcontrib-jsmath==1.0.1; python_version >= '3.5'
+sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-plantuml==0.26
-sphinxcontrib-qthelp==1.0.6; python_version >= '3.9'
-sphinxcontrib-serializinghtml==1.1.9; python_version >= '3.9'
+sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-serializinghtml==1.1.9
 stevedore==5.1.0; python_version >= '3.8'
 tomli==2.0.1; python_version < '3.11'
-tox==4.11.3; python_version >= '3.8'
+tox==3.28.0
 typing-extensions==4.8.0; python_version >= '3.8'
-urllib3==2.0.6; python_version >= '3.7'
-virtualenv==20.24.5; python_version >= '3.7'
-alembic==1.12.0; python_version >= '3.7'
+urllib3==1.26.17; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+virtualenv==20.24.5
+alembic==1.12.0
 amqp==5.1.1; python_version >= '3.6'
 annotated-types==0.5.0; python_version >= '3.7'
 async-timeout==4.0.3; python_full_version <= '3.11.2'
+awswrangler==3.4.0
 billiard==4.1.0; python_version >= '3.7'
-celery==5.3.4; python_version >= '3.8'
+celery==5.3.4
 cffi==1.16.0; python_version >= '3.8'
 click-didyoumean==0.3.0; python_full_version >= '3.6.2' and python_full_version < '4.0.0'
 click-plugins==1.1.1
 click-repl==0.3.0; python_version >= '3.6'
 configobj==5.0.8
 cryptography==41.0.4
-dynaconf[ini]==3.2.3; python_version >= '3.8'
+dynaconf[ini]==3.2.3
 greenlet==3.0.0; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
 kombu==5.3.2; python_version >= '3.8'
 mako==1.2.4; python_version >= '3.7'
+numpy==1.26.0; python_version < '3.13' and python_version >= '3.9'
+pandas==2.1.1; python_version >= '3.9'
 prompt-toolkit==3.0.39; python_full_version >= '3.7.0'
-psycopg2==2.9.8; python_version >= '3.6'
+psycopg2==2.9.8
+pyarrow==13.0.0; python_version >= '3.8'
 pycparser==2.21
-pydantic==2.4.2; python_version >= '3.7'
+pydantic==2.4.2
 pydantic-core==2.10.1; python_version >= '3.7'
 pynacl==1.5.0
-python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-redis==5.0.1; python_version >= '3.7'
-securesystemslib[crypto,pynacl]==0.29.0; python_version ~= '3.7'
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-sqlalchemy==2.0.21; python_version >= '3.7'
+pytz==2023.3.post1
+redis==5.0.1
+securesystemslib[crypto,pynacl]==0.29.0
+sqlalchemy==2.0.21
 supervisor==4.2.5
-tuf==3.0.0; python_version >= '3.7'
+tuf==3.0.0
 tzdata==2023.3; python_version >= '2'
 vine==5.0.0; python_version >= '3.6'
-watchdog==3.0.0; python_version >= '3.7'
+watchdog==3.0.0
 wcwidth==0.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
 -i https://pypi.org/simple
-alembic==1.12.0; python_version >= '3.7'
+alembic==1.12.0
 amqp==5.1.1; python_version >= '3.6'
 annotated-types==0.5.0; python_version >= '3.7'
 async-timeout==4.0.3; python_full_version <= '3.11.2'
+awswrangler==3.4.0
 billiard==4.1.0; python_version >= '3.7'
-celery==5.3.4; python_version >= '3.8'
+boto3==1.28.58
+botocore==1.31.58; python_version >= '3.7'
+celery==5.3.4
 certifi==2023.7.22; python_version >= '3.6'
 cffi==1.16.0; python_version >= '3.8'
 charset-normalizer==3.3.0; python_full_version >= '3.7.0'
@@ -14,30 +17,37 @@ click-plugins==1.1.1
 click-repl==0.3.0; python_version >= '3.6'
 configobj==5.0.8
 cryptography==41.0.4
-dynaconf[ini]==3.2.3; python_version >= '3.8'
+dynaconf[ini]==3.2.3
 greenlet==3.0.0; platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
 idna==3.4; python_version >= '3.5'
+jmespath==1.0.1; python_version >= '3.7'
 kombu==5.3.2; python_version >= '3.8'
 mako==1.2.4; python_version >= '3.7'
 markupsafe==2.1.3; python_version >= '3.7'
+numpy==1.26.0; python_version < '3.13' and python_version >= '3.9'
+packaging==23.2; python_version >= '3.7'
+pandas==2.1.1; python_version >= '3.9'
 prompt-toolkit==3.0.39; python_full_version >= '3.7.0'
-psycopg2==2.9.8; python_version >= '3.6'
+psycopg2==2.9.8
+pyarrow==13.0.0; python_version >= '3.8'
 pycparser==2.21
-pydantic==2.4.2; python_version >= '3.7'
+pydantic==2.4.2
 pydantic-core==2.10.1; python_version >= '3.7'
 pynacl==1.5.0
 python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-redis==5.0.1; python_version >= '3.7'
+pytz==2023.3.post1
+redis==5.0.1
 requests==2.31.0; python_version >= '3.7'
-securesystemslib[crypto,pynacl]==0.29.0; python_version ~= '3.7'
+s3transfer==0.7.0; python_version >= '3.7'
+securesystemslib[crypto,pynacl]==0.29.0
 setuptools==68.2.2; python_version >= '3.8'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-sqlalchemy==2.0.21; python_version >= '3.7'
+sqlalchemy==2.0.21
 supervisor==4.2.5
-tuf==3.0.0; python_version >= '3.7'
+tuf==3.0.0
 typing-extensions==4.8.0; python_version >= '3.8'
 tzdata==2023.3; python_version >= '2'
-urllib3==2.0.6; python_version >= '3.7'
+urllib3==1.26.17; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 vine==5.0.0; python_version >= '3.6'
-watchdog==3.0.0; python_version >= '3.7'
+watchdog==3.0.0
 wcwidth==0.2.8

--- a/tests/files/aws/init-services.sh
+++ b/tests/files/aws/init-services.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+awslocal s3 mb s3://tuf-metadata

--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -10,9 +10,9 @@ curl http://web:8080
 if [[ $? -eq 0 ]]; then
     export METADATA_BASE_URL=http://web:8080
 else
-    # using localstack for AWS S3
+    # using localstack for AWS
     export METADATA_BASE_URL=http://localstack:4566/tuf-metadata
-    export PERFORMANCE_FAILURE=False
+    export PERFORMANCE=False
 fi
 
 

--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -8,9 +8,9 @@ pip install -r ${UMBRELLA_PATH}/requirements.txt
 
 curl http://web:8080
 if [[ $? -eq 0 ]]; then
-    METADATA_URL=http://web:8080/1.root.json
+    export METADATA_BASE_URL=http://web:8080
 else
-    METADATA_URL=http://localstack:4566/tuf-metadata/1.root.json
+    export METADATA_BASE_URL=http://localstack:4566/tuf-metadata
 fi
 
 
@@ -93,7 +93,7 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-sign.py '{
 
 # Get initial trusted Root
 rm metadata/1.root.json
-wget -P metadata/ ${METADATA_URL}
+wget -P metadata/ ${METADATA_BASE_URL}/1.root.json
 cp -r metadata ${UMBRELLA_PATH}/
 
 make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst

--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -10,7 +10,9 @@ curl http://web:8080
 if [[ $? -eq 0 ]]; then
     export METADATA_BASE_URL=http://web:8080
 else
+    # using localstack for AWS S3
     export METADATA_BASE_URL=http://localstack:4566/tuf-metadata
+    export PERFORMANCE_FAILURE=False
 fi
 
 

--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -1,0 +1,100 @@
+#!/bin/bash -x
+
+CLI_VERSION=$1
+# Install required dependencies for Functional Tests
+apt update
+apt install -y make wget git curl
+pip install -r ${UMBRELLA_PATH}/requirements.txt
+
+curl http://web:8080
+if [[ $? -eq 0 ]]; then
+    METADATA_URL=http://web:8080/1.root.json
+else
+    METADATA_URL=http://localstack:4566/tuf-metadata/1.root.json
+fi
+
+
+# Install CLI
+case ${CLI_VERSION} in
+    v*)
+        pip install repository-service-tuf==${CLI_VERSION}
+        ;;
+
+    latest)
+        pip install repository-service-tuf
+        pip install --upgrade repository-service-tuf
+        ;;
+
+    source) # it install froom the source code (used by CLI)
+        pip install -e .
+        ;;
+
+    *) # dev or none
+        pip install git+https://github.com/repository-service-tuf/repository-service-tuf-cli
+        ;;
+esac
+
+# Execute the Ceremony using DAS
+python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-ceremony.py '{
+    "Do you want more information about roles and responsibilities?": "n",
+    "Do you want to start the ceremony?": "y",
+    "What is the metadata expiration for the root role?(Days)": "365",
+    "What is the number of keys for the root role?": "3",
+    "What is the key threshold for root role signing?": "2",
+    "What is the metadata expiration for the targets role?": "365",
+    "Show example?": "n",
+    "Choose the number of delegated hash bin roles": "4",
+    "What is the targets base URL": "http://rstuf.org/downloads",
+    "What is the metadata expiration for the snapshot role?(Days)": "1",
+    "What is the metadata expiration for the timestamp role?(Days)": "1",
+    "What is the metadata expiration for the bins role?(Days)": "1",
+    "(online) Select the ONLINE`s key type [ed25519/ecdsa/rsa] (ed25519)": "",
+    "(online) Enter ONLINE`s key id": "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8",
+    "(online) Enter ONLINE`s public key hash": "9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8",
+    "Give a name/tag to the key [Optional]": "online v1",
+    "Ready to start loading the root keys?": "y",
+    "(root 1) Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)": "ed25519",
+    "(root 1) Enter the root`s private key path": "tests/files/key_storage/JanisJoplin.key",
+    "(root 1) Enter the root`s private key password": "strongPass",
+    "(root 1) [Optional] Give a name/tag to the key": "JJ",
+    "(root 2) Select to use private key or public info? [private/public] (public)": "public",
+    "(root 2) Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)": "",
+    "(root 2) Enter root`s key id": "800dfb5a1982b82b7893e58035e19f414f553fc08cbb1130cfbae302a7b7fee5",
+    "(root 2) Enter ONLINE`s public key hash": "7098f769f6ab8502b50f3b58686b8a042d5d3bb75d8b3a48a2fcbc15a0223501",
+    "(root 2) [Optional] Give a name/tag to the key": "JH",
+    "(root 3) Select to use private key or public info? [private/public] (public)": "public",
+    "(root 3) Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)": "",
+    "(root 3) Enter root`s key id": "7641c1c12b98c18cfbadd87209fe190072e712cc0e14e13fe83febc2150f7520",
+    "(root 3) Enter ONLINE`s public key hash": "414af03cbaae93b5f44363f0bf757421e64bd892b891b0dff3ad6af5eb3a3038",
+    "(root 3) [Optional] Give a name/tag to the key": "JC",
+    "Is the online key configuration correct? [y/n]": "y",
+    "Is the root configuration correct? [y/n]": "y",
+    "Is the targets configuration correct? [y/n]": "y",
+    "Is the snapshot configuration correct? [y/n]": "y",
+    "Is the timestamp configuration correct? [y/n]": "y",
+    "Is the bins configuration correct? [y/n]": "y"
+}'
+
+
+# Bootstrap using DAS
+rstuf admin ceremony -b -u -f payload.json --upload-server http://repository-service-tuf-api
+
+
+# Finish the DAS signing the Root Metadata (bootstrap)
+python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-sign.py '{
+    "API URL address:": "http://repository-service-tuf-api",
+    "Choose a metadata to sign [root]": "root",
+    "Do you still want to sign root? [y/n]": "y",
+    "Choose a private key to load [JH]": "JH",
+    "Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)": "",
+    "Enter the root`s private key path": "tests/files/key_storage/JimiHendrix.key",
+    "Enter the root`s private key password": "strongPass"
+}'
+
+# Get initial trusted Root
+rm metadata/1.root.json
+wget -P metadata/ ${METADATA_URL}
+cp -r metadata ${UMBRELLA_PATH}/
+
+make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst
+

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -8,11 +8,10 @@ pip install -r ${UMBRELLA_PATH}/requirements.txt
 
 curl http://web:8080
 if [[ $? -eq 0 ]]; then
-    METADATA_URL=http://web:8080/1.root.json
+    export METADATA_BASE_URL=http://web:8080
 else
-    METADATA_URL=http://localstack:4566/tuf-metadata/1.root.json
+    export METADATA_BASE_URL=http://localstack:4566/tuf-metadata
 fi
-
 
 # Install CLI
 case ${CLI_VERSION} in
@@ -76,7 +75,7 @@ rstuf admin ceremony -b -u -f payload.json --upload-server http://repository-ser
 
 # Get initial trusted Root
 rm metadata/1.root.json
-wget -P metadata/ ${METADATA_URL}
+wget -P metadata/ ${METADATA_BASE_URL}/1.root.json
 cp -r metadata ${UMBRELLA_PATH}/
 
 make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -10,8 +10,11 @@ curl http://web:8080
 if [[ $? -eq 0 ]]; then
     export METADATA_BASE_URL=http://web:8080
 else
+    # using localstack for AWS
     export METADATA_BASE_URL=http://localstack:4566/tuf-metadata
+    export PERFORMANCE=False
 fi
+
 
 # Install CLI
 case ${CLI_VERSION} in

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -1,0 +1,83 @@
+#!/bin/bash -x
+
+CLI_VERSION=$1
+# Install required dependencies for Functional Tests
+apt update
+apt install -y make wget git curl
+pip install -r ${UMBRELLA_PATH}/requirements.txt
+
+curl http://web:8080
+if [[ $? -eq 0 ]]; then
+    METADATA_URL=http://web:8080/1.root.json
+else
+    METADATA_URL=http://localstack:4566/tuf-metadata/1.root.json
+fi
+
+
+# Install CLI
+case ${CLI_VERSION} in
+    v*)
+        pip install repository-service-tuf==${CLI_VERSION}
+        ;;
+
+    latest)
+        pip install repository-service-tuf
+        pip install --upgrade repository-service-tuf
+        ;;
+
+    source) # it install froom the source code (used by CLI)
+        pip install -e .
+        ;;
+
+    *) # dev or none
+        pip install git+https://github.com/repository-service-tuf/repository-service-tuf-cli
+        ;;
+esac
+
+# Execute the Ceremony full signed
+python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-ceremony.py '{
+    "Do you want more information about roles and responsibilities?": "n",
+    "Do you want to start the ceremony?": "y",
+    "What is the metadata expiration for the root role?(Days)": "365",
+    "What is the number of keys for the root role?": "2",
+    "What is the key threshold for root role signing?": "1",
+    "What is the metadata expiration for the targets role?": "365",
+    "Show example?": "n",
+    "Choose the number of delegated hash bin roles": "4",
+    "What is the targets base URL": "http://rstuf.org/downloads",
+    "What is the metadata expiration for the snapshot role?(Days)": "1",
+    "What is the metadata expiration for the timestamp role?(Days)": "1",
+    "What is the metadata expiration for the bins role?(Days)": "1",
+    "(online) Select the ONLINE`s key type [ed25519/ecdsa/rsa] (ed25519)": "",
+    "(online) Enter ONLINE`s key id": "f7a6872f297634219a80141caa2ec9ae8802098b07b67963272603e36cc19fd8",
+    "(online) Enter ONLINE`s public key hash": "9fe7ddccb75b977a041424a1fdc142e01be4abab918dc4c611fbfe4a3360a9a8",
+    "Give a name/tag to the key [Optional]": "online v1",
+    "Ready to start loading the root keys?": "y",
+    "(root 1) Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)": "ed25519",
+    "(root 1) Enter the root`s private key path": "tests/files/key_storage/JanisJoplin.key",
+    "(root 1) Enter the root`s private key password": "strongPass",
+    "(root 1) [Optional] Give a name/tag to the key": "JJ",
+    "(root 2) Select to use private key or public info? [private/public] (public)": "private",
+    "(root 2) Select the root`s key type [ed25519/ecdsa/rsa] (ed25519)": "",
+    "(root 2) Enter the root`s private key path": "tests/files/key_storage/JimiHendrix.key",
+    "(root 2) Enter the root`s private key password": "strongPass",
+    "(root 2) [Optional] Give a name/tag to the key": "JH",
+    "Is the online key configuration correct? [y/n]": "y",
+    "Is the root configuration correct? [y/n]": "y",
+    "Is the targets configuration correct? [y/n]": "y",
+    "Is the snapshot configuration correct? [y/n]": "y",
+    "Is the timestamp configuration correct? [y/n]": "y",
+    "Is the bins configuration correct? [y/n]": "y"
+}'
+
+
+# Bootstrap using DAS
+rstuf admin ceremony -b -u -f payload.json --upload-server http://repository-service-tuf-api
+
+# Get initial trusted Root
+rm metadata/1.root.json
+wget -P metadata/ ${METADATA_URL}
+cp -r metadata ${UMBRELLA_PATH}/
+
+make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst
+

--- a/tests/unit/tuf_repository_service_worker/services/storage/conftest.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/conftest.py
@@ -17,7 +17,6 @@ def mocked_boto3(monkeypatch):
     )
     mock_boto3 = pretend.stub(
         Session=pretend.call_recorder(lambda *a, **kw: fake_Session),
-        client=pretend.call_recorder(lambda *a, **kw: fake_client),
         resource=pretend.call_recorder(lambda *a, **kw: fake_resource),
     )
 

--- a/tests/unit/tuf_repository_service_worker/services/storage/conftest.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/conftest.py
@@ -1,0 +1,27 @@
+import pretend
+import pytest
+
+
+@pytest.fixture
+def mocked_boto3(monkeypatch):
+    fake_bucket = pretend.stub(name="bucket")
+    fake_resource = pretend.stub(
+        buckets=pretend.stub(all=pretend.call_recorder(lambda: [fake_bucket]))
+    )
+    fake_client = pretend.stub(
+        put_object=pretend.call_recorder(lambda **kw: None)
+    )
+    fake_Session = pretend.stub(
+        client=pretend.call_recorder(lambda *a, **kw: fake_client),
+        resource=pretend.call_recorder(lambda *a, **kw: fake_resource),
+    )
+    mock_boto3 = pretend.stub(
+        Session=pretend.call_recorder(lambda *a, **kw: fake_Session),
+        client=pretend.call_recorder(lambda *a, **kw: fake_client),
+        resource=pretend.call_recorder(lambda *a, **kw: fake_resource),
+    )
+
+    monkeypatch.setattr(
+        "repository_service_tuf_worker.services.storage.awss3.boto3",
+        mock_boto3,
+    )

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
+#
+# SPDX-License-Identifier: MIT
+
+import pretend
+import pytest
+from tuf.api.metadata import Metadata, Root, Timestamp
+
+from repository_service_tuf_worker.services.storage import awss3
+
+
+class TestAWSS3Service:
+    def test_basic_init(self, mocked_boto3):
+        service = awss3.AWSS3(
+            "bucket",
+            "access_key",
+            "secret_key",
+            "region",
+        )
+
+        assert service._bucket == "bucket"
+        assert service._access_key == "access_key"
+        assert service._secret_key == "secret_key"
+        assert service._region == "region"
+        assert service._endpoint_url is None
+        assert awss3.boto3.Session.calls == [
+            pretend.call(
+                aws_access_key_id="access_key",
+                aws_secret_access_key="secret_key",
+                region_name="region",
+            )
+        ]
+        assert service._s3_session.client.calls == [
+            pretend.call(
+                "s3",
+                aws_access_key_id=service._access_key,
+                aws_secret_access_key=service._secret_key,
+                region_name=service._region,
+                endpoint_url=service._endpoint_url,
+            )
+        ]
+        assert service._s3_session.resource.calls == [
+            pretend.call(
+                "s3",
+                aws_access_key_id=service._access_key,
+                aws_secret_access_key=service._secret_key,
+                region_name=service._region,
+                endpoint_url=service._endpoint_url,
+            )
+        ]
+
+    def test_configure(self, mocked_boto3):
+        test_settings = pretend.stub(
+            get=pretend.call_recorder(lambda *a: None),
+            AWSS3_STORAGE_BUCKET="bucket",
+            AWSS3_STORAGE_ACCESS_KEY="access_key",
+            AWSS3_STORAGE_SECRET_KEY="secret_key",
+            AWSS3_STORAGE_REGION="region",
+            AWSS3_STORAGE_ENDPOINT_URL=None,
+        )
+
+        service = awss3.AWSS3(
+            "bucket",
+            "access_key",
+            "secret_key",
+            "region",
+        )
+        service.configure(test_settings)
+        assert service._bucket == "bucket"
+        assert service._access_key == "access_key"
+        assert service._secret_key == "secret_key"
+        assert service._region == "region"
+        assert service._endpoint_url is None
+        assert awss3.boto3.resource.calls == [
+            pretend.call(
+                "s3",
+                aws_access_key_id="access_key",
+                aws_secret_access_key="secret_key",
+                region_name="region",
+                endpoint_url=None,
+            )
+        ]
+        assert awss3.boto3.resource().buckets.all.calls == [pretend.call()]
+
+    def test_configure_bucket_not_found(self, mocked_boto3):
+        test_settings = pretend.stub(
+            get=pretend.call_recorder(lambda *a: None),
+            AWSS3_STORAGE_BUCKET="bucket",
+            AWSS3_STORAGE_ACCESS_KEY="access_key",
+            AWSS3_STORAGE_SECRET_KEY="secret_key",
+            AWSS3_STORAGE_REGION="region",
+            AWSS3_STORAGE_ENDPOINT_URL=None,
+        )
+
+        fake_resource = pretend.stub(
+            buckets=pretend.stub(all=pretend.call_recorder(lambda: []))
+        )
+        awss3.boto3.resource = pretend.call_recorder(
+            lambda *a, **kw: fake_resource
+        )
+
+        service = awss3.AWSS3(
+            "bucket",
+            "access_key",
+            "secret_key",
+            "region",
+        )
+        with pytest.raises(ValueError) as err:
+            service.configure(test_settings)
+
+        assert "Bucket 'bucket' not found." in str(err)
+        assert service._bucket == "bucket"
+        assert service._access_key == "access_key"
+        assert service._secret_key == "secret_key"
+        assert service._region == "region"
+        assert service._endpoint_url is None
+        assert awss3.boto3.resource().buckets.all.calls
+
+    def test_settings(self, mocked_boto3):
+        service = awss3.AWSS3(
+            "bucket",
+            "access_key",
+            "secret_key",
+            "region",
+        )
+        service_settings = service.settings()
+
+        assert service_settings == [
+            awss3.ServiceSettings(
+                name="AWSS3_STORAGE_BUCKET",
+                argument="bucket",
+                required=True,
+            ),
+            awss3.ServiceSettings(
+                name="AWSS3_STORAGE_ACCESS_KEY",
+                argument="access_key",
+                required=True,
+            ),
+            awss3.ServiceSettings(
+                name="AWSS3_STORAGE_SECRET_KEY",
+                argument="secret_key",
+                required=True,
+            ),
+            awss3.ServiceSettings(
+                name="AWSS3_STORAGE_REGION",
+                argument="region",
+                required=True,
+            ),
+            awss3.ServiceSettings(
+                name="AWSS3_STORAGE_ENDPOINT_URL",
+                argument="endpoint_url",
+                required=False,
+            ),
+        ]
+
+    def test_get(self, mocked_boto3):
+        service = awss3.AWSS3(
+            "bucket",
+            "access_key",
+            "secret_key",
+            "region",
+        )
+        awss3.awswrangler.s3.list_objects = pretend.call_recorder(
+            lambda *a, **kw: [
+                f"s3://{service._bucket}/1.root.json",
+                f"s3://{service._bucket}/2.root.json",
+            ]
+        )
+        fake_file_obj = pretend.stub(
+            read=pretend.call_recorder(lambda: None),
+            close=pretend.call_recorder(lambda: None),
+        )
+        fake_aws3_object = pretend.stub(
+            get=pretend.call_recorder(lambda *a: fake_file_obj)
+        )
+        service._s3 = pretend.stub(
+            get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
+        )
+
+        expected_root = Metadata(Root())
+        awss3.Metadata = pretend.stub(
+            from_bytes=pretend.call_recorder(lambda *a: expected_root)
+        )
+        result = service.get("root")
+
+        assert result == expected_root
+        assert fake_file_obj.read.calls == [pretend.call()]
+        assert fake_file_obj.close.calls == [pretend.call()]
+        assert awss3.Metadata.from_bytes.calls == [pretend.call(None)]
+        assert awss3.awswrangler.s3.list_objects.calls == [
+            pretend.call(
+                path=f"s3://{service._bucket}/*.root.json",
+                boto3_session=service._s3_session,
+            )
+        ]
+        assert service._s3.get_object.calls == [
+            pretend.call(Bucket=service._bucket, Key="2.root.json")
+        ]
+
+    def test_get_timestamp(self, mocked_boto3):
+        service = awss3.AWSS3(
+            "bucket",
+            "access_key",
+            "secret_key",
+            "region",
+            "http://localstack:4566",
+        )
+
+        awss3.awswrangler.s3.list_objects = pretend.call_recorder(
+            lambda *a, **kw: [
+                f"s3://{service._bucket}/1.root.json",
+                f"s3://{service._bucket}/2.root.json",
+            ]
+        )
+        fake_file_obj = pretend.stub(
+            read=pretend.call_recorder(lambda: None),
+            close=pretend.call_recorder(lambda: None),
+        )
+        fake_aws3_object = pretend.stub(
+            get=pretend.call_recorder(lambda *a: fake_file_obj)
+        )
+        service._s3 = pretend.stub(
+            get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
+        )
+        expected_timestamp = Metadata(Timestamp())
+        awss3.Metadata = pretend.stub(
+            from_bytes=pretend.call_recorder(lambda *a: expected_timestamp)
+        )
+        result = service.get("timestamp")
+
+        assert result == expected_timestamp
+        assert fake_file_obj.read.calls == [pretend.call()]
+        assert fake_file_obj.close.calls == [pretend.call()]
+        assert awss3.Metadata.from_bytes.calls == [pretend.call(None)]
+        assert awss3.awswrangler.s3.list_objects.calls == []
+        assert service._s3.get_object.calls == [
+            pretend.call(Bucket=service._bucket, Key="timestamp.json")
+        ]
+
+    def test_get_max_version_ValueError(self, mocked_boto3, monkeypatch):
+        service = awss3.AWSS3(
+            "bucket",
+            "access_key",
+            "secret_key",
+            "region",
+            "http://localstack:4566",
+        )
+
+        awss3.awswrangler.s3.list_objects = pretend.call_recorder(
+            lambda *a, **kw: [
+                f"s3://{service._bucket}/1.root.json",
+            ]
+        )
+        fake_file_obj = pretend.stub(
+            read=pretend.call_recorder(lambda: None),
+            close=pretend.call_recorder(lambda: None),
+        )
+        fake_aws3_object = pretend.stub(
+            get=pretend.call_recorder(lambda *a: fake_file_obj)
+        )
+        service._s3 = pretend.stub(
+            get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
+        )
+        monkeypatch.setitem(
+            awss3.__builtins__, "max", pretend.raiser(ValueError)
+        )
+        expected_root = Metadata(Root())
+        awss3.Metadata = pretend.stub(
+            from_bytes=pretend.call_recorder(lambda *a: expected_root)
+        )
+        result = service.get("root")
+
+        assert result == expected_root
+        assert fake_file_obj.read.calls == [pretend.call()]
+        assert fake_file_obj.close.calls == [pretend.call()]
+        assert awss3.Metadata.from_bytes.calls == [pretend.call(None)]
+        assert awss3.awswrangler.s3.list_objects.calls == [
+            pretend.call(
+                path=f"s3://{service._bucket}/*.root.json",
+                boto3_session=service._s3_session,
+            )
+        ]
+        assert service._s3.get_object.calls == [
+            pretend.call(Bucket=service._bucket, Key="1.root.json")
+        ]
+
+    def test_get_DeserializationError(self, mocked_boto3):
+        service = awss3.AWSS3(
+            "bucket",
+            "access_key",
+            "secret_key",
+            "region",
+            "http://localstack:4566",
+        )
+
+        awss3.awswrangler.s3.list_objects = pretend.call_recorder(
+            lambda *a, **kw: [
+                f"s3://{service._bucket}/1.root.json",
+            ]
+        )
+        fake_file_obj = pretend.stub(
+            read=pretend.call_recorder(lambda: None),
+            close=pretend.call_recorder(lambda: None),
+        )
+        fake_aws3_object = pretend.stub(
+            get=pretend.call_recorder(lambda *a: fake_file_obj)
+        )
+        service._s3 = pretend.stub(
+            get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
+        )
+        awss3.Metadata = pretend.stub(
+            from_bytes=pretend.raiser(awss3.DeserializationError("failed"))
+        )
+
+        with pytest.raises(awss3.StorageError) as err:
+            service.get("root")
+
+        assert "Can't open Role 'root'" in str(err)
+
+        assert fake_file_obj.read.calls == [pretend.call()]
+        assert fake_file_obj.close.calls == [pretend.call()]
+        assert awss3.awswrangler.s3.list_objects.calls == [
+            pretend.call(
+                path=f"s3://{service._bucket}/*.root.json",
+                boto3_session=service._s3_session,
+            )
+        ]
+        assert service._s3.get_object.calls == [
+            pretend.call(Bucket=service._bucket, Key="1.root.json")
+        ]
+
+    def test_put(self, mocked_boto3):
+        service = awss3.AWSS3(
+            "bucket",
+            "access_key",
+            "secret_key",
+            "region",
+        )
+
+        fake_file_data = b"fake_byte_data"
+        result = service.put(fake_file_data, "3.bin-e.json")
+
+        assert result is None
+        assert service._s3.put_object.calls == [
+            pretend.call(
+                Body=fake_file_data, Bucket=service._bucket, Key="3.bin-e.json"
+            )
+        ]
+
+    def test_put_ClientErro(self, mocked_boto3):
+        service = awss3.AWSS3(
+            "bucket",
+            "access_key",
+            "secret_key",
+            "region",
+        )
+
+        service._s3.put_object = pretend.raiser(
+            awss3.ClientError({}, "put_object")
+        )
+
+        fake_file_data = b"fake_byte_data"
+
+        with pytest.raises(awss3.StorageError) as err:
+            service.put(fake_file_data, "3.bin-e.json")
+
+        assert "Can't write role file '3.bin-e.json'" in str(err)

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
@@ -15,19 +15,18 @@ class TestAWSS3Service:
             "bucket",
             "access_key",
             "secret_key",
-            "region",
         )
 
         assert service._bucket == "bucket"
         assert service._access_key == "access_key"
         assert service._secret_key == "secret_key"
-        assert service._region == "region"
+        assert service._region is None
         assert service._endpoint_url is None
         assert awss3.boto3.Session.calls == [
             pretend.call(
                 aws_access_key_id="access_key",
                 aws_secret_access_key="secret_key",
-                region_name="region",
+                region_name=None,
             )
         ]
         assert service._s3_session.client.calls == [

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
@@ -127,27 +127,27 @@ class TestAWSS3Service:
 
         assert service_settings == [
             awss3.ServiceSettings(
-                name="AWSS3_STORAGE_BUCKET",
+                names=["AWSS3_STORAGE_BUCKET"],
                 argument="bucket",
                 required=True,
             ),
             awss3.ServiceSettings(
-                name="AWSS3_STORAGE_ACCESS_KEY",
+                names=["AWSS3_STORAGE_ACCESS_KEY"],
                 argument="access_key",
                 required=True,
             ),
             awss3.ServiceSettings(
-                name="AWSS3_STORAGE_SECRET_KEY",
+                names=["AWSS3_STORAGE_SECRET_KEY"],
                 argument="secret_key",
                 required=True,
             ),
             awss3.ServiceSettings(
-                name="AWSS3_STORAGE_REGION",
+                names=["AWSS3_STORAGE_REGION"],
                 argument="region",
-                required=True,
+                required=False,
             ),
             awss3.ServiceSettings(
-                name="AWSS3_STORAGE_ENDPOINT_URL",
+                names=["AWSS3_STORAGE_ENDPOINT_URL"],
                 argument="endpoint_url",
                 required=False,
             ),

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
@@ -55,28 +55,25 @@ class TestAWSS3Service:
             AWSS3_STORAGE_BUCKET="bucket",
             AWSS3_STORAGE_ACCESS_KEY="access_key",
             AWSS3_STORAGE_SECRET_KEY="secret_key",
-            AWSS3_STORAGE_REGION="region",
-            AWSS3_STORAGE_ENDPOINT_URL=None,
         )
 
         service = awss3.AWSS3(
             "bucket",
             "access_key",
             "secret_key",
-            "region",
         )
         service.configure(test_settings)
         assert service._bucket == "bucket"
         assert service._access_key == "access_key"
         assert service._secret_key == "secret_key"
-        assert service._region == "region"
+        assert service._region is None
         assert service._endpoint_url is None
         assert awss3.boto3.resource.calls == [
             pretend.call(
                 "s3",
                 aws_access_key_id="access_key",
                 aws_secret_access_key="secret_key",
-                region_name="region",
+                region_name=None,
                 endpoint_url=None,
             )
         ]
@@ -114,7 +111,7 @@ class TestAWSS3Service:
         assert service._secret_key == "secret_key"
         assert service._region == "region"
         assert service._endpoint_url is None
-        assert awss3.boto3.resource().buckets.all.calls
+        assert awss3.boto3.resource().buckets.all.calls == [pretend.call()]
 
     def test_settings(self, mocked_boto3):
         service = awss3.AWSS3(
@@ -186,6 +183,7 @@ class TestAWSS3Service:
         assert result == expected_root
         assert fake_file_obj.read.calls == [pretend.call()]
         assert fake_file_obj.close.calls == [pretend.call()]
+        assert fake_aws3_object.get.calls == [pretend.call("Body")]
         assert awss3.Metadata.from_bytes.calls == [pretend.call(None)]
         assert awss3.awswrangler.s3.list_objects.calls == [
             pretend.call(
@@ -231,6 +229,7 @@ class TestAWSS3Service:
         assert result == expected_timestamp
         assert fake_file_obj.read.calls == [pretend.call()]
         assert fake_file_obj.close.calls == [pretend.call()]
+        assert fake_aws3_object.get.calls == [pretend.call("Body")]
         assert awss3.Metadata.from_bytes.calls == [pretend.call(None)]
         assert awss3.awswrangler.s3.list_objects.calls == []
         assert service._s3.get_object.calls == [

--- a/tests/unit/tuf_repository_service_worker/test__init__.py
+++ b/tests/unit/tuf_repository_service_worker/test__init__.py
@@ -1,19 +1,48 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
+import pretend
 
-from repository_service_tuf_worker import (
-    Dynaconf,
-    get_repository_settings,
-    get_worker_settings,
-)
+import repository_service_tuf_worker
 
 
 class TestSettingsSetup:
     def test_get_worker_settings(self):
-        worker_settings = get_worker_settings()
-        assert isinstance(worker_settings, Dynaconf)
+        worker_settings = repository_service_tuf_worker.get_worker_settings()
+        assert isinstance(
+            worker_settings, repository_service_tuf_worker.Dynaconf
+        )
 
     def test_get_repository_settings(self):
-        repository_settings = get_repository_settings()
-        assert isinstance(repository_settings, Dynaconf)
+        repository_settings = (
+            repository_service_tuf_worker.get_repository_settings()
+        )
+        assert isinstance(
+            repository_settings, repository_service_tuf_worker.Dynaconf
+        )
+
+
+class TestParseIfSecret:
+    def test_parse_if_secret(self):
+        result = repository_service_tuf_worker.parse_if_secret("variable")
+        assert result == "variable"
+
+    def test_parse_if_secret_as_secret(self, monkeypatch):
+        fake_file_obj = pretend.stub(
+            __enter__=pretend.call_recorder(
+                lambda *a: pretend.stub(read=lambda: "mysecret")
+            ),
+            read=pretend.call_recorder(lambda *a: "mysecret"),
+            close=pretend.call_recorder(lambda *a: None),
+            __exit__=pretend.call_recorder(lambda *a: None),
+        )
+        monkeypatch.setitem(
+            repository_service_tuf_worker.__builtins__,
+            "open",
+            lambda *a: fake_file_obj,
+        )
+
+        result = repository_service_tuf_worker.parse_if_secret(
+            "/run/secrets/VARIABLE"
+        )
+        assert result == "mysecret"


### PR DESCRIPTION
### Prepare RSTUF development environment

  - Add boto3 to use AWS services
  - Add awswrangler to parse objects in the bucket
  - Add localstack to enable a development in the docker-compose.yml
  - Add localstack-init in Makefile to enable developers to initiate the
    services configuration
  
### Implements the AWS S3 Storage Backend Service

It uses the official `boto3` library for AWS Sessions, Client and
Resources and also the `awswrangler` to query the AWS S3 metadata.

It implements all the unit tests covering 100% coverage.

Updates the RSTUF Worker documentation adding a better format for
Storage Backend and KeyVault Backend.
  