### PR TITLE
Do not require key vault at start up time

### DIFF
--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -175,13 +175,16 @@ storage service (`RSTUF_STORAGE_BACKEND`).
 
 In most use cases, the timeout of 60.0 seconds is sufficient.
 
-#### (Required) `RSTUF_KEYVAULT_BACKEND`
+#### `RSTUF_KEYVAULT_BACKEND`
 
-Select a supported type of Key Vault Service.
-
+Select a supported type of Key Vault Service. 
 Available types:
 
 * `LocalKeyVault` (container volume)
+
+**_NOTE:_** You can start the worker
+service without a keyvault backend, but you need to configure one before the 
+[bootstrap ceremony](https://repository-service-tuf.readthedocs.io/en/latest/guide/repository-service-tuf-cli/index.html#ceremony-ceremony).
 
 ##### `LocalKeyVault` (container volume)
 

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -519,12 +519,7 @@ class MetadataRepository:
         # sign, add to `Snapshot` meta and persist in the backend storage
         # service.
         for delegated_name in succinct_roles.get_roles():
-            targets.signed.add_key(
-                SSlibKey.from_securesystemslib_key(
-                    self._key_storage_backend.get(public_key).key_dict
-                ),
-                delegated_name,
-            )
+            targets.signed.add_key(public_key, delegated_name)
             bins_role = Metadata(Targets())
             self._bump_expiry(bins_role, BINS)
             self._sign(bins_role)

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -161,7 +161,8 @@ class MetadataRepository:
         IStorage.from_dynaconf(settings)
 
         # keyvault
-        IKeyVault.from_dynaconf(settings)
+        if settings.get("KEYVAULT_BACKEND"):
+            IKeyVault.from_dynaconf(settings)
 
         self._worker_settings = settings
         return settings

--- a/repository_service_tuf_worker/signer.py
+++ b/repository_service_tuf_worker/signer.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024 Repository Service for TUF Contributors
+#
+# SPDX-License-Identifier: MIT
+
+from dynaconf import Dynaconf
+from securesystemslib.signer import Key, Signer
+
+
+class SignerStore:
+    """Generic signer store."""
+
+    def __init__(self, settings: Dynaconf):
+        self._settings = settings
+        self._signers: dict[str, Signer] = {}
+
+    def get(self, key: Key) -> Signer:
+        """Return signer for passed key."""
+
+        if key.keyid not in self._signers:
+            self._signers[key.keyid] = self._settings.KEYVAULT.get(key)
+
+        return self._signers[key.keyid]

--- a/repository_service_tuf_worker/signer.py
+++ b/repository_service_tuf_worker/signer.py
@@ -5,6 +5,8 @@
 from dynaconf import Dynaconf
 from securesystemslib.signer import Key, Signer
 
+from repository_service_tuf_worker.interfaces import IKeyVault
+
 
 class SignerStore:
     """Generic signer store."""
@@ -17,6 +19,12 @@ class SignerStore:
         """Return signer for passed key."""
 
         if key.keyid not in self._signers:
-            self._signers[key.keyid] = self._settings.KEYVAULT.get(key)
+            vault = self._settings.get("KEYVAULT")
+            if not isinstance(vault, IKeyVault):
+                raise ValueError(
+                    "RSTUF_KEYVAULT_BACKEND is required for online signing"
+                )
+
+            self._signers[key.keyid] = vault.get(key)
 
         return self._signers[key.keyid]

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -34,6 +34,16 @@ class TestMetadataRepository:
         test_repo = repository.MetadataRepository()
         assert isinstance(test_repo, repository.MetadataRepository) is True
 
+    def test_init_with_no_keyvault(self, monkeypatch):
+        settings = repository.get_worker_settings()
+        del settings.KEYVAULT_BACKEND
+
+        monkeypatch.setattr(
+            repository, "get_worker_settings", lambda: settings
+        )
+        test_repo = repository.MetadataRepository()
+        assert "KEYVAULT" not in test_repo.refresh_settings()
+
     def test_create_service(self, test_repo):
         assert isinstance(test_repo, repository.MetadataRepository) is True
 

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -174,14 +174,14 @@ class TestMetadataRepository:
         test_repo._storage_backend = pretend.stub(
             get=pretend.call_recorder(lambda *a: fake_md)
         )
-        test_repo._key_storage_backend = pretend.stub(
+        test_repo._signer_store = pretend.stub(
             get=pretend.call_recorder(lambda *a: "key_signer_1")
         )
 
         test_result = test_repo._sign(fake_md)
 
         assert test_result is None
-        assert test_repo._key_storage_backend.get.calls == [pretend.call({})]
+        assert test_repo._signer_store.get.calls == [pretend.call({})]
         assert fake_md.signatures.clear.calls == [pretend.call()]
         assert test_repo._storage_backend.get.calls == [pretend.call("root")]
         assert fake_md.sign.calls == [

--- a/tests/unit/tuf_repository_service_worker/test_signer.py
+++ b/tests/unit/tuf_repository_service_worker/test_signer.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2024 Repository Service for TUF Contributors
+#
+# SPDX-License-Identifier: MIT
+
+import pytest
+from pretend import stub
+
+from repository_service_tuf_worker.interfaces import IKeyVault
+from repository_service_tuf_worker.signer import SignerStore
+
+
+class TestSigner:
+    def test_get_cached(self):
+        fake_id = "fake_id"
+        fake_signer = stub()
+        fake_key = stub(keyid=fake_id)
+        fake_settings = stub()
+
+        store = SignerStore(fake_settings)
+        store._signers[fake_id] = fake_signer
+
+        assert store.get(fake_key) == fake_signer
+
+    def test_get_load_and_cache(self):
+        class FakeKeyVault(IKeyVault):
+            @classmethod
+            def configure(cls, settings):
+                pass
+
+            @classmethod
+            def settings(cls):
+                pass
+
+            def get(self, public_key):
+                return fake_signer
+
+        fake_id = "fake_id"
+        fake_signer = stub()
+        fake_key = stub(keyid=fake_id)
+        fake_settings = stub(get=lambda x: FakeKeyVault())
+
+        store = SignerStore(fake_settings)
+
+        assert not store._signers
+        assert store.get(fake_key) == fake_signer
+        assert fake_id in store._signers
+
+    def test_get_no_vault(self):
+        fake_id = "fake_id"
+        fake_key = stub(keyid=fake_id)
+        fake_settings = stub(get=lambda x: None)
+
+        store = SignerStore(fake_settings)
+
+        with pytest.raises(ValueError):
+            store.get(fake_key)


### PR DESCRIPTION
This PR allows starting the worker without key vault configuration. Unlike a previous attempt (#441), it does not change any specific key vault initialisation code, but instead skips key vault initialisation altogether, if the configuration is not provided.

In addition, the repository is updated to retrieve signers from a newly added signer store, instead of calling the key vault directly. Under the hood, the signer store does use the existing key vault, but only when needed. Moreover, this design makes it easier to provide a meaningful error message about missing config, again, only when needed.

Also note that in the future the signer store can easily be extended to fetch signers from other locations, e.g. URIs provided via public key metadata.

See commits for details!
