### PR TITLE
Stop calling refresh_settings on each task

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,7 +75,6 @@ def repository_service_tuf_worker(
     self,
     action: str,
     payload: Optional[Dict[str, Any]] = None,
-    refresh_settings: Optional[bool] = True,
 ):
     """
     Repository Service for TUF Metadata Worker main Celery consumer.
@@ -83,11 +82,7 @@ def repository_service_tuf_worker(
     Args:
         action: which action to be executed by the task.
         payload: data that will be given to the action.
-        refresh_settings: whether to refresh repository settings.
     """
-    if refresh_settings is True:
-        repository.refresh_settings(worker_settings)
-
     repository_action = getattr(repository, action)
     if payload is None:
         result = repository_action()

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -108,16 +108,17 @@ class MetadataRepository:
 
     def __init__(self):
         self._worker_settings: Dynaconf = get_worker_settings()
-        self._storage_backend: IStorage = self.refresh_settings().STORAGE
-        self._key_storage_backend: IKeyVault = self.refresh_settings().KEYVAULT
-        self._db = self.refresh_settings().SQL
+        app_settings = self.refresh_settings()
+        self._storage_backend: IStorage = app_settings.STORAGE
+        self._key_storage_backend: IKeyVault = app_settings.KEYVAULT
+        self._db = app_settings.SQL
         self._redis = redis.StrictRedis.from_url(
             self._worker_settings.REDIS_SERVER
         )
         self._hours_before_expire: int = self._settings.get_fresh(
             "HOURS_BEFORE_EXPIRE", 1
         )
-        self._timeout = int(self.refresh_settings().get("LOCK_TIMEOUT", 60.0))
+        self._timeout = int(app_settings.get("LOCK_TIMEOUT", 60.0))
 
     @property
     def _settings(self) -> Dynaconf:
@@ -520,7 +521,6 @@ class MetadataRepository:
             kwargs={
                 "action": "publish_targets",
                 "payload": {"bin_targets": bins_targets},
-                "refresh_settings": False,
             },
             task_id=f"publish_targets-{task_id}",
             queue="rstuf_internals",

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -48,24 +48,6 @@ class TestApp:
             pretend.call(),
         ]
 
-    def test_repository_service_tuf_worker_refresh_settings_false(self):
-        import app
-
-        app.repository = pretend.stub(
-            test_action=pretend.call_recorder(lambda *a, **kw: True),
-        )
-
-        result = app.repository_service_tuf_worker(
-            "test_action", payload={"k": "v"}, refresh_settings=False
-        )
-        assert result is True
-        assert app.repository.test_action.calls == [
-            pretend.call(
-                {"k": "v", "task_id": None},
-                update_state=app.repository_service_tuf_worker.update_state,
-            ),
-        ]
-
     def test__publish_signals(self, app):
         app.redis_backend = pretend.stub(
             set=pretend.call_recorder(lambda *a: None)


### PR DESCRIPTION
Currently, we are calling refresh_settings many times:
1. a couple of times when we set up SQL, Storage Backend, KeyVault and timeout when initializing MetadataRepository
2. once per task we call refresh_settings

In a discussion with Kairo, we reevaluated this design and realized that if there is a change that needs to be made then the user needs to update the environmental variables which will require a restart of all worker containers and as a result, refresh_settings will be called for sure. This means that us calling refresh_settings on each task or during MetadataRepository initialization is redundant as nothing can be changed from the settings without the requirement to restart the containers, otherwise, an error will be raised.