### PR TITLE
Add simple online signer store (wip)

### DIFF
--- a/repository_service_tuf_worker/_signer.py
+++ b/repository_service_tuf_worker/_signer.py
@@ -1,86 +1,33 @@
-from base64 import b64decode
-from hashlib import blake2b
-from pathlib import Path
-
-from securesystemslib.signer import Key, SecretsHandler, Signer
-
-from repository_service_tuf_worker import Dynaconf
+from securesystemslib.signer import Key, Signer
 
 
 class SignerStore:
     """Generic signer store.
 
-    - Loads per-signer info (uri, secrets handler) from config on `init`.
-    - Loads signer for pub key on `get`.
+    Provides method to load and cache signer for passed public key, using a URI
+    configured in a custom field of the passed key.
 
-    FIXME: include keyid in signer config to map config to public keys
     """
 
-    def __init__(self, settings: Dynaconf):
+    def __init__(self):
         self._signers: dict[str, Signer] = {}
-        self._signer_infos: dict[str, tuple[str, SecretsHandler]]
-
-        if settings.KEYVAULT_BACKEND == "LocalKeyVault":
-            for signer_info in settings.LOCAL_KEYVAULT_KEYS.split(":"):
-                keyid, uri, secrets_handler = self._parse_local(
-                    signer_info, settings.LOCAL_KEYVAULT_PATH
-                )
-
-            self._signer_infos[keyid] = (uri, secrets_handler)
-
-    @staticmethod
-    def _parse_local(
-        signer_info: str, signer_dir: str
-    ) -> tuple[str, str, SecretsHandler]:
-        """Parses keyid, uri and secrets handler from single signer info chunk.
-
-        If chunk contains key data, it is written to a file.
-        Colon-separated chunks can be found in RSTUF_LOCAL_KEYVAULT_KEYS.
-
-        FIXME: encoding is overly complex, each chunk can be one of:
-            1. path to key file , password, type (optional)
-            2. base64 encoded key data, password, type (optional)
-            3. path to a secret, which contains (1)
-
-        I recommend to pick one good way to configure file-based keys only
-        """
-        # Case-handle signer_info is in a secret
-        if signer_info.startswith("/run/secrets/"):
-            with open(signer_info) as f:
-                signer_info = f.read().rstrip("\n")
-
-        # Unpack signer_info, ignore irrelevant optional 'keytype' (*_)
-        # FIXME: 'keytype' in public key is authoritative, no need to config
-        filename, password, *_ = signer_info.split(",")
-
-        # Case-handle signer_info contains key data
-        if filename.startswith("base64|"):
-            key_data = b64decode(filename[len("base64|") :])
-            filename = blake2b(key_data, digest_size=16)
-            with open(Path(signer_dir) / filename, "wb") as f:
-                f.write(key_data)
-
-        # FIXME: we can't use this keyid because it does not map to a pubkey.
-        keyid = filename
-
-        path = f"{signer_dir}/{filename}"
-        uri = f"file:{path}?encrypted=true"
-
-        # FIXME: what is the benefit of using a 'password', which is passed
-        # along with the secret key data?
-        secrets_handler = lambda name: password
-
-        return keyid, uri, secrets_handler
 
     def get(self, key: Key) -> Signer:
-        """Return signer for passed key."""
+        """Return signer for passed key.
+
+        NOTE: the passed `key` is expected to have an "x-rstuf-online-key-uri"
+        field in its `unrecognized_fields` attribute. This uri is used with the
+        generic `Signer.from_priv_key_uri` interface, and, along with the
+        public key, it encodes all information necessary to load the signer.
+
+        Additional required information, e.g. to authenticate with a Cloud KMS,
+        may be provided via signer type specific environment variables.
+
+        """
 
         # If signer not in cache, load it using config
         if key.keyid not in self._signers:
-            # FIXME: provide keyid mapping and use it here
-            # uri, sec = self._signer_infos[key.keyid]
-            uri, sec = self._signer_infos.values()[0]
-
-            self._signers[key.keyid] = Signer.from_priv_key_uri(uri, key, sec)
+            uri = key.unrecognized_fields["x-rstuf-online-key-uri"]
+            self._signers[key.keyid] = Signer.from_priv_key_uri(uri, key)
 
         return self._signers[key.keyid]

--- a/repository_service_tuf_worker/_signer.py
+++ b/repository_service_tuf_worker/_signer.py
@@ -1,4 +1,49 @@
-from securesystemslib.signer import Key, Signer
+import os
+from pathlib import Path
+from typing import Optional
+
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from securesystemslib.signer import (
+    SIGNER_FOR_URI_SCHEME,
+    CryptoSigner,
+    Key,
+    SecretsHandler,
+    Signer,
+)
+
+
+class FileSigner(CryptoSigner):
+    """File-based signer implementation.
+
+    Overrides `CryptoSigner.from_priv_key_uri` to load private key file from a
+
+    * directory, defined in envvar: `RSTUF_ONLINE_KEY_DIR`, and a
+    * file name, defined in the passed uri: `fn:<file name>`
+
+    """
+
+    SCHEME = "fn"
+    DIR_VAR = "RSTUF_ONLINE_KEY_DIR"
+
+    @classmethod
+    def from_priv_key_uri(
+        cls,
+        priv_key_uri: str,
+        public_key: Key,
+        secrets_handler: Optional[SecretsHandler] = None,
+    ) -> "FileSigner":
+        _, _, file_name = priv_key_uri.partition(":")
+        dir_ = os.environ[cls.DIR_VAR]
+
+        with open(Path(dir_, file_name), "rb") as f:
+            private_pem = f.read()
+
+        private_key = load_pem_private_key(private_pem, None)
+        return FileSigner(private_key, public_key)
+
+
+# Register signer for scheme for usage via generic `Signer.from_priv_key_uri`
+SIGNER_FOR_URI_SCHEME.update({FileSigner.SCHEME: FileSigner})
 
 
 class SignerStore:

--- a/repository_service_tuf_worker/_signer.py
+++ b/repository_service_tuf_worker/_signer.py
@@ -42,8 +42,34 @@ class FileSigner(CryptoSigner):
         return FileSigner(private_key, public_key)
 
 
+class EnvSigner(CryptoSigner):
+    """Environment variable -based signer implementation.
+
+    Overrides `CryptoSigner.from_priv_key_uri` to load private key from an
+    environment variable defined in the passed uri:
+
+    `env:<environment variable name>`
+
+    """
+
+    SCHEME = "env"
+
+    @classmethod
+    def from_priv_key_uri(
+        cls,
+        priv_key_uri: str,
+        public_key: Key,
+        secrets_handler: Optional[SecretsHandler] = None,
+    ) -> "EnvSigner":
+        _, _, env_name = priv_key_uri.partition(":")
+        private_pem = os.environ[env_name]
+        private_key = load_pem_private_key(private_pem, None)
+        return EnvSigner(private_key, public_key)
+
+
 # Register signer for scheme for usage via generic `Signer.from_priv_key_uri`
 SIGNER_FOR_URI_SCHEME.update({FileSigner.SCHEME: FileSigner})
+SIGNER_FOR_URI_SCHEME.update({EnvSigner.SCHEME: EnvSigner})
 
 
 class SignerStore:

--- a/repository_service_tuf_worker/_signer.py
+++ b/repository_service_tuf_worker/_signer.py
@@ -1,0 +1,86 @@
+from base64 import b64decode
+from hashlib import blake2b
+from pathlib import Path
+
+from securesystemslib.signer import Key, SecretsHandler, Signer
+
+from repository_service_tuf_worker import Dynaconf
+
+
+class SignerStore:
+    """Generic signer store.
+
+    - Loads per-signer info (uri, secrets handler) from config on `init`.
+    - Loads signer for pub key on `get`.
+
+    FIXME: include keyid in signer config to map config to public keys
+    """
+
+    def __init__(self, settings: Dynaconf):
+        self._signers: dict[str, Signer] = {}
+        self._signer_infos: dict[str, tuple[str, SecretsHandler]]
+
+        if settings.KEYVAULT_BACKEND == "LocalKeyVault":
+            for signer_info in settings.LOCAL_KEYVAULT_KEYS.split(":"):
+                keyid, uri, secrets_handler = self._parse_local(
+                    signer_info, settings.LOCAL_KEYVAULT_PATH
+                )
+
+            self._signer_infos[keyid] = (uri, secrets_handler)
+
+    @staticmethod
+    def _parse_local(
+        signer_info: str, signer_dir: str
+    ) -> tuple[str, str, SecretsHandler]:
+        """Parses keyid, uri and secrets handler from single signer info chunk.
+
+        If chunk contains key data, it is written to a file.
+        Colon-separated chunks can be found in RSTUF_LOCAL_KEYVAULT_KEYS.
+
+        FIXME: encoding is overly complex, each chunk can be one of:
+            1. path to key file , password, type (optional)
+            2. base64 encoded key data, password, type (optional)
+            3. path to a secret, which contains (1)
+
+        I recommend to pick one good way to configure file-based keys only
+        """
+        # Case-handle signer_info is in a secret
+        if signer_info.startswith("/run/secrets/"):
+            with open(signer_info) as f:
+                signer_info = f.read().rstrip("\n")
+
+        # Unpack signer_info, ignore irrelevant optional 'keytype' (*_)
+        # FIXME: 'keytype' in public key is authoritative, no need to config
+        filename, password, *_ = signer_info.split(",")
+
+        # Case-handle signer_info contains key data
+        if filename.startswith("base64|"):
+            key_data = b64decode(filename[len("base64|") :])
+            filename = blake2b(key_data, digest_size=16)
+            with open(Path(signer_dir) / filename, "wb") as f:
+                f.write(key_data)
+
+        # FIXME: we can't use this keyid because it does not map to a pubkey.
+        keyid = filename
+
+        path = f"{signer_dir}/{filename}"
+        uri = f"file:{path}?encrypted=true"
+
+        # FIXME: what is the benefit of using a 'password', which is passed
+        # along with the secret key data?
+        secrets_handler = lambda name: password
+
+        return keyid, uri, secrets_handler
+
+    def get(self, key: Key) -> Signer:
+        """Return signer for passed key."""
+
+        # If signer not in cache, load it using config
+        if key.keyid not in self._signers:
+            # FIXME: provide keyid mapping and use it here
+            # uri, sec = self._signer_infos[key.keyid]
+            uri, sec = self._signer_infos.values()[0]
+
+            self._signers[key.keyid] = Signer.from_priv_key_uri(uri, key, sec)
+
+        return self._signers[key.keyid]

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -106,7 +106,7 @@ class MetadataRepository:
         self._worker_settings: Dynaconf = get_worker_settings()
         app_settings = self.refresh_settings()
         self._storage_backend: IStorage = app_settings.STORAGE
-        self._signer_store = _signer.SignerStore(app_settings)
+        self._signer_store = _signer.SignerStore()
         self._db = app_settings.SQL
         self._redis = redis.StrictRedis.from_url(
             self._worker_settings.REDIS_SERVER


### PR DESCRIPTION
- Can be used to load/cache/use any signer from securesystemslib Signer API, including custom signers.
- Should replace IKeyVault and related classes.
- Details in #419 