### PR TITLE
feat: Add a new delete_sign_metadata task

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1549,7 +1549,9 @@ class MetadataRepository:
             )
 
         self.write_repository_settings(f"{role.upper()}_SIGNING", None)
-        m = f"Deletion of {role} metadata succesfull, signing process stopped"
+        msg = (
+            f"Deletion of {role} metadata successful, signing process stopped"
+        )
         if role == Root.type:
             bootstrap: Optional[str] = self._settings.get_fresh("BOOTSTRAP")
             # bootstrap is in a signing process pending signatures
@@ -1559,7 +1561,7 @@ class MetadataRepository:
                     TaskName.DELETE_SIGN_METADATA,
                     True,
                     {
-                        "message": m,
+                        "message": msg,
                         "bootstrap": "Bootstrap process has been stopped",
                     },
                 )
@@ -1567,5 +1569,5 @@ class MetadataRepository:
         return self._task_result(
             TaskName.DELETE_SIGN_METADATA,
             True,
-            {"message": m},
+            {"message": msg},
         )

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -3340,13 +3340,13 @@ class TestMetadataRepository:
         )
 
         result = test_repo.delete_sign_metadata({"role": "root"})
-        m = "Deletion of root metadata succesfull, signing process stopped"
+        msg = "Deletion of root metadata successful, signing process stopped"
         assert result == {
             "task": "delete_sign_metadata",
             "status": True,
             "last_update": mocked_datetime.now(),
             "details": {
-                "message": m,
+                "message": msg,
                 "bootstrap": "Bootstrap process has been stopped",
             },
         }
@@ -3385,12 +3385,12 @@ class TestMetadataRepository:
         )
 
         result = test_repo.delete_sign_metadata({"role": "root"})
-        m = "Deletion of root metadata succesfull, signing process stopped"
+        msg = "Deletion of root metadata successful, signing process stopped"
         assert result == {
             "task": "delete_sign_metadata",
             "status": True,
             "last_update": mocked_datetime.now(),
-            "details": {"message": m},
+            "details": {"message": msg},
         }
         assert fake_settings.get_fresh.calls == [
             pretend.call("ROOT_SIGNING"),
@@ -3423,7 +3423,7 @@ class TestMetadataRepository:
         )
 
         result = test_repo.delete_sign_metadata({"role": "targets"})
-        m = "Deletion of targets metadata succesfull, signing process stopped"
+        m = "Deletion of targets metadata successful, signing process stopped"
         assert result == {
             "task": "delete_sign_metadata",
             "status": True,


### PR DESCRIPTION
This will add support to the new `DELETE /api/v1/metadata/sign endpoint`.

Check https://github.com/repository-service-tuf/repository-service-tuf-api/pull/432.

Fixes: #368 

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>