### PR TITLE
build: Use new FT structure

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,8 +28,8 @@ jobs:
     needs: build-pre-dev
     uses: ./.github/workflows/functional-tests.yml
     with:
-      api_version: dev
-      cli_version: dev
+      api_version: ${{ inputs.api_version }}
+      cli_version: ${{ inputs.cli_version }}
 
   functional-tests-local-redis:
     name: FT Deploy Local Services with Redis as Broker
@@ -37,8 +37,8 @@ jobs:
     uses: ./.github/workflows/functional-tests.yml
     with:
       docker_compose: docker-compose-redis.yml
-      api_version: dev
-      cli_version: dev
+      api_version: ${{ inputs.api_version }}
+      cli_version: ${{ inputs.cli_version }}
 
   prepare-rc:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,33 +23,22 @@ jobs:
     with:
       image_version: ${{ github.sha }}
 
-  set-component-versions:
-    needs: publish-container-image
-    runs-on: ubuntu-latest
-    outputs:
-      api_version: ${{ steps.api_version.outputs.VERSION }}
-      cli_version: ${{ steps.cli_version.outputs.VERSION }}
-
-    steps:
-      - id: api_version
-        name: dynamic input worker version
-        run: |
-          if [[ "${{ inputs.api_version }}" == "" ]]; then echo "VERSION=latest" >> $GITHUB_OUTPUT; else echo "VERSION=${{ inputs.api_version }}" >> $GITHUB_OUTPUT;fi
-
-      - id: cli_version
-        name: dynamic input cli version
-        run: |
-          if [[ "${{ inputs.cli_version }}" == "" ]]; then echo "VERSION=latest" >> $GITHUB_OUTPUT; else echo "VERSION=${{ inputs.cli_version }}" >> $GITHUB_OUTPUT;fi
-
-  functional-tests:
-    needs: set-component-versions
-    uses: repository-service-tuf/repository-service-tuf/.github/workflows/functional.yml@main
+  functional-tests-local:
+    name: FT Deploy Local Services
+    needs: build-pre-dev
+    uses: ./.github/workflows/functional-tests.yml
     with:
-      worker_version: ${{ github.sha }}
-      api_version: ${{ needs.set-component-versions.outputs.api_version }}
-      cli_version: ${{ needs.set-component-versions.outputs.cli_version }}
-    secrets:
-      RSTUF_ONLINE_KEY: ${{ secrets.RSTUF_ONLINE_KEY }}
+      api_version: dev
+      cli_version: dev
+
+  functional-tests-local-redis:
+    name: FT Deploy Local Services with Redis as Broker
+    needs: build-pre-dev
+    uses: ./.github/workflows/functional-tests.yml
+    with:
+      docker_compose: docker-compose-redis.yml
+      api_version: dev
+      cli_version: dev
 
   prepare-rc:
     runs-on: ubuntu-latest

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,0 +1,101 @@
+name: Functional Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_compose:
+        description: "Docker Compose File"
+        default: "docker-compose.yml"
+        type: string
+        required: False
+      umbrella_branch:
+        description: "Umbrella Branch (Functional Tests)"
+        default: "main"
+        type: string
+        required: False
+      api_version:
+        description: "API Version"
+        default: "latest"
+        type: string
+        required: False
+      cli_version:
+        description: "CLI Version"
+        default: "latest"
+        type: string
+        required: False
+
+  workflow_call:
+    inputs:
+      docker_compose:
+        description: "Docker Compose File"
+        default: "docker-compose.yml"
+        type: string
+        required: False
+      umbrella_branch:
+        description: "Umbrella Branch (Functional Tests)"
+        default: "main"
+        type: string
+        required: False
+      api_version:
+        description: "API Version"
+        default: "latest"
+        type: string
+        required: False
+      cli_version:
+        description: "CLI Version"
+        default: "latest"
+        type: string
+        required: False
+
+jobs:
+  functional-das:
+    name: "DAS"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout RSTUF Worker source code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+
+      - name: Checkout RSTUF Umbrella (FT)
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+            repository: repository-service-tuf/repository-service-tuf
+            path: rstuf-umbrella
+            ref: ${{ inputs.umbrella_branch }}
+
+      - name: Deploy RSTUF with Worker container from source code
+        uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf
+        with:
+          compose-file: ${{ inputs.docker_compose }}
+        env:
+          API_VERSION: ${{ inputs.api_version }}
+
+      - name: Bootstrap/Setup RSTUF DAS and run Functional Tests
+        run: |
+          make ft-das CLI_VERSION=${{ inputs.cli_version }}
+
+  functional-signed:
+    name: "Signed"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout RSTUF Worker source code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+
+      - name: Checkout RSTUF Umbrella (FT)
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          repository: repository-service-tuf/repository-service-tuf
+          path: rstuf-umbrella
+          ref: ${{ inputs.umbrella_branch }}
+
+      - name: Deploy RSTUF with Worker container from source code
+        uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf
+        with:
+          compose-file: ${{ inputs.docker_compose }}
+        env:
+          API_VERSION: ${{ inputs.api_version }}
+
+      - name: Bootstrap/Setup RSTUF full Signed and run Functional Tests
+        run: |
+          make ft-signed CLI_VERSION=${{ inputs.cli_version }}

--- a/.github/workflows/review-approved.yml
+++ b/.github/workflows/review-approved.yml
@@ -5,46 +5,22 @@ on:
     types: [submitted]
 
 jobs:
-  build-pre-dev:
-    permissions:
-      contents: read
-      packages: write
-    if: github.event.review.state == 'approved'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
-  
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
-  
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-  
-      - name: Build and push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/repository-service-tuf/repository-service-tuf-worker:${{ github.sha }}
-          build-args: |
-            RELEASE_VERSION=${{ github.sha }}
-
-  functional-tests:
+  functional-tests-local:
+    name: Deploy Local Services
     if: github.event.review.state == 'approved'
     needs: build-pre-dev
-    uses: repository-service-tuf/repository-service-tuf/.github/workflows/functional.yml@main
+    uses: ./.github/workflows/functional-tests.yml
     with:
-      worker_version: ${{ github.sha }}
       api_version: dev
       cli_version: dev
-    secrets:
-      RSTUF_ONLINE_KEY: ${{ secrets.RSTUF_ONLINE_KEY }}
+
+  functional-tests-local-redis:
+    name: Deploy Local Services with Redis as Broker
+    if: github.event.review.state == 'approved'
+    needs: build-pre-dev
+    uses: ./.github/workflows/functional-tests.yml
+    with:
+      docker_compose: docker-compose-redis.yml
+      api_version: dev
+      cli_version: dev

--- a/.github/workflows/review-approved.yml
+++ b/.github/workflows/review-approved.yml
@@ -5,11 +5,9 @@ on:
     types: [submitted]
 
 jobs:
-
   functional-tests-local:
     name: Deploy Local Services
     if: github.event.review.state == 'approved'
-    needs: build-pre-dev
     uses: ./.github/workflows/functional-tests.yml
     with:
       api_version: dev
@@ -18,7 +16,6 @@ jobs:
   functional-tests-local-redis:
     name: Deploy Local Services with Redis as Broker
     if: github.event.review.state == 'approved'
-    needs: build-pre-dev
     uses: ./.github/workflows/functional-tests.yml
     with:
       docker_compose: docker-compose-redis.yml

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ coverage.xml
 # repository-service-tuf-api stuff:
 data/
 data-test/
+metadata/
+rstuf-umbrella/
+payload.json
 
 # Scrapy stuff:
 .scrapy

--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,14 @@ clone-umbrella:
 	fi
 
 ft-das:
+# Use "GITHUB_ACTION" to identify if we are running from a GitHub action.
 ifeq ($(GITHUB_ACTION),)
 	$(MAKE) clone-umbrella
 endif
 	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash rstuf-umbrella/tests/functional/scripts/run-ft-das.sh $(CLI_VERSION)' --rm repository-service-tuf-worker
 
 ft-signed:
+# Use "GITHUB_ACTION" to identify if we are running from a GitHub action.
 ifeq ($(GITHUB_ACTION),)
 	$(MAKE) clone-umbrella
 endif

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,17 @@
 build-dev:
 	docker build -t repository-service-tuf-worker:dev .
 
+
+run-dev: export API_VERSION = dev
 run-dev:
 	$(MAKE) build-dev
 	docker pull ghcr.io/repository-service-tuf/repository-service-tuf-api:dev
-	docker compose up --remove-orphans
+ifneq ($(DC),)
+	docker compose -f docker-compose-$(DC).yml up --remove-orphans
+else
+	docker compose -f docker-compose.yml up --remove-orphans
+endif
+
 
 db-migration:
 	if [ -z "$(M)" ]; then echo "Use: make db-migration M=\'message here\'"; exit 1; fi
@@ -53,3 +60,23 @@ precommit:
 	pre-commit install
 	pre-commit autoupdate
 	pre-commit run --all-files --show-diff-on-failure
+
+clone-umbrella:
+	if [ -d rstuf-umbrella ];\
+		then \
+		cd rstuf-umbrella && git pull;\
+	else \
+		git clone https://github.com/repository-service-tuf/repository-service-tuf.git rstuf-umbrella;\
+	fi
+
+ft-das:
+ifeq ($(GITHUB_ACTION),)
+	$(MAKE) clone-umbrella
+endif
+	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash rstuf-umbrella/tests/functional/scripts/run-ft-das.sh $(CLI_VERSION)' --rm repository-service-tuf-worker
+
+ft-signed:
+ifeq ($(GITHUB_ACTION),)
+	$(MAKE) clone-umbrella
+endif
+	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash rstuf-umbrella/tests/functional/scripts/run-ft-signed.sh $(CLI_VERSION)' --rm repository-service-tuf-worker

--- a/README.rst
+++ b/README.rst
@@ -156,7 +156,7 @@ You can run specific test from `tox.ini` using `-e`
 Functional tests
 ----------------
 
-1. Make sure you have a development environment Running (``make run-dev``)
+1. Make sure you have a development environment running (``make run-dev``)
 
 2. Run the FT tests ``make ft-das`` or ``make ft-signed``
 

--- a/README.rst
+++ b/README.rst
@@ -98,16 +98,6 @@ Install development requirements
         $ pip cache purge
         $ LDFLAGS=-L$(brew --prefix libffi)/lib CFLAGS=-I$(brew --prefix libffi)/include pip install cffi cryptography
 
-Database migrations
-===================
-
-Changing database model requires to generate a database migrations with Alembic.
-
-.. code:: shell
-
-  $ make db-migration M="update message"
-
-
 Running checks with pre-commit:
 ===============================
 
@@ -134,12 +124,20 @@ Running the development Worker locally
 
   $ make run-dev
 
+A specific docker compose can be used giving the parameter `DC=<name>`
+For example: `docker-compose-redis.yml` use `DC=redis`
+
+.. code:: shell
+
+  $ make run-dev DC=redis
 
 See Makefile for more options
 
 Tests
 =====
 
+Unit tests
+----------
 We use `Tox <ttps://tox.wiki/en/latest/>`_ to manage running the tests.
 
 Running tests
@@ -147,6 +145,20 @@ Running tests
 .. code:: shell
 
   $ tox
+
+You can run specific test from `tox.ini` using `-e`
+
+
+.. code:: shell
+
+  $ tox -e test
+
+Functional tests
+----------------
+
+1. Make sure you have a development environment Running (``make run-dev``)
+
+2. Run the FT tests ``make ft-das`` or ``make ft-signed``
 
 
 Managing requirements
@@ -175,3 +187,18 @@ Updating requirements files from Pipenv
 .. code:: shell
 
   $ make requirements
+
+
+Managing Database migrations
+============================
+
+It is required when changing the RSTUF Worker Database Models
+`repository_service_tuf_worker/models/`
+
+Updating the models requires a database migrations with Alembic.
+
+Use a clear update message with `M="Added field XYZ for Targets"`
+
+.. code:: shell
+
+  $ make db-migration M="update message"

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -1,30 +1,16 @@
-# Default development deployment
+# Development deployment using Redis as Broker
 version: "3.9"
 
 volumes:
   repository-service-tuf-storage:
   repository-service-tuf-api-data:
-  repository-service-tuf-mq-data:
-  repository-service-tuf-settings:
   repository-service-tuf-redis-data:
   repository-service-tuf-pgsql-data:
 
 services:
-  rabbitmq:
-    image: rabbitmq:3.10.7-management-alpine
-    volumes:
-     - "repository-service-tuf-mq-data:/var/lib/rabbitmq"
-    ports:
-      - 5672:5672
-      - 15672:15672
-    healthcheck:
-      test: "exit 0"
-    restart: always
-
   postgres:
     image: postgres:15.1
     ports:
-      # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"
     environment:
       - POSTGRES_PASSWORD=secret
@@ -41,10 +27,10 @@ services:
     ports:
       - 80:80
     environment:
-      - RSTUF_BROKER_SERVER="amqp://guest:guest@rabbitmq:5672"
-      - RSTUF_REDIS_SERVER="redis://redis"
+      - RSTUF_BROKER_SERVER=redis://redis
+      - RSTUF_REDIS_SERVER=redis://redis
     depends_on:
-      rabbitmq:
+      redis:
         condition: service_healthy
 
   web:
@@ -61,6 +47,9 @@ services:
       - repository-service-tuf-redis-data:/data
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
 
   repository-service-tuf-worker:
     build:
@@ -73,16 +62,14 @@ services:
       - RSTUF_LOCAL_STORAGE_BACKEND_PATH=/var/opt/repository-service-tuf/storage
       - RSTUF_LOCAL_KEYVAULT_PATH=/opt/repository-service-tuf-worker/tests/files/key_storage
       - RSTUF_LOCAL_KEYVAULT_KEYS=online.key,strongPass:online-rsa.key,strongPass,rsa
-      - RSTUF_BROKER_SERVER=amqp://guest:guest@rabbitmq:5672
-      - RSTUF_SQL_SERVER=postgres:5432
-      - RSTUF_SQL_USER=postgres
-      - RSTUF_SQL_PASSWORD=secret
+      - RSTUF_BROKER_SERVER=redis://redis
       - RSTUF_REDIS_SERVER=redis://redis
+      - RSTUF_SQL_SERVER=postgres:secret@postgres:5432
     volumes:
       - ./:/opt/repository-service-tuf-worker:z
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
     depends_on:
-      rabbitmq:
+      redis:
         condition: service_healthy
       postgres:
         condition: service_healthy

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands =
 
 [testenv:test]
 commands =
-    coverage run --omit='tests/*' -m pytest -vv
+    coverage run --omit='tests/*' -m pytest -vv tests/
     coverage xml -i
     coverage report
 
@@ -55,6 +55,7 @@ commands =
     plantuml -Djava.awt.headless=true -o ../source/_static/ -tpng docs/diagrams/*.puml
 	sphinx-apidoc -f -o docs/source/devel/ repository_service_tuf_worker
 	sphinx-build -E -W -b html docs/source docs/build/html
+
 
 [gh-actions]
 python =


### PR DESCRIPTION
* Deploys the RSTUF using Worker image from source code

* Uses two different deployment:
  - Local Services with RabbitMQ as broker (message queue)
  - Local Service with Redis as broker (message queue)

* Uses the RSTF Umbrella `run-ft` scripts
  - DAS
  - Signed

* Enables developers to run FT locally