### PR TITLE
Split test running in CI

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -51,6 +51,9 @@ jobs:
   functional-das:
     name: "DAS"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pytest-group: [ "1", "2", "3"]
 
     steps:
       - name: Checkout RSTUF Worker source code
@@ -72,10 +75,65 @@ jobs:
 
       - name: Bootstrap/Setup RSTUF DAS and run Functional Tests
         run: |
-          make ft-das CLI_VERSION=${{ inputs.cli_version }}
+          make ft-das CLI_VERSION=${{ inputs.cli_version }} PYTEST_GROUP=${{ matrix.pytest-group }}
+
+  functional-das-slow:
+    name: "DAS Slow"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout RSTUF Worker source code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Checkout RSTUF Umbrella (FT)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+            repository: repository-service-tuf/repository-service-tuf
+            path: rstuf-umbrella
+            ref: ${{ inputs.umbrella_branch }}
+
+      - name: Deploy RSTUF with Worker container from source code
+        uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf
+        with:
+          compose-file: ${{ inputs.docker_compose }}
+        env:
+          API_VERSION: ${{ inputs.api_version }}
+
+      - name: Bootstrap/Setup RSTUF DAS and run Functional Tests
+        run: |
+          make ft-das CLI_VERSION=${{ inputs.cli_version }} PYTEST_GROUP=none SLOW="yes"
 
   functional-signed:
     name: "Signed"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pytest-group: [ "1", "2", "3"]
+
+    steps:
+      - name: Checkout RSTUF Worker source code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Checkout RSTUF Umbrella (FT)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          repository: repository-service-tuf/repository-service-tuf
+          path: rstuf-umbrella
+          ref: ${{ inputs.umbrella_branch }}
+
+      - name: Deploy RSTUF with Worker container from source code
+        uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf
+        with:
+          compose-file: ${{ inputs.docker_compose }}
+        env:
+          API_VERSION: ${{ inputs.api_version }}
+
+      - name: Bootstrap/Setup RSTUF full Signed and run Functional Tests
+        run: |
+          make ft-signed CLI_VERSION=${{ inputs.cli_version }} PYTEST_GROUP=${{ matrix.pytest-group }}
+
+  functional-signed-slow:
+    name: "Signed Slow"
     runs-on: ubuntu-latest
 
     steps:
@@ -98,4 +156,4 @@ jobs:
 
       - name: Bootstrap/Setup RSTUF full Signed and run Functional Tests
         run: |
-          make ft-signed CLI_VERSION=${{ inputs.cli_version }}
+          make ft-signed CLI_VERSION=${{ inputs.cli_version }} PYTEST_GROUP=none SLOW="yes"

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,11 @@ ft-das:
 ifeq ($(GITHUB_ACTION),)
 	$(MAKE) clone-umbrella
 endif
-	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash tests/functional/scripts/run-ft-das.sh $(CLI_VERSION)' --rm repository-service-tuf-worker
+	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash tests/functional/scripts/run-ft-das.sh $(CLI_VERSION) $(PYTEST_GROUP) $(SLOW)' --rm repository-service-tuf-worker
 
 ft-signed:
 # Use "GITHUB_ACTION" to identify if we are running from a GitHub action.
 ifeq ($(GITHUB_ACTION),)
 	$(MAKE) clone-umbrella
 endif
-	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash tests/functional/scripts/run-ft-signed.sh $(CLI_VERSION)' --rm repository-service-tuf-worker
+	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash tests/functional/scripts/run-ft-signed.sh $(CLI_VERSION) $(PYTEST_GROUP) $(SLOW)' --rm repository-service-tuf-worker

--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -x
 
 CLI_VERSION=$1
+PYTEST_GROUP=$2
+SLOW=$3
 # Install required dependencies for Functional Tests
 apt update
 apt install -y make wget git curl
@@ -116,5 +118,5 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py 
 
 cp ./metadata-update-payload.json ${UMBRELLA_PATH}
 
-make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst
+make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst PYTEST_GROUP=${PYTEST_GROUP} SLOW=${SLOW}
 

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -x
 
 CLI_VERSION=$1
+PYTEST_GROUP=$2
+SLOW=$3
 # Install required dependencies for Functional Tests
 apt update
 apt install -y make wget git curl
@@ -98,5 +100,5 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py 
 
 cp ./metadata-update-payload.json ${UMBRELLA_PATH}
 
-make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst
+make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst PYTEST_GROUP=${PYTEST_GROUP} SLOW=${SLOW}
 


### PR DESCRIPTION
- Split (fast) tests into 3 jobs
- Put slow tests in a separate job. If we start storing the test durations
we won't need to do that probably.

Related to https://github.com/repository-service-tuf/repository-service-tuf/pull/603