### PR TITLE
Update docker-compose commands by docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,18 +6,18 @@ build-dev:
 run-dev:
 	$(MAKE) build-dev
 	docker pull ghcr.io/repository-service-tuf/repository-service-tuf-api:dev
-	docker-compose up --remove-orphans
+	docker compose up --remove-orphans
 
 db-migration:
 	if [ -z "$(M)" ]; then echo "Use: make db-migration M=\'message here\'"; exit 1; fi
-	docker-compose run --rm --entrypoint='alembic revision --autogenerate -m "$(M)"' repository-service-tuf-worker
+	docker compose run --rm --entrypoint='alembic revision --autogenerate -m "$(M)"' repository-service-tuf-worker
 
 stop:
-	docker-compose down -v
+	docker compose down -v
 
 clean:
 	$(MAKE) stop
-	docker-compose rm --force
+	docker compose rm --force
 	rm -rf ./data
 	rm -rf ./data_test
 


### PR DESCRIPTION
**Update docker-compose commands to use "docker compose"**

This PR updates the usage of Docker Compose commands in Makefile to use the new "docker compose" syntax introduced in Docker Compose. 

The new syntax offers improved consistency and ease of use.

Changes made:
- Replaced occurrences of "docker-compose" with "docker compose".

Closes #342 

# Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


# Additional requirements
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


# Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst).
