### PR TITLE
Save `TRUSTED_ROOT` repository setting 

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -217,6 +217,9 @@ class MetadataRepository:
             if filename[0].isdigit() is False:
                 filename = f"{role.signed.version}.{filename}"
 
+            if role_name == Root.type:
+                self.write_repository_settings("TRUSTED_ROOT", role.to_dict())
+
         bytes_data = role.to_bytes(JSONSerializer())
         self._storage_backend.put(bytes_data, filename)
         logging.debug(f"{filename} saved")


### PR DESCRIPTION
The TRUSTED_ROOT repository setting will be used by RSTUF API when composing the 
`GET /api/v1/metadata/sign response`.

Connected: https://github.com/repository-service-tuf/repository-service-tuf-api/pull/499

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>