### PR TITLE
Refactor update_snapshot & _run_online_roles_bump

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -331,6 +331,9 @@ class MetadataRepository:
                     version=bins_md.signed.version
                 )
 
+            bins = "".join(target_roles)
+            logging.info(f"Bumped all expired target 'bin' roles: {bins}")
+
         elif bump_all:
             db_target_roles = targets_crud.read_all_roles(self._db)
             for db_role in db_target_roles:
@@ -345,6 +348,7 @@ class MetadataRepository:
                 snapshot.signed.meta[f"{rolename}.json"] = MetaFile(
                     version=bins_md.signed.version
                 )
+            logging.info("Bumped all target 'bin' roles")
 
         if len(db_target_roles) > 0:
             targets_crud.update_roles_version(
@@ -358,6 +362,7 @@ class MetadataRepository:
 
         # update expiry, bump version and persist to the storage
         self._bump_and_persist(snapshot, Snapshot.type)
+        logging.info("Bumped version of 'Snapshot' role")
 
         return snapshot.signed.version
 
@@ -1260,7 +1265,7 @@ class MetadataRepository:
                 False,
                 {
                     "message": "Metadata Update Failed",
-                    "error": "Metadata Update requires a complete bootstrap",
+                    "error": "Metadata Update requires a completed bootstrap",
                 },
             )
 

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1059,8 +1059,8 @@ class MetadataRepository:
             return False
 
         if (snapshot.signed.expires - datetime.now()) < timedelta(
-            hours=self._hours_before_expire or force is True
-        ):
+            hours=self._hours_before_expire
+        ) or force:
             timestamp = self._update_timestamp(self._update_snapshot())
             logging.info(
                 "[scheduled snapshot bump] Snapshot version bumped: "

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -17,10 +17,7 @@ from celery.app.task import Task
 from celery.exceptions import ChordError
 from celery.result import AsyncResult, states
 from dynaconf.loaders import redis_loader
-from securesystemslib.exceptions import (  # type: ignore
-    StorageError,
-    UnverifiedSignatureError,
-)
+from securesystemslib.exceptions import UnverifiedSignatureError
 from securesystemslib.signer import Signature, SSlibKey
 from tuf.api.exceptions import (
     BadVersionNumberError,
@@ -960,7 +957,7 @@ class MetadataRepository:
             },
         )
 
-    def _run_online_roles_bump(self, force: Optional[bool] = False) -> bool:
+    def _run_online_roles_bump(self, force: Optional[bool] = False):
         """
         Bumps version and expiration date of all online roles (`Targets`,
         `Succinct Delegated` targets roles, `Timestamp` and `Snapshot`).
@@ -975,12 +972,7 @@ class MetadataRepository:
             force: force all target roles bump even if they have more than
             `self._hours_before_expire` hours to expire.
         """
-        try:
-            targets: Metadata = self._storage_backend.get(Targets.type)
-        except StorageError:
-            logging.error(f"{Targets.type} not found, not bumping.")
-            return False
-
+        targets: Metadata = self._storage_backend.get(Targets.type)
         timestamp: Metadata
         snapshot_bump = False
         if self._settings.get_fresh("TARGETS_ONLINE_KEY") is None:
@@ -1040,9 +1032,7 @@ class MetadataRepository:
                 f"[scheduled bump] Timestamp version bumped: {timestamp_v}"
             )
 
-        return True
-
-    def bump_snapshot(self, force: Optional[bool] = False) -> bool:
+    def bump_snapshot(self, force: Optional[bool] = False):
         """
         Bumps version and expiration date of TUF 'snapshot' role metadata.
 
@@ -1057,12 +1047,7 @@ class MetadataRepository:
                 expire (`self._hours_before_expire`)
         """
 
-        try:
-            snapshot = self._storage_backend.get(Snapshot.type)
-        except StorageError:
-            logging.error(f"{Snapshot.type} not found, not bumping.")
-            return False
-
+        snapshot = self._storage_backend.get(Snapshot.type)
         if (snapshot.signed.expires - datetime.now()) < timedelta(
             hours=self._hours_before_expire
         ) or force:
@@ -1083,8 +1068,6 @@ class MetadataRepository:
                 f"{snapshot.signed.expires}. More than "
                 f"{self._hours_before_expire} hour, skipping"
             )
-
-        return True
 
     def bump_online_roles(self, force: Optional[bool] = False) -> bool:
         """

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1007,7 +1007,7 @@ class MetadataRepository:
             for bin in targets_succinct_roles.get_roles():
                 bin_role: Metadata[Targets] = self._storage_backend.get(bin)
                 if (bin_role.signed.expires - datetime.now()) < timedelta(
-                    hours=self._hours_before_expire or force is True
+                    hours=self._hours_before_expire
                 ):
                     bin_roles.append(bin)
 

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -2984,7 +2984,7 @@ class TestMetadataRepository:
             "last_update": mocked_datetime.now(),
             "details": {
                 "message": "Metadata Update Failed",
-                "error": "Metadata Update requires a complete bootstrap",
+                "error": "Metadata Update requires a completed bootstrap",
             },
         }
         assert test_repo._settings.get_fresh.calls == [


### PR DESCRIPTION
The goal of the "update_snapshot" refactoring is to:
1. make a better separation between the two usages of "update_snapshot"
- the first is to update snapshot and all roles that were given with the "targets_roles" argument
- the second is to update snapshot and ALL bin target roles In the end, I wanted to be able to call "update_snapshot" with "bump_all" without having to pass the "targets_roles" argument.
2. fix a bug where when calling "update_snapshot" the resulting new snapshot meta didn't contain updated information for targets.json This resulted in a bug that when calling "_run_online_roles_bump", which updated targets.json, we saved the new targets.json, but the new snapshot.json didn't reference it.

The second part of this refactoring is about "_run_online_roles_bump". Again there were two goals of this refactoring:
1. make sure we call "update_snapshot" correctly. This means when we force an update of all target bins we shouldn't also pass the "targets_roles" list.
2. make it clearer how we use the "force" argument:
- when "force = True" we force a bump of all bins and targets.json
- when "force = False" we bump only those bins and targets.json which have expired.

Finally, I did some small tweaks on our tests with the idea to improve our asserts and checks.

Besides unit tests, it was tested locally with a worker instance and triggered the automatic online roles bump.

Signed-off-by: Martin Vrachev <martin.vrachev@broadcom.com>