### PR TITLE
Use I(KeyVault|Storage).cofigure as factory method 

### DIFF
--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -26,7 +26,7 @@ class IKeyVault(ABC):
     @abstractmethod
     def configure(cls, settings: Dynaconf) -> "IKeyVault":
         """
-        Run actions to check and configure the service using the settings.
+        Run actions to test, configure and create object using the settings.
         """
         pass  # pragma: no cover
 
@@ -56,7 +56,7 @@ class IStorage(ABC):
     @abstractmethod
     def configure(cls, settings: Dynaconf) -> "IStorage":
         """
-        Run actions to test, configure using the settings.
+        Run actions to test, configure and create object using the settings.
         """
         raise NotImplementedError  # pragma: no cover
 

--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -5,7 +5,7 @@ import importlib
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from dynaconf import Dynaconf
 from securesystemslib.signer import Key, Signer

--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -26,14 +26,14 @@ class IKeyVault(ABC):
     @abstractmethod
     def configure(cls, settings: Dynaconf) -> "IKeyVault":
         """
-        Run actions to test, configure and create object using the settings.
+        Run actions to verify, configure and create object using the settings.
         """
         pass  # pragma: no cover
 
     @classmethod
     def from_dynaconf(cls, settings: Dynaconf) -> None:
         """
-        Run actions to test, configure using the settings.
+        Run actions to verify and configure using the settings.
         """
         _setup_service_dynaconf(cls, settings.KEYVAULT_BACKEND, settings)
 
@@ -56,14 +56,14 @@ class IStorage(ABC):
     @abstractmethod
     def configure(cls, settings: Dynaconf) -> "IStorage":
         """
-        Run actions to test, configure and create object using the settings.
+        Run actions to verify, configure and create object using the settings.
         """
         raise NotImplementedError  # pragma: no cover
 
     @classmethod
     def from_dynaconf(cls, settings: Dynaconf) -> None:
         """
-        Run actions to test and configure using the dynaconf settings.
+        Run actions to verify and configure using the dynaconf settings.
         """
         _setup_service_dynaconf(cls, settings.STORAGE_BACKEND, settings)
 

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -134,7 +134,7 @@ class LocalKeyVault(IKeyVault):
         return parsed_keys
 
     @classmethod
-    def configure(cls, settings: Dynaconf) -> None:
+    def configure(cls, settings: Dynaconf) -> "LocalKeyVault":
         """
         Run actions to check and configure the service using the settings.
         """
@@ -164,18 +164,18 @@ class LocalKeyVault(IKeyVault):
             logging.error("No valid keys found in the LocalKeyVault")
             raise error
 
+        return cls(path, settings.LOCAL_KEYVAULT_KEYS)
+
     @classmethod
     def settings(cls) -> List[ServiceSettings]:
         """Define the settings parameters."""
         return [
             ServiceSettings(
                 names=["LOCAL_KEYVAULT_PATH"],
-                argument="path",
                 required=True,
             ),
             ServiceSettings(
                 names=["LOCAL_KEYVAULT_KEYS"],
-                argument="keys",
                 required=True,
             ),
         ]

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -129,7 +129,7 @@ class LocalKeyVault(IKeyVault):
     @classmethod
     def configure(cls, settings: Dynaconf) -> "LocalKeyVault":
         """
-        Run actions to check and configure the service using the settings.
+        Run actions to verify, configure and create object using the settings.
         """
         # Check that the online key can be loaded without an error.
         path = settings.LOCAL_KEYVAULT_PATH

--- a/repository_service_tuf_worker/services/storage/awss3.py
+++ b/repository_service_tuf_worker/services/storage/awss3.py
@@ -57,9 +57,9 @@ class AWSS3(IStorage):
             endpoint_url=endpoint,
         )
         buckets = [bucket.name for bucket in s3_resource.buckets.all()]
-        user_bucket = settings.AWSS3_STORAGE_BUCKET
-        if user_bucket not in buckets:
-            raise ValueError(f"Bucket '{user_bucket}' not found.")
+        bucket_name = settings.AWSS3_STORAGE_BUCKET
+        if bucket_name not in buckets:
+            raise ValueError(f"Bucket '{bucket_name}' not found.")
 
         s3_client = s3_session.client(
             "s3",
@@ -70,7 +70,7 @@ class AWSS3(IStorage):
         )
 
         return cls(
-            user_bucket, s3_session, s3_client, s3_resource, region, endpoint
+            bucket_name, s3_session, s3_client, s3_resource, region, endpoint
         )
 
     @classmethod

--- a/repository_service_tuf_worker/services/storage/local.py
+++ b/repository_service_tuf_worker/services/storage/local.py
@@ -10,7 +10,11 @@ from securesystemslib.exceptions import StorageError  # noqa
 from tuf.api.metadata import Metadata, T, Timestamp
 from tuf.api.serialization import DeserializationError
 
-from repository_service_tuf_worker.interfaces import IStorage, ServiceSettings
+from repository_service_tuf_worker.interfaces import (
+    Dynaconf,
+    IStorage,
+    ServiceSettings,
+)
 
 
 class LocalStorage(IStorage):
@@ -18,18 +22,18 @@ class LocalStorage(IStorage):
         self._path: str = path
 
     @classmethod
-    def configure(cls, settings) -> None:
+    def configure(cls, settings: Dynaconf) -> "LocalStorage":
         path = settings.get("LOCAL_STORAGE_BACKEND_PATH") or settings.get(
             "LOCAL_STORAGE_PATH"
         )
         os.makedirs(path, exist_ok=True)
+        return cls(path)
 
     @classmethod
     def settings(cls) -> List[ServiceSettings]:
         return [
             ServiceSettings(
                 names=["LOCAL_STORAGE_BACKEND_PATH", "LOCAL_STORAGE_PATH"],
-                argument="path",
                 required=True,
             ),
         ]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,10 +12,13 @@ from repository_service_tuf_worker.repository import MetadataRepository
 
 @pytest.fixture()
 def test_repo(monkeypatch: pytest.MonkeyPatch) -> MetadataRepository:
-    fake_configure = pretend.call_recorder(lambda *a: None)
+    from repository_service_tuf_worker.services.keyvault import local
+
+    fake_import_privatekey_from_file = pretend.call_recorder(lambda *a: None)
     monkeypatch.setattr(
-        "repository_service_tuf_worker.services.keyvault.local.LocalKeyVault.configure",  # noqa
-        fake_configure,
+        local,
+        "import_privatekey_from_file",
+        fake_import_privatekey_from_file,
     )
     return MetadataRepository.create_service()
 

--- a/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
@@ -174,11 +174,14 @@ class TestLocalStorageService:
             lambda *a: {}
         )
 
-        local.LocalKeyVault.configure(test_settings)
+        service = local.LocalKeyVault.configure(test_settings)
         assert local.import_privatekey_from_file.calls == [
             pretend.call("/path/key_vault/key1.key", "ed25519", "pass1"),
             pretend.call("/path/key_vault/key2.key", "rsa", "pass2"),
         ]
+        assert isinstance(service, local.LocalKeyVault)
+        assert service._path == test_settings.LOCAL_KEYVAULT_PATH
+        assert service._keys == test_settings.LOCAL_KEYVAULT_KEYS
 
     def test_configure_file_base64(self):
         test_settings = pretend.stub(
@@ -195,7 +198,10 @@ class TestLocalStorageService:
             lambda *a: {}
         )
 
-        local.LocalKeyVault.configure(test_settings)
+        service = local.LocalKeyVault.configure(test_settings)
+        assert isinstance(service, local.LocalKeyVault)
+        assert service._path == test_settings.LOCAL_KEYVAULT_PATH
+        assert service._keys == test_settings.LOCAL_KEYVAULT_KEYS
         assert local.import_privatekey_from_file.calls == [
             pretend.call("/path/key_vault/fake_hash", "ed25519", "pass1"),
             pretend.call("/path/key_vault/key2.key", "rsa", "pass2"),
@@ -246,8 +252,10 @@ class TestLocalStorageService:
         ]
         local.import_privatekey_from_file = mocked_import_pk_from_file
 
-        local.LocalKeyVault.configure(test_settings)
-
+        service = local.LocalKeyVault.configure(test_settings)
+        assert isinstance(service, local.LocalKeyVault)
+        assert service._path == test_settings.LOCAL_KEYVAULT_PATH
+        assert service._keys == test_settings.LOCAL_KEYVAULT_KEYS
         assert caplog.record_tuples == [
             ("root", 40, "Invalid format"),
             ("root", 30, "Failed to load LocalKeyVault key"),
@@ -303,12 +311,10 @@ class TestLocalStorageService:
         assert service_settings == [
             local.ServiceSettings(
                 names=["LOCAL_KEYVAULT_PATH"],
-                argument="path",
                 required=True,
             ),
             local.ServiceSettings(
                 names=["LOCAL_KEYVAULT_KEYS"],
-                argument="keys",
                 required=True,
             ),
         ]

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
@@ -39,8 +39,8 @@ class TestAWSS3Service:
         assert service._s3_session == "session"
         assert service._s3_client == "client"
         assert service._s3_resource == "resource"
-        assert service._region is "region"
-        assert service._endpoint_url is "http://localstack:4566"
+        assert service._region == "region"
+        assert service._endpoint_url == "http://localstack:4566"
 
     def test_configure(self, mocked_boto3):
         test_settings = pretend.stub(

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
@@ -4,7 +4,7 @@
 
 import pretend
 import pytest
-from tuf.api.metadata import Metadata, Root, Timestamp
+from tuf.api.metadata import Metadata, Optional, Root, Timestamp
 
 from repository_service_tuf_worker.services.storage import awss3
 
@@ -13,40 +13,34 @@ class TestAWSS3Service:
     def test_basic_init(self, mocked_boto3):
         service = awss3.AWSS3(
             "bucket",
-            "access_key",
-            "secret_key",
+            "session",
+            "client",
+            "resource",
         )
 
         assert service._bucket == "bucket"
-        assert service._access_key == "access_key"
-        assert service._secret_key == "secret_key"
+        assert service._s3_session == "session"
+        assert service._s3_client == "client"
+        assert service._s3_resource == "resource"
         assert service._region is None
         assert service._endpoint_url is None
-        assert awss3.boto3.Session.calls == [
-            pretend.call(
-                aws_access_key_id="access_key",
-                aws_secret_access_key="secret_key",
-                region_name=None,
-            )
-        ]
-        assert service._s3_session.client.calls == [
-            pretend.call(
-                "s3",
-                aws_access_key_id=service._access_key,
-                aws_secret_access_key=service._secret_key,
-                region_name=service._region,
-                endpoint_url=service._endpoint_url,
-            )
-        ]
-        assert service._s3_session.resource.calls == [
-            pretend.call(
-                "s3",
-                aws_access_key_id=service._access_key,
-                aws_secret_access_key=service._secret_key,
-                region_name=service._region,
-                endpoint_url=service._endpoint_url,
-            )
-        ]
+
+    def test_full_init(self, mocked_boto3):
+        service = awss3.AWSS3(
+            "bucket",
+            "session",
+            "client",
+            "resource",
+            "region",
+            "http://localstack:4566",
+        )
+
+        assert service._bucket == "bucket"
+        assert service._s3_session == "session"
+        assert service._s3_client == "client"
+        assert service._s3_resource == "resource"
+        assert service._region is "region"
+        assert service._endpoint_url is "http://localstack:4566"
 
     def test_configure(self, mocked_boto3):
         test_settings = pretend.stub(
@@ -56,95 +50,109 @@ class TestAWSS3Service:
             AWSS3_STORAGE_SECRET_KEY="secret_key",
         )
 
-        service = awss3.AWSS3(
-            "bucket",
-            "access_key",
-            "secret_key",
-        )
-        service.configure(test_settings)
-        assert service._bucket == "bucket"
-        assert service._access_key == "access_key"
-        assert service._secret_key == "secret_key"
-        assert service._region is None
-        assert service._endpoint_url is None
-        assert awss3.boto3.resource.calls == [
+        service = awss3.AWSS3.configure(test_settings)
+        assert awss3.boto3.Session.calls == [
+            pretend.call(
+                aws_access_key_id="access_key",
+                aws_secret_access_key="secret_key",
+                region_name=None,
+            )
+        ]
+        assert service._s3_session.resource.calls == [
             pretend.call(
                 "s3",
                 aws_access_key_id="access_key",
                 aws_secret_access_key="secret_key",
-                region_name=None,
+                region_name=service._region,
+                endpoint_url=service._endpoint_url,
+            )
+        ]
+        assert service._s3_session.client.calls == [
+            pretend.call(
+                "s3",
+                aws_access_key_id="access_key",
+                aws_secret_access_key="secret_key",
+                region_name=service._region,
+                endpoint_url=service._endpoint_url,
+            )
+        ]
+        assert awss3.boto3.Session().resource().buckets.all.calls == [
+            pretend.call()
+        ]
+        # By using awss3.boto3 functions we can access the internal objects
+        # mocked in mocked_boto3.
+        assert service._bucket == "bucket"
+        assert service._s3_session == awss3.boto3.Session()
+        assert service._s3_client == awss3.boto3.Session().client()
+        assert service._s3_resource == awss3.boto3.Session().resource()
+        assert service._region is None
+        assert service._endpoint_url is None
+
+    def test_configure_bucket_not_found(self, mocked_boto3):
+        def _fake_get(key: str) -> Optional[str]:
+            if key == "AWSS3_STORAGE_REGION":
+                return "region"
+            return None
+
+        test_settings = pretend.stub(
+            get=pretend.call_recorder(lambda a: _fake_get(a)),
+            AWSS3_STORAGE_BUCKET="nonexistent-bucket",
+            AWSS3_STORAGE_ACCESS_KEY="access_key",
+            AWSS3_STORAGE_SECRET_KEY="secret_key",
+        )
+
+        service = None
+        with pytest.raises(ValueError) as err:
+            service = awss3.AWSS3.configure(test_settings)
+
+        assert "Bucket 'nonexistent-bucket' not found." in str(err)
+        assert service is None
+        assert awss3.boto3.resource().buckets.all.calls == [pretend.call()]
+        assert awss3.boto3.Session.calls == [
+            pretend.call(
+                aws_access_key_id="access_key",
+                aws_secret_access_key="secret_key",
+                region_name="region",
+            )
+        ]
+        assert awss3.boto3.Session().resource.calls == [
+            pretend.call(
+                "s3",
+                aws_access_key_id="access_key",
+                aws_secret_access_key="secret_key",
+                region_name="region",
                 endpoint_url=None,
             )
         ]
-        assert awss3.boto3.resource().buckets.all.calls == [pretend.call()]
-
-    def test_configure_bucket_not_found(self, mocked_boto3):
-        test_settings = pretend.stub(
-            get=pretend.call_recorder(lambda *a: None),
-            AWSS3_STORAGE_BUCKET="bucket",
-            AWSS3_STORAGE_ACCESS_KEY="access_key",
-            AWSS3_STORAGE_SECRET_KEY="secret_key",
-            AWSS3_STORAGE_REGION="region",
-            AWSS3_STORAGE_ENDPOINT_URL=None,
-        )
-
-        fake_resource = pretend.stub(
-            buckets=pretend.stub(all=pretend.call_recorder(lambda: []))
-        )
-        awss3.boto3.resource = pretend.call_recorder(
-            lambda *a, **kw: fake_resource
-        )
-
-        service = awss3.AWSS3(
-            "bucket",
-            "access_key",
-            "secret_key",
-            "region",
-        )
-        with pytest.raises(ValueError) as err:
-            service.configure(test_settings)
-
-        assert "Bucket 'bucket' not found." in str(err)
-        assert service._bucket == "bucket"
-        assert service._access_key == "access_key"
-        assert service._secret_key == "secret_key"
-        assert service._region == "region"
-        assert service._endpoint_url is None
-        assert awss3.boto3.resource().buckets.all.calls == [pretend.call()]
 
     def test_settings(self, mocked_boto3):
         service = awss3.AWSS3(
             "bucket",
-            "access_key",
-            "secret_key",
-            "region",
+            "session",
+            "client",
+            "resource",
         )
         service_settings = service.settings()
 
         assert service_settings == [
             awss3.ServiceSettings(
                 names=["AWSS3_STORAGE_BUCKET"],
-                argument="bucket",
                 required=True,
             ),
             awss3.ServiceSettings(
                 names=["AWSS3_STORAGE_ACCESS_KEY"],
-                argument="access_key",
                 required=True,
             ),
             awss3.ServiceSettings(
                 names=["AWSS3_STORAGE_SECRET_KEY"],
-                argument="secret_key",
                 required=True,
             ),
             awss3.ServiceSettings(
                 names=["AWSS3_STORAGE_REGION"],
-                argument="region",
                 required=False,
             ),
             awss3.ServiceSettings(
                 names=["AWSS3_STORAGE_ENDPOINT_URL"],
-                argument="endpoint_url",
                 required=False,
             ),
         ]
@@ -152,9 +160,9 @@ class TestAWSS3Service:
     def test_get(self, mocked_boto3):
         service = awss3.AWSS3(
             "bucket",
-            "access_key",
-            "secret_key",
-            "region",
+            "session",
+            "client",
+            "resource",
         )
         awss3.awswrangler.s3.list_objects = pretend.call_recorder(
             lambda *a, **kw: [
@@ -169,7 +177,7 @@ class TestAWSS3Service:
         fake_aws3_object = pretend.stub(
             get=pretend.call_recorder(lambda *a: fake_file_obj)
         )
-        service._s3 = pretend.stub(
+        service._s3_client = pretend.stub(
             get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         )
 
@@ -190,15 +198,64 @@ class TestAWSS3Service:
                 boto3_session=service._s3_session,
             )
         ]
-        assert service._s3.get_object.calls == [
+        assert service._s3_client.get_object.calls == [
+            pretend.call(Bucket=service._bucket, Key="2.root.json")
+        ]
+
+    def test_get_endpoint_url_not_none(self, mocked_boto3):
+        service = awss3.AWSS3(
+            "bucket",
+            "session",
+            "client",
+            "resource",
+            "region",
+            "http://localstack",
+        )
+        awss3.awswrangler.s3.list_objects = pretend.call_recorder(
+            lambda *a, **kw: [
+                f"s3://{service._bucket}/1.root.json",
+                f"s3://{service._bucket}/2.root.json",
+            ]
+        )
+        fake_file_obj = pretend.stub(
+            read=pretend.call_recorder(lambda: None),
+            close=pretend.call_recorder(lambda: None),
+        )
+        fake_aws3_object = pretend.stub(
+            get=pretend.call_recorder(lambda *a: fake_file_obj)
+        )
+        service._s3_client = pretend.stub(
+            get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
+        )
+
+        expected_root = Metadata(Root())
+        awss3.Metadata = pretend.stub(
+            from_bytes=pretend.call_recorder(lambda *a: expected_root)
+        )
+        result = service.get("root")
+
+        assert result == expected_root
+        assert awss3.awswrangler.config.s3_endpoint_url == "http://localstack"
+        assert fake_file_obj.read.calls == [pretend.call()]
+        assert fake_file_obj.close.calls == [pretend.call()]
+        assert fake_aws3_object.get.calls == [pretend.call("Body")]
+        assert awss3.Metadata.from_bytes.calls == [pretend.call(None)]
+        assert awss3.awswrangler.s3.list_objects.calls == [
+            pretend.call(
+                path=f"s3://{service._bucket}/*.root.json",
+                boto3_session=service._s3_session,
+            )
+        ]
+        assert service._s3_client.get_object.calls == [
             pretend.call(Bucket=service._bucket, Key="2.root.json")
         ]
 
     def test_get_timestamp(self, mocked_boto3):
         service = awss3.AWSS3(
             "bucket",
-            "access_key",
-            "secret_key",
+            "session",
+            "client",
+            "resource",
             "region",
             "http://localstack:4566",
         )
@@ -216,7 +273,7 @@ class TestAWSS3Service:
         fake_aws3_object = pretend.stub(
             get=pretend.call_recorder(lambda *a: fake_file_obj)
         )
-        service._s3 = pretend.stub(
+        service._s3_client = pretend.stub(
             get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         )
         expected_timestamp = Metadata(Timestamp())
@@ -231,15 +288,16 @@ class TestAWSS3Service:
         assert fake_aws3_object.get.calls == [pretend.call("Body")]
         assert awss3.Metadata.from_bytes.calls == [pretend.call(None)]
         assert awss3.awswrangler.s3.list_objects.calls == []
-        assert service._s3.get_object.calls == [
+        assert service._s3_client.get_object.calls == [
             pretend.call(Bucket=service._bucket, Key="timestamp.json")
         ]
 
     def test_get_max_version_ValueError(self, mocked_boto3, monkeypatch):
         service = awss3.AWSS3(
             "bucket",
-            "access_key",
-            "secret_key",
+            "session",
+            "client",
+            "resource",
             "region",
             "http://localstack:4566",
         )
@@ -256,7 +314,7 @@ class TestAWSS3Service:
         fake_aws3_object = pretend.stub(
             get=pretend.call_recorder(lambda *a: fake_file_obj)
         )
-        service._s3 = pretend.stub(
+        service._s3_client = pretend.stub(
             get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         )
         monkeypatch.setitem(
@@ -278,15 +336,16 @@ class TestAWSS3Service:
                 boto3_session=service._s3_session,
             )
         ]
-        assert service._s3.get_object.calls == [
+        assert service._s3_client.get_object.calls == [
             pretend.call(Bucket=service._bucket, Key="1.root.json")
         ]
 
     def test_get_DeserializationError(self, mocked_boto3):
         service = awss3.AWSS3(
             "bucket",
-            "access_key",
-            "secret_key",
+            "session",
+            "client",
+            "resource",
             "region",
             "http://localstack:4566",
         )
@@ -303,7 +362,7 @@ class TestAWSS3Service:
         fake_aws3_object = pretend.stub(
             get=pretend.call_recorder(lambda *a: fake_file_obj)
         )
-        service._s3 = pretend.stub(
+        service._s3_client = pretend.stub(
             get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         )
         awss3.Metadata = pretend.stub(
@@ -323,37 +382,40 @@ class TestAWSS3Service:
                 boto3_session=service._s3_session,
             )
         ]
-        assert service._s3.get_object.calls == [
+        assert service._s3_client.get_object.calls == [
             pretend.call(Bucket=service._bucket, Key="1.root.json")
         ]
 
     def test_put(self, mocked_boto3):
-        service = awss3.AWSS3(
-            "bucket",
-            "access_key",
-            "secret_key",
-            "region",
+        test_settings = pretend.stub(
+            get=pretend.call_recorder(lambda *a: None),
+            AWSS3_STORAGE_BUCKET="bucket",
+            AWSS3_STORAGE_ACCESS_KEY="access_key",
+            AWSS3_STORAGE_SECRET_KEY="secret_key",
         )
+
+        service = awss3.AWSS3.configure(test_settings)
 
         fake_file_data = b"fake_byte_data"
         result = service.put(fake_file_data, "3.bin-e.json")
 
         assert result is None
-        assert service._s3.put_object.calls == [
+        assert service._s3_client.put_object.calls == [
             pretend.call(
                 Body=fake_file_data, Bucket=service._bucket, Key="3.bin-e.json"
             )
         ]
 
     def test_put_ClientErro(self, mocked_boto3):
-        service = awss3.AWSS3(
-            "bucket",
-            "access_key",
-            "secret_key",
-            "region",
+        test_settings = pretend.stub(
+            get=pretend.call_recorder(lambda *a: None),
+            AWSS3_STORAGE_BUCKET="bucket",
+            AWSS3_STORAGE_ACCESS_KEY="access_key",
+            AWSS3_STORAGE_SECRET_KEY="secret_key",
         )
+        service = awss3.AWSS3.configure(test_settings)
 
-        service._s3.put_object = pretend.raiser(
+        service._s3_client.put_object = pretend.raiser(
             awss3.ClientError({}, "put_object")
         )
 

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
@@ -23,8 +23,8 @@ class TestLocalStorageService:
             makedirs=pretend.call_recorder(lambda *a, **kw: None)
         )
 
-        service = local.LocalStorage("/path")
-        service.configure(test_settings)
+        service = local.LocalStorage.configure(test_settings)
+        assert isinstance(service, local.LocalStorage)
         assert service._path == "/path"
         assert local.os.makedirs.calls == [
             pretend.call("/path", exist_ok=True)
@@ -40,7 +40,6 @@ class TestLocalStorageService:
         assert service_settings == [
             local.ServiceSettings(
                 names=["LOCAL_STORAGE_BACKEND_PATH", "LOCAL_STORAGE_PATH"],
-                argument="path",
                 required=True,
             ),
         ]

--- a/tests/unit/tuf_repository_service_worker/test_interfaces.py
+++ b/tests/unit/tuf_repository_service_worker/test_interfaces.py
@@ -1,5 +1,8 @@
+from typing import Optional, List
+
 import pretend
 import pytest
+from tuf.api.metadata import Metadata, T
 
 from repository_service_tuf_worker import interfaces
 
@@ -58,7 +61,6 @@ class TestInterfaces:
                 lambda: [
                     interfaces.ServiceSettings(
                         names=["FAKE_VAR1", "FAKE_VAR2"],
-                        argument="var",
                         required=True,
                     )
                 ]
@@ -89,28 +91,30 @@ class TestInterfaces:
                 self._var2 = var2
 
             @classmethod
-            def configure(cls, settings):
-                ...
+            def configure(cls, settings: interfaces.Dynaconf) -> "FakeStorage":
+                return FakeStorage(
+                    settings.TEST_STORAGE_VAR1, settings.TEST_STORAGE_VAR2
+                )
 
             @classmethod
-            def settings(cls):
+            def settings(cls) -> List[interfaces.ServiceSettings]:
                 return [
                     interfaces.ServiceSettings(
                         names=["TEST_STORAGE_VAR1", "TEST_STORAGE_VARIABLE1"],
-                        argument="var1",
                         required=False,
                     ),
                     interfaces.ServiceSettings(
                         names=["TEST_STORAGE_VAR2"],
-                        argument="var2",
                         required=False,
                     ),
                 ]
 
-            def get():
+            def get(
+                self, rolename: str, version: Optional[int]
+            ) -> Metadata[T]:
                 ...
 
-            def put():
+            def put(self, file_data: bytes, filename: str) -> None:
                 ...
 
         test_settings = interfaces.Dynaconf()
@@ -145,7 +149,6 @@ class TestInterfaces:
                     lambda: [
                         interfaces.ServiceSettings(
                             names=["FAKE_VAR1", "FAKE_VAR2"],
-                            argument="var",
                             required=True,
                         )
                     ]

--- a/tests/unit/tuf_repository_service_worker/test_interfaces.py
+++ b/tests/unit/tuf_repository_service_worker/test_interfaces.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List, Optional
 
 import pretend
 import pytest


### PR DESCRIPTION
Fixes #401 

Transform the I(KeyVault|Storage).cofigure as factory method meaning
it will be used as a constructor.
This will allow removing duplicating code from `__init__` or `configure`.

Additionally, I used the opportunity to remove the "kwargs" variable
and operations inside interfaces._setup_service_dynaconf() as we
don't use it for anything. 

As a continuation, I was able also to remove
ServerSettings.argument field from ServerSettings as again it was not
used anywhere any more.

Finally, I used `configure` as a constructor to remove the calls
of `_raw_key_parser` inside `LocalKeyVault.get()` as the result
of those calls will be the same during the container's lifetime.