### PR TITLE
RSTUF Interface refactoring (IServices)

### DIFF
--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -1,12 +1,13 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
-
-
+import importlib
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
+from dynaconf import Dynaconf
 from securesystemslib.signer import Key, Signer
 from tuf.api.metadata import Metadata, T
 
@@ -15,7 +16,7 @@ from tuf.api.metadata import Metadata, T
 class ServiceSettings:
     """Dataclass for service settings."""
 
-    name: str
+    name: List[str]
     argument: str
     required: bool
     default: Optional[Any] = None
@@ -29,6 +30,13 @@ class IKeyVault(ABC):
         Run actions to check and configure the service using the settings.
         """
         pass  # pragma: no cover
+
+    @classmethod
+    def from_dynaconf(cls, settings: Dynaconf) -> None:
+        """
+        Run actions to test, configure using the settings.
+        """
+        _setup_service_dynaconf(cls, settings.KEYVAULT_BACKEND, settings)
 
     @classmethod
     @abstractmethod
@@ -47,11 +55,18 @@ class IKeyVault(ABC):
 class IStorage(ABC):
     @classmethod
     @abstractmethod
-    def configure(cls, settings: Any) -> None:
+    def configure(cls, settings: Dynaconf) -> None:
         """
         Run actions to test, configure using the settings.
         """
         raise NotImplementedError  # pragma: no cover
+
+    @classmethod
+    def from_dynaconf(cls, settings: Dynaconf) -> None:
+        """
+        Run actions to test, configure using the settings.
+        """
+        _setup_service_dynaconf(cls, settings.STORAGE_BACKEND, settings)
 
     @classmethod
     @abstractmethod
@@ -59,6 +74,7 @@ class IStorage(ABC):
         """
         Define all the ServiceSettings required in settings.
         """
+
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
@@ -79,3 +95,79 @@ class IStorage(ABC):
         Stores file bytes within a file with a specific filename.
         """
         raise NotImplementedError  # pragma: no cover
+
+
+def _setup_service_dynaconf(cls: Any, backend: Any, settings: Dynaconf):
+    """
+    Setup a Interface Service (IService) from settings Dynaconf (environment
+    variables)
+    """
+    # the 'service import is used to retrieve sublcasses (Implemented Services)
+    from repository_service_tuf_worker import services  # noqa
+
+    service_backends = [i.__name__.upper() for i in cls.__subclasses__()]
+    backend_name = f"RSTUF_{cls.__name__.replace('I', '').upper()}_BACKEND"
+
+    if type(backend) is not str and issubclass(
+        backend, tuple(cls.__subclasses__())
+    ):
+        logging.debug(f"{backend_name} is defined as {backend}")
+
+    elif backend.upper() not in service_backends:
+        raise ValueError(
+            f"Invalid {backend_name} {backend}. "
+            f"Supported {backend_name} {', '.join(service_backends)}"
+        )
+    else:
+        backend = getattr(
+            importlib.import_module("repository_service_tuf_worker.services"),
+            backend,
+        )
+        # look all required settings
+        if missing_settings := [
+            s.name
+            for s in backend.settings()
+            if s.required and all(n not in settings for n in s.name)
+        ]:
+            # map and fix name of the attributes including RSTUF_
+            missing_stg: List = []
+            for missing in missing_settings:
+                missing_stg.append("RSTUF_" + " or RSTUF_".join(missing))
+
+            raise AttributeError(
+                "'Settings' object has not attribute(s) "
+                f"{', '.join(missing_stg)}"
+            )
+
+        # parse and define the keyargs from dynaconf
+        kwargs: Dict[str, Any] = {}
+        for s_var in backend.settings():
+            if all(
+                [
+                    settings.store.get(var_name) is None
+                    for var_name in s_var.name
+                ]
+            ):
+                for var_name in s_var.name:
+                    settings.store[var_name] = s_var.default
+                kwargs[s_var.argument] = settings.store[s_var.name[0]]
+            else:
+                for var_name in s_var.name:
+                    if settings.store.get(var_name) is not None:
+                        kwargs[s_var.argument] = settings.store[var_name]
+                        break
+
+        backend.configure(settings)
+
+        if cls.__name__ == "IStorage":
+            settings.STORAGE_BACKEND = backend
+            settings.STORAGE_BACKEND.configure(settings)
+            settings.STORAGE = settings.STORAGE_BACKEND(**kwargs)
+
+        elif cls.__name__ == "IKeyVault":
+            settings.KEYVAULT_BACKEND = backend
+            settings.KEYVAULT_BACKEND.configure(settings)
+            settings.KEYVAULT = settings.KEYVAULT_BACKEND(**kwargs)
+
+        else:
+            raise ValueError(f"Invalid Interface {cls.__name__}")

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -165,12 +165,12 @@ class LocalKeyVault(IKeyVault):
         """Define the settings parameters."""
         return [
             ServiceSettings(
-                name="LOCAL_KEYVAULT_PATH",
+                name=["LOCAL_KEYVAULT_PATH"],
                 argument="path",
                 required=True,
             ),
             ServiceSettings(
-                name="LOCAL_KEYVAULT_KEYS",
+                name=["LOCAL_KEYVAULT_KEYS"],
                 argument="keys",
                 required=True,
             ),

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -18,7 +18,11 @@ from securesystemslib.exceptions import (
 from securesystemslib.interface import import_privatekey_from_file
 from securesystemslib.signer import Key, SSlibKey, SSlibSigner
 
-from repository_service_tuf_worker.interfaces import IKeyVault, ServiceSettings
+from repository_service_tuf_worker.interfaces import (
+    Dynaconf,
+    IKeyVault,
+    ServiceSettings,
+)
 
 
 @dataclass
@@ -130,7 +134,7 @@ class LocalKeyVault(IKeyVault):
         return parsed_keys
 
     @classmethod
-    def configure(cls, settings) -> None:
+    def configure(cls, settings: Dynaconf) -> None:
         """
         Run actions to check and configure the service using the settings.
         """
@@ -165,12 +169,12 @@ class LocalKeyVault(IKeyVault):
         """Define the settings parameters."""
         return [
             ServiceSettings(
-                name=["LOCAL_KEYVAULT_PATH"],
+                names=["LOCAL_KEYVAULT_PATH"],
                 argument="path",
                 required=True,
             ),
             ServiceSettings(
-                name=["LOCAL_KEYVAULT_KEYS"],
+                names=["LOCAL_KEYVAULT_KEYS"],
                 argument="keys",
                 required=True,
             ),

--- a/repository_service_tuf_worker/services/storage/local.py
+++ b/repository_service_tuf_worker/services/storage/local.py
@@ -19,13 +19,16 @@ class LocalStorage(IStorage):
 
     @classmethod
     def configure(cls, settings) -> None:
-        os.makedirs(settings.LOCAL_STORAGE_BACKEND_PATH, exist_ok=True)
+        path = settings.get("LOCAL_STORAGE_BACKEND_PATH") or settings.get(
+            "LOCAL_STORAGE_PATH"
+        )
+        os.makedirs(path, exist_ok=True)
 
     @classmethod
     def settings(cls) -> List[ServiceSettings]:
         return [
             ServiceSettings(
-                name="LOCAL_STORAGE_BACKEND_PATH",
+                name=["LOCAL_STORAGE_BACKEND_PATH", "LOCAL_STORAGE_PATH"],
                 argument="path",
                 required=True,
             ),

--- a/repository_service_tuf_worker/services/storage/local.py
+++ b/repository_service_tuf_worker/services/storage/local.py
@@ -28,7 +28,7 @@ class LocalStorage(IStorage):
     def settings(cls) -> List[ServiceSettings]:
         return [
             ServiceSettings(
-                name=["LOCAL_STORAGE_BACKEND_PATH", "LOCAL_STORAGE_PATH"],
+                names=["LOCAL_STORAGE_BACKEND_PATH", "LOCAL_STORAGE_PATH"],
                 argument="path",
                 required=True,
             ),

--- a/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
@@ -302,12 +302,12 @@ class TestLocalStorageService:
 
         assert service_settings == [
             local.ServiceSettings(
-                name="LOCAL_KEYVAULT_PATH",
+                name=["LOCAL_KEYVAULT_PATH"],
                 argument="path",
                 required=True,
             ),
             local.ServiceSettings(
-                name="LOCAL_KEYVAULT_KEYS",
+                name=["LOCAL_KEYVAULT_KEYS"],
                 argument="keys",
                 required=True,
             ),

--- a/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
@@ -302,12 +302,12 @@ class TestLocalStorageService:
 
         assert service_settings == [
             local.ServiceSettings(
-                name=["LOCAL_KEYVAULT_PATH"],
+                names=["LOCAL_KEYVAULT_PATH"],
                 argument="path",
                 required=True,
             ),
             local.ServiceSettings(
-                name=["LOCAL_KEYVAULT_KEYS"],
+                names=["LOCAL_KEYVAULT_KEYS"],
                 argument="keys",
                 required=True,
             ),

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
@@ -39,7 +39,7 @@ class TestLocalStorageService:
 
         assert service_settings == [
             local.ServiceSettings(
-                name=["LOCAL_STORAGE_BACKEND_PATH", "LOCAL_STORAGE_PATH"],
+                names=["LOCAL_STORAGE_BACKEND_PATH", "LOCAL_STORAGE_PATH"],
                 argument="path",
                 required=True,
             ),

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
@@ -15,7 +15,10 @@ class TestLocalStorageService:
         assert service._path == "/path"
 
     def test_configure(self):
-        test_settings = pretend.stub(LOCAL_STORAGE_BACKEND_PATH="/path")
+        test_settings = pretend.stub(
+            LOCAL_STORAGE_BACKEND_PATH="/path",
+            get=pretend.call_recorder(lambda *a: "/path"),
+        )
         local.os = pretend.stub(
             makedirs=pretend.call_recorder(lambda *a, **kw: None)
         )
@@ -26,6 +29,9 @@ class TestLocalStorageService:
         assert local.os.makedirs.calls == [
             pretend.call("/path", exist_ok=True)
         ]
+        assert test_settings.get.calls == [
+            pretend.call("LOCAL_STORAGE_BACKEND_PATH")
+        ]
 
     def test_settings(self):
         service = local.LocalStorage("/path")
@@ -33,7 +39,7 @@ class TestLocalStorageService:
 
         assert service_settings == [
             local.ServiceSettings(
-                name="LOCAL_STORAGE_BACKEND_PATH",
+                name=["LOCAL_STORAGE_BACKEND_PATH", "LOCAL_STORAGE_PATH"],
                 argument="path",
                 required=True,
             ),

--- a/tests/unit/tuf_repository_service_worker/test_interfaces.py
+++ b/tests/unit/tuf_repository_service_worker/test_interfaces.py
@@ -1,0 +1,154 @@
+import pretend
+import pytest
+
+from repository_service_tuf_worker import interfaces
+
+
+class TestInterfaces:
+    def test_IKeyVault(self):
+        class TestKeyVault(interfaces.IKeyVault):
+            @classmethod
+            def configure():
+                ...
+
+            def get():
+                ...
+
+            @classmethod
+            def settings():
+                ...
+
+        test_keyvault = TestKeyVault()
+
+        assert isinstance(test_keyvault, interfaces.IKeyVault)
+
+    def test_IStorage(self):
+        class TestStorage(interfaces.IStorage):
+            @classmethod
+            def configure():
+                ...
+
+            @classmethod
+            def settings():
+                ...
+
+            def get():
+                ...
+
+            def put():
+                ...
+
+        test_keyvault = TestStorage()
+
+        assert isinstance(test_keyvault, interfaces.IStorage)
+
+    def test__setup_service_dynaconf_invalid_interface(self, monkeypatch):
+        test_cls = pretend.stub(
+            __subclasses__=pretend.call_recorder(
+                lambda: [pretend.stub(__name__="FakeService")]
+            ),
+            __name__="IFake",
+        )
+        test_settings = interfaces.Dynaconf()
+        test_settings.RSTUF_FAKE_BACKEND = "FAKESERVICE"
+        test_settings.FAKE_VAR1 = "value1"
+        test_settings.FAKE_VAR2 = "value2"
+        test_backend = pretend.stub(
+            settings=pretend.call_recorder(
+                lambda: [
+                    interfaces.ServiceSettings(
+                        name=["FAKE_VAR1", "FAKE_VAR2"],
+                        argument="var",
+                        required=True,
+                    )
+                ]
+            ),
+            configure=pretend.call_recorder(lambda *a: None),
+        )
+        test_module = pretend.stub(FAKESERVICE=test_backend)
+
+        monkeypatch.setattr(
+            "repository_service_tuf_worker.interfaces.importlib.import_module",
+            lambda *a: test_module,
+        )
+
+        with pytest.raises(ValueError) as err:
+            interfaces._setup_service_dynaconf(
+                test_cls, test_settings.RSTUF_FAKE_BACKEND, test_settings
+            )
+
+        assert "Invalid Interface IFake" in str(err)
+
+    def test__setup_service_dynaconf_all_none(self, monkeypatch):
+        test_cls = pretend.stub(
+            __subclasses__=pretend.call_recorder(
+                lambda: [pretend.stub(__name__="FakeService")]
+            ),
+            __name__="IFake",
+        )
+        test_settings = interfaces.Dynaconf()
+        test_settings.RSTUF_FAKE_BACKEND = "FAKESERVICE"
+        test_settings.FAKE_VAR1 = None
+        test_settings.FAKE_VAR2 = None
+        test_backend = pretend.stub(
+            settings=pretend.call_recorder(
+                lambda: [
+                    interfaces.ServiceSettings(
+                        name=["FAKE_VAR1", "FAKE_VAR2"],
+                        argument="var",
+                        required=True,
+                    )
+                ]
+            ),
+            configure=pretend.call_recorder(lambda *a: None),
+        )
+        test_module = pretend.stub(FAKESERVICE=test_backend)
+
+        monkeypatch.setattr(
+            "repository_service_tuf_worker.interfaces.importlib.import_module",
+            lambda *a: test_module,
+        )
+
+        with pytest.raises(ValueError) as err:
+            interfaces._setup_service_dynaconf(
+                test_cls, test_settings.RSTUF_FAKE_BACKEND, test_settings
+            )
+
+        assert "Invalid Interface IFake" in str(err)
+
+    def test__setup_service_dynaconf_missing_config(self, monkeypatch):
+        test_cls = pretend.stub(
+            __subclasses__=pretend.call_recorder(
+                lambda: [pretend.stub(__name__="FakeService")]
+            ),
+            __name__="IFake",
+        )
+        test_settings = interfaces.Dynaconf()
+        test_settings.RSTUF_FAKE_BACKEND = "FAKESERVICE"
+        test_backend = pretend.stub(
+            FAKESERVICE=pretend.stub(
+                settings=pretend.call_recorder(
+                    lambda: [
+                        interfaces.ServiceSettings(
+                            name=["FAKE_VAR1", "FAKE_VAR2"],
+                            argument="var",
+                            required=True,
+                        )
+                    ]
+                ),
+            )
+        )
+
+        monkeypatch.setattr(
+            "repository_service_tuf_worker.interfaces.importlib.import_module",
+            lambda *a: test_backend,
+        )
+
+        with pytest.raises(AttributeError) as err:
+            interfaces._setup_service_dynaconf(
+                test_cls, test_settings.RSTUF_FAKE_BACKEND, test_settings
+            )
+
+        assert "not attribute(s) RSTUF_FAKE_VAR1 or RSTUF_FAKE_VAR2" in str(
+            err
+        )


### PR DESCRIPTION
- The old `repository.refresh_settings` handling the IServices
  configuration was moved to the `interfaces`
- Now the way to import a `I{Services}` uses the dynaconf directly
- Adds better error messages for the wrong configuration
- Support a service has one setting with multiple environment variables
  what is helpful for third-party libraries that use environment vars