### PR TITLE
Add FileNameSigner and register in SignerStore

### DIFF
--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -234,10 +234,7 @@ service without a keyvault backend, but you need to configure one before the
 
 #### (Optional, *experimental*) `RSTUF_ONLINE_KEY_DIR`
 
-Directory path to online signing key. The setting is required, if the related
-public key metadata includes a field `x-rstuf-online-key-uri` with a value
-`fn:<file name>`. The full path is constructed by joining directory path
-and file name. The expected private key file format is unencrypted PKCS8/PEM.
+Directory path for online signing key file. Expected file format is unencrypted PKCS8/PEM.
 
 Make sure to use the secrets management service of your deployment platform to
 protect the private key!
@@ -245,21 +242,8 @@ protect the private key!
 Replaces `RSTUF_KEYVAULT_BACKEND` and related settings.
 
 Example:
--  `RSTUF_ONLINE_KEY_DIR=/run/secrets`
-- TUF root metadata (part):
-  ```
-  "keys": {
-   "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc": {
-    "keytype": "ed25519",
-    "keyval": {
-     "public": "4f66dabebcf30628963786001984c0b75c175cdcf3bc4855933a2628f0cd0a0f"
-    },
-    "scheme": "ed25519",
-    "x-rstuf-online-key-uri": "fn:my_online_key"
-   }
-   ...
-  }
-- RSTUF worker expects related private key under  `/run/secrets/my_online_key`
+- `RSTUF_ONLINE_KEY_DIR=/run/secrets`
+- RSTUF worker expects related private key under  `/run/secrets/<file name>`
 
 
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -232,6 +232,37 @@ service without a keyvault backend, but you need to configure one before the
 
   Example: ``RSTUF_LOCAL_KEYVAULT_KEYS=/run/secrets/ONLINE_KEY_1:/run/secrets/ONLINE_KEY_2``
 
+#### (Optional, *experimental*) `RSTUF_ONLINE_KEY_DIR`
+
+Directory path to online signing key. The setting is required, if the related
+public key metadata includes a field `x-rstuf-online-key-uri` with a value
+`fn:<file name>`. The full path is constructed by joining directory path
+and file name. The expected private key file format is unencrypted PKCS8/PEM.
+
+Make sure to use the secrets management service of your deployment platform to
+protect the private key!
+
+Replaces `RSTUF_KEYVAULT_BACKEND` and related settings.
+
+Example:
+-  `RSTUF_ONLINE_KEY_DIR=/run/secrets`
+- TUF root metadata (part):
+  ```
+  "keys": {
+   "c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc": {
+    "keytype": "ed25519",
+    "keyval": {
+     "public": "4f66dabebcf30628963786001984c0b75c175cdcf3bc4855933a2628f0cd0a0f"
+    },
+    "scheme": "ed25519",
+    "x-rstuf-online-key-uri": "fn:my_online_key"
+   }
+   ...
+  }
+- RSTUF worker expects related private key under  `/run/secrets/my_online_key`
+
+
+
 
 #### (Optional) `RSTUF_WORKER_ID`
 

--- a/repository_service_tuf_worker/signer.py
+++ b/repository_service_tuf_worker/signer.py
@@ -24,7 +24,7 @@ class FileNameSigner(CryptoSigner):
 
     Provide method to load **unencrypted** PKCS8/PEM private key from file.
 
-    File path is constructed by joining base path in envrionment variable
+    File path is constructed by joining base path in environment variable
     ``RSTUF_ONLINE_KEY_DIR`` with file in ``priv_key_uri``.
 
     NOTE: Make sure to use the secrets management service of your deployment
@@ -40,7 +40,7 @@ class FileNameSigner(CryptoSigner):
     Raises:
         KeyError: RSTUF_ONLINE_KEY_DIR environment variable not set
         OSError: file cannot be loaded
-        ValueError: uri has no filenmae, or private key cannot be decoded,
+        ValueError: uri has no file name, or private key cannot be decoded,
                 or type does not match public key
         cryptography.exceptions.UnsupportedAlgorithm: key type not supported
 

--- a/repository_service_tuf_worker/signer.py
+++ b/repository_service_tuf_worker/signer.py
@@ -1,22 +1,83 @@
 # SPDX-FileCopyrightText: 2024 Repository Service for TUF Contributors
 #
 # SPDX-License-Identifier: MIT
+import os
+from pathlib import Path
+from typing import Optional
 
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from dynaconf import Dynaconf
 from securesystemslib.signer import (
     SIGNER_FOR_URI_SCHEME,
     CryptoSigner,
     Key,
+    SecretsHandler,
     Signer,
 )
 
 from repository_service_tuf_worker.interfaces import IKeyVault
+
+
+class FileNameSigner(CryptoSigner):
+    """File-based signer implementation.
+
+    Provide method to load **unencrypted** PKCS8/PEM private key from file.
+
+    File path is constructed by joining base path in envrionment variable
+    ``RSTUF_ONLINE_KEY_DIR`` with file in ``priv_key_uri``.
+
+    NOTE: Make sure to use the secrets management service of your deployment
+    platform to protect your private key!
+
+    Example::
+
+        RSTUF_ONLINE_KEY_DIR (env) "/run/secrets"
+        priv_key_uri (arg): "fn:foo"
+
+        File path: "/run/secrets/foo"
+
+    Raises:
+        KeyError: RSTUF_ONLINE_KEY_DIR environment variable not set
+        OSError: file cannot be loaded
+        ValueError: uri has no filenmae, or private key cannot be decoded,
+                or type does not match public key
+        cryptography.exceptions.UnsupportedAlgorithm: key type not supported
+
+    """
+
+    SCHEME = "fn"
+    DIR_VAR = "RSTUF_ONLINE_KEY_DIR"
+
+    @classmethod
+    def from_priv_key_uri(
+        cls,
+        priv_key_uri: str,
+        public_key: Key,
+        secrets_handler: Optional[SecretsHandler] = None,
+    ) -> "FileNameSigner":
+        _, _, file_name = priv_key_uri.partition(":")
+        if not file_name:
+            raise ValueError(
+                f"bad uri: expected '{cls.SCHEME}:<file name>', "
+                f"'got {priv_key_uri}'"
+            )
+
+        dir_ = os.environ[cls.DIR_VAR]
+
+        with open(Path(dir_, file_name), "rb") as f:
+            private_pem = f.read()
+
+        private_key = load_pem_private_key(private_pem, None)
+        return cls(private_key, public_key)
+
 
 RSTUF_ONLINE_KEY_URI_FIELD = "x-rstuf-online-key-uri"
 
 # Register non-default securesystemslib file signer
 # secure-systems-lab/securesystemslib#617
 SIGNER_FOR_URI_SCHEME[CryptoSigner.FILE_URI_SCHEME] = CryptoSigner
+# Register custom FileNameSigner
+SIGNER_FOR_URI_SCHEME[FileNameSigner.SCHEME] = FileNameSigner
 
 
 class SignerStore:

--- a/tests/unit/tuf_repository_service_worker/test_signer.py
+++ b/tests/unit/tuf_repository_service_worker/test_signer.py
@@ -17,6 +17,20 @@ from repository_service_tuf_worker.signer import (
 _FILES = Path(__file__).parent.parent.parent / "files"
 
 
+@pytest.fixture()
+def key_metadata():
+    return {
+        "keytype": "ed25519",
+        "scheme": "ed25519",
+        "keyval": {
+            "public": (
+                "4f66dabebcf30628963786001984c0b7"
+                "5c175cdcf3bc4855933a2628f0cd0a0f"
+            )
+        },
+    }
+
+
 class TestSigner:
     def test_get_cached(self):
         fake_id = "fake_id"
@@ -63,21 +77,10 @@ class TestSigner:
         with pytest.raises(ValueError):
             store.get(fake_key)
 
-    def test_get_from_file_uri(self):
+    def test_get_from_file_uri(self, key_metadata):
         path = _FILES / "pem" / "ed25519_private.pem"
         uri = f"file:{path}?encrypted=false"
-
-        key_metadata = {
-            "keytype": "ed25519",
-            "scheme": "ed25519",
-            "keyval": {
-                "public": (
-                    "4f66dabebcf30628963786001984c0b7"
-                    "5c175cdcf3bc4855933a2628f0cd0a0f"
-                )
-            },
-            RSTUF_ONLINE_KEY_URI_FIELD: uri,
-        }
+        key_metadata[RSTUF_ONLINE_KEY_URI_FIELD] = uri
 
         fake_id = "fake_id"
         key = Key.from_dict(fake_id, key_metadata)


### PR DESCRIPTION
The custom FileNameSigner is similar to the previously registered CryptoSigner provided by securesystemslib, with the following differences:

- uri format is `fn:<file name>`
- a base path for the key in `<file name>` must be provided via environment variable `RSTUF_ONLINE_KEY_DIR`
- only **unencrypted** keys are supported

supersedes #427 