### PR TITLE
Rename CLI argument in ft-tests scripts

### DIFF
--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -79,7 +79,7 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-ceremony.py '{
 
 
 # Bootstrap using DAS
-rstuf admin ceremony -b -u -f payload.json --upload-server http://repository-service-tuf-api
+rstuf admin ceremony -b -u -f payload.json --api-server http://repository-service-tuf-api
 
 
 # Finish the DAS signing the Root Metadata (bootstrap)

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -74,7 +74,7 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-ceremony.py '{
 
 
 # Bootstrap using DAS
-rstuf admin ceremony -b -u -f payload.json --upload-server http://repository-service-tuf-api
+rstuf admin ceremony -b -u -f payload.json --api-server http://repository-service-tuf-api
 
 # Get initial trusted Root
 rm metadata/1.root.json


### PR DESCRIPTION
This change is required after the following CLI commit was merged: 
https://github.com/repository-service-tuf/repository-service-tuf-cli/commit/d2e066eaee2f7986aa7994a5c57d7a8cd4ade3c3

Signed-off-by: Martin Vrachev <mvrachev@vmware.com