### PR TITLE
Fix incorrect test data in test_sign_metadata*

### DIFF
--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -3018,9 +3018,7 @@ class TestMetadataRepository:
             "get_repository_settings",
             lambda *a, **kw: fake_settings,
         )
-        fake_root_md = repository.Root(version=1)
-        fake_root_md.signatures = {}
-        fake_root_md.signed = repository.Root()
+        fake_root_md = repository.Metadata(repository.Root())
         repository.Metadata.from_dict = pretend.call_recorder(
             lambda *a: fake_root_md
         )
@@ -3203,9 +3201,7 @@ class TestMetadataRepository:
             "get_repository_settings",
             lambda *a, **kw: fake_settings,
         )
-        fake_root_md = repository.Root(version=1)
-        fake_root_md.signatures = {}
-        fake_root_md.signed = repository.Root()
+        fake_root_md = repository.Metadata(repository.Root())
         repository.Metadata.from_dict = pretend.call_recorder(
             lambda *a: fake_root_md
         )
@@ -3260,9 +3256,7 @@ class TestMetadataRepository:
             "get_repository_settings",
             lambda *a, **kw: fake_settings,
         )
-        fake_root_md = repository.Root()
-        fake_root_md.signatures = {}
-        fake_root_md.signed = repository.Root()
+        fake_root_md = repository.Metadata(repository.Root())
         fake_root_md.to_dict = pretend.call_recorder(lambda: "fake_metadata")
         repository.Metadata.from_dict = pretend.call_recorder(
             lambda *a: fake_root_md


### PR DESCRIPTION
Fixes a few instances of test Root objects being incorrectly wrapped in Root objects, when they should be wrapped in Metadata objects.

Additionally, uses default values for Root.version and Metadata.signatures, instead of passing the same values explicitly.

Note that neither the mistakes nor their fix affect the test results, because the test doesn't care about the signature wrapper (*if it doesn't quack, it can still be a duck*).

Fixing this still seems reasonable.