### PR TITLE
Prepare Release v0.10.0b1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022, VMware Inc
+Copyright (c) 2023, Repository Service for TUF Contributors
+Copyright (c) 2022-2023, VMware Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -4,7 +4,7 @@ Maintainers
 Kairo de Araujo
 ---------------
 
-Email: kdearaujo@vmware.com
+Email: kdearaujo@testifysec.com
 
 GitHub username: @kairoaraujo
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 #!/bin/env python3
 
-# SPDX-FileCopyrightText: 2022 VMware Inc
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
+# SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
 

--- a/repository_service_tuf_worker/__init__.py
+++ b/repository_service_tuf_worker/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/__version__.py
+++ b/repository_service_tuf_worker/__version__.py
@@ -1,7 +1,8 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
 
-version = "0.9.0b1"
-copyright = "Copyright (c) 2022-2023 VMware Inc"
+version = "0.10.0b1"
+copyright = "Copyright (c) 2023 Repository Service for TUF Contributors"
 author = "Kairo de Araujo"

--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/models/__init__.py
+++ b/repository_service_tuf_worker/models/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/models/targets/__init__.py
+++ b/repository_service_tuf_worker/models/targets/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/models/targets/crud.py
+++ b/repository_service_tuf_worker/models/targets/crud.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/models/targets/models.py
+++ b/repository_service_tuf_worker/models/targets/models.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/models/targets/schemas.py
+++ b/repository_service_tuf_worker/models/targets/schemas.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/services/__init__.py
+++ b/repository_service_tuf_worker/services/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/services/keyvault/__init__.py
+++ b/repository_service_tuf_worker/services/keyvault/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/services/keyvault/local.py
+++ b/repository_service_tuf_worker/services/keyvault/local.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/services/storage/__init__.py
+++ b/repository_service_tuf_worker/services/storage/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/services/storage/awss3.py
+++ b/repository_service_tuf_worker/services/storage/awss3.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/repository_service_tuf_worker/services/storage/local.py
+++ b/repository_service_tuf_worker/services/storage/local.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,10 @@
 # SPDX-License-Identifier: MIT
 
 from setuptools import find_packages, setup
-from repository_service_tuf_worker.__version__ import version
 
 setup(
     name="repository-service-tuf-worker",
-    version=version,
+    version="0.0.1",
     url="https://github.com/repository-service-tuf/repository-service-tuf-worker",  # noqa
     author="Kairo de Araujo",
     author_email="kairo@dearaujo.nl",

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
 
 from setuptools import find_packages, setup
+from repository_service_tuf_worker.__version__ import version
 
 setup(
     name="repository-service-tuf-worker",
-    version="0.0.1",
+    version=version,
     url="https://github.com/repository-service-tuf/repository-service-tuf-worker",  # noqa
     author="Kairo de Araujo",
     author_email="kairo@dearaujo.nl",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/tuf_repository_service_worker/__init__.py
+++ b/tests/unit/tuf_repository_service_worker/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
+++ b/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/tuf_repository_service_worker/services/__init__.py
+++ b/tests/unit/tuf_repository_service_worker/services/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/tuf_repository_service_worker/services/keyvault/__init__.py
+++ b/tests/unit/tuf_repository_service_worker/services/keyvault/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/keyvault/test_local.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/tuf_repository_service_worker/services/storage/__init__.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/tuf_repository_service_worker/test__init__.py
+++ b/tests/unit/tuf_repository_service_worker/test__init__.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT


### PR DESCRIPTION
- Update the Copyright as project is now part of OpenSSF
- Make the setup.py version dynamic. (Note: we don't release it as a python package, but we use it in tox. In the future it could be used as well)
- Bump release to v0.10.0b1