### PR TITLE
Add support for custom delegated targets

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -573,7 +573,10 @@ class MetadataRepository:
     def _get_delegation_roles(
         self, targets: Metadata[Targets]
     ) -> Iterator[str]:
-        """Get all Targets delegation roles no matter if bins or custom."""
+        """Get all Targets delegation roles no matter if bins or custom.
+
+        Raises ValueError if targets.signed.delegation is not initialized.
+        """
         if targets.signed.delegations is None:
             raise ValueError("Targets must have delegation, internal error")
 

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -320,9 +320,11 @@ class MetadataRepository:
                     # one target file with action "REMOVE" and the CRUD
                     # will return None for this specific role.
                 }
-                deleg_name = BINS if bins_used else rolename
+                delegation_name = BINS if bins_used else rolename
                 # update expiry, bump version and persist to the storage
-                self._bump_and_persist(delegation, deleg_name, persist=False)
+                self._bump_and_persist(
+                    delegation, delegation_name, persist=False
+                )
                 self._persist(delegation, rolename)
                 # update targetfile in db
                 # note: It update only if is not published see the CRUD.
@@ -345,9 +347,11 @@ class MetadataRepository:
                 delegation: Metadata[Targets] = self._storage_backend.get(
                     db_role.rolename
                 )
-                deleg_name = BINS if bins_used else rolename
+                delegation_name = BINS if bins_used else rolename
                 # update expiry, bump version and persist to the storage
-                self._bump_and_persist(delegation, deleg_name, persist=False)
+                self._bump_and_persist(
+                    delegation, delegation_name, persist=False
+                )
                 self._persist(delegation, db_role.rolename)
 
                 snapshot.signed.meta[f"{rolename}.json"] = MetaFile(

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -291,10 +291,14 @@ class MetadataRepository:
         Args:
             target_roles: List of roles to bump. If provided, 'bump_all' arg
                 will NOT be taken into account.
-            bump_all: Wheter to bump all bin target roles. If provided, then
-                'target_roles' arg is NOT taken into acount.
+            bump_all: Wheter to bump all delegated target roles. If provided,
+                then 'target_roles' arg is NOT taken into acount.
         """
         snapshot: Metadata[Snapshot] = self._storage_backend.get(Snapshot.type)
+        targets: Metadata[Targets] = self._storage_backend.get(Targets.type)
+        bins_used = (
+            True if targets.signed.delegations.succinct_roles else False
+        )
 
         db_target_roles: List[targets_models.RSTUFTargetRoles] = []
         if target_roles:
@@ -304,11 +308,11 @@ class MetadataRepository:
 
             for db_role in db_target_roles:
                 rolename = db_role.rolename
-                bins_md: Metadata[Targets] = self._storage_backend.get(
+                delegation: Metadata[Targets] = self._storage_backend.get(
                     rolename
                 )
-                bins_md.signed.targets.clear()
-                bins_md.signed.targets = {
+                delegation.signed.targets.clear()
+                delegation.signed.targets = {
                     file.path: TargetFile.from_dict(file.info, file.path)
                     for file in db_role.target_files
                     if file.action == targets_schema.TargetAction.ADD
@@ -320,10 +324,10 @@ class MetadataRepository:
                     # one target file with action "REMOVE" and the CRUD
                     # will return None for this specific role.
                 }
-
+                deleg_name = BINS if bins_used else rolename
                 # update expiry, bump version and persist to the storage
-                self._bump_and_persist(bins_md, BINS, persist=False)
-                self._persist(bins_md, rolename)
+                self._bump_and_persist(delegation, deleg_name, persist=False)
+                self._persist(delegation, rolename)
                 # update targetfile in db
                 # note: It update only if is not published see the CRUD.
                 targets_crud.update_files_to_published(
@@ -331,34 +335,36 @@ class MetadataRepository:
                 )
 
                 snapshot.signed.meta[f"{rolename}.json"] = MetaFile(
-                    version=bins_md.signed.version
+                    version=delegation.signed.version
                 )
 
-            bins = "".join(target_roles)
-            logging.info(f"Bumped all expired target 'bin' roles: {bins}")
+            roles = "".join(target_roles)
+            msg = f"Bumped all expired target delegation roles: {roles}"
+            logging.info(msg)
 
         elif bump_all:
             db_target_roles = targets_crud.read_all_roles(self._db)
             for db_role in db_target_roles:
                 rolename = db_role.rolename
-                bins_md: Metadata[Targets] = self._storage_backend.get(
+                delegation: Metadata[Targets] = self._storage_backend.get(
                     db_role.rolename
                 )
+                deleg_name = BINS if bins_used else rolename
                 # update expiry, bump version and persist to the storage
-                self._bump_and_persist(bins_md, BINS, persist=False)
-                self._persist(bins_md, db_role.rolename)
+                self._bump_and_persist(delegation, deleg_name, persist=False)
+                self._persist(delegation, db_role.rolename)
 
                 snapshot.signed.meta[f"{rolename}.json"] = MetaFile(
-                    version=bins_md.signed.version
+                    version=delegation.signed.version
                 )
-            logging.info("Bumped all target 'bin' roles")
+
+            logging.info("Bumped all target delegation roles")
 
         if len(db_target_roles) > 0:
             targets_crud.update_roles_version(
                 self._db, [int(db_role.id) for db_role in db_target_roles]
             )
 
-        targets: Metadata[Targets] = self._storage_backend.get(Targets.type)
         snapshot.signed.meta[f"{Targets.type}.json"] = MetaFile(
             version=targets.signed.version
         )
@@ -889,7 +895,7 @@ class MetadataRepository:
             )
         # The task id will be used by `_send_publish_targets_task` (sub-task).
         task_id = payload.get("task_id")
-        # Group target files by responsible 'bins' delegated roles.
+        # Group target files by responsible delegated role.
         # This will be used to by `_update_task` for updating task status.
         bin_targets: Dict[str, List[targets_models.RSTUFTargetFiles]] = {}
         for target in targets:
@@ -974,7 +980,7 @@ class MetadataRepository:
         deleted_targets: List[str] = []
         not_found_targets: List[str] = []
 
-        # Group target files by responsible 'bins' delegated roles.
+        # Group target files by responsible delegated role.
         # This will be used to by `publish_targets`
         bin_targets: Dict[str, List[targets_models.RSTUFTargetFiles]] = {}
         for target in targets:
@@ -1057,33 +1063,32 @@ class MetadataRepository:
                 snapshot_bump = True
 
         if force:
-            # Updating all bin target roles.
+            # Updating all delegated target roles.
             timestamp = self._update_timestamp(
                 self._update_snapshot(bump_all=True)
             )
             snapshot_bump = True
             logging.info("Targets and delegated Targets roles version bumped")
         else:
-            # Updating only those bins that have expired.
-            bin_roles: List[str] = []
-            targets_succinct_roles = targets.signed.delegations.succinct_roles
-            for bin in targets_succinct_roles.get_roles():
-                bin_role: Metadata[Targets] = self._storage_backend.get(bin)
-                if (bin_role.signed.expires - datetime.now()) < timedelta(
+            # Updating only those delegated roles that have expired.
+            delegated_roles: List[str] = []
+            for role in self._get_delegation_roles(targets):
+                role_md: Metadata[Targets] = self._storage_backend.get(role)
+                if (role_md.signed.expires - datetime.now()) < timedelta(
                     hours=self._hours_before_expire
                 ):
-                    bin_roles.append(bin)
+                    delegated_roles.append(role)
 
-            if len(bin_roles) > 0:
+            if len(delegated_roles) > 0:
                 timestamp = self._update_timestamp(
-                    self._update_snapshot(target_roles=bin_roles)
+                    self._update_snapshot(target_roles=delegated_roles)
                 )
                 snapshot_bump = True
-                bins = "".join(bin_roles)
-                logging.info(f"Bumped versions of expired bin roles: {bins}")
+                roles = "".join(delegated_roles)
+                logging.info(f"Bumped versions of expired roles: {roles}")
             else:
                 logging.debug(
-                    "[scheduled bump] All bin roles have more than "
+                    "[scheduled bump] All delegated roles have more than "
                     f"{self._hours_before_expire} hour(s) to expire, "
                     "skipping"
                 )
@@ -1137,7 +1142,7 @@ class MetadataRepository:
 
     def bump_online_roles(self, force: Optional[bool] = False) -> bool:
         """
-        Bump online roles (Snapshot, Timestamp, Targets and BINS).
+        Bump online roles (Snapshot, Timestamp, Targets and delegated roles).
 
         Args:
             force: force target roles bump if they don't match the hours before
@@ -1164,8 +1169,8 @@ class MetadataRepository:
             # the error because another task didn't lock it.
             if status_lock_targets is False:
                 logging.error(
-                    "The task to bump Timestamp, Snapshot, and BINS exceeded "
-                    f"the timeout of {self._timeout} seconds."
+                    "The task to bump all online roles exceeded the timeout "
+                    f"of {self._timeout} seconds."
                 )
                 raise redis.exceptions.LockError(
                     f"RSTUF: Task exceed `LOCK_TIMEOUT` ({self._timeout} "

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -710,7 +710,7 @@ class MetadataRepository:
 
         custom_targets = tuf_settings["roles"].get("delegated_roles")
         if custom_targets:
-            if tuf_settings["services"].get("number_of_delegated_bins"):
+            if tuf_settings["roles"].get("bins"):
                 return self._task_result(
                     TaskName.BOOTSTRAP,
                     message="Bootstrap Failed",

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -522,6 +522,7 @@ class MetadataRepository:
 
         else:
             delegated_roles = roles_info["delegated_roles"]
+            self.write_repository_settings("DELEGATED_ROLES", delegated_roles)
             for deleg_name, deleg_info in delegated_roles.items():
                 name = deleg_name.upper()
                 self.write_repository_settings(
@@ -654,15 +655,16 @@ class MetadataRepository:
         )
         return asdict(result)
 
-    def _bootstrap_finalize(
-        self, root: Metadata[Root], task_id: str, roles_info: Dict[str, Any]
-    ):
+    def _bootstrap_finalize(self, root: Metadata[Root], task_id: str):
         """
         Register the bootstrap finished.
         """
+        delegated_roles: Dict[str, Any] = self._settings.get_fresh(
+            "DELEGATED_ROLES"
+        )
         self._persist(root, Root.type)
         self.write_repository_settings("ROOT_SIGNING", None)
-        self._bootstrap_online_roles(root, roles_info.get("delegated_roles"))
+        self._bootstrap_online_roles(root, delegated_roles)
         self.write_repository_settings("BOOTSTRAP", task_id)
 
     def bootstrap(
@@ -740,7 +742,7 @@ class MetadataRepository:
 
         signed = self._validate_threshold(root)
         if signed:
-            self._bootstrap_finalize(root, task_id, roles_info)
+            self._bootstrap_finalize(root, task_id)
             message = f"Bootstrap finished {task_id}"
             logging.info(message)
         else:

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -837,7 +837,6 @@ class MetadataRepository:
         try:
             with self._redis.lock(LOCK_TARGETS, timeout=self._timeout):
                 # get all delegated role names with unpublished targets
-                delegated_targets = []
                 if payload is None or payload.get("delegated_targets") is None:
                     db_roles = targets_crud.read_roles_with_unpublished_files(
                         self._db
@@ -848,6 +847,10 @@ class MetadataRepository:
                         delegated_targets = [
                             targets_role[0] for targets_role in db_roles
                         ]
+                else:
+                    delegated_targets: List[str] = payload.get(
+                        "delegated_targets"
+                    )
 
                 if len(delegated_targets) == 0:
                     logging.debug(

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -985,7 +985,7 @@ class TestMetadataRepository:
         test_repo.write_repository_settings = pretend.call_recorder(
             lambda *a: None
         )
-        payload_settings = {
+        payload = {
             "roles": {
                 "root": {"expiration": 365},
                 "targets": {"expiration": 365},
@@ -1534,7 +1534,15 @@ class TestMetadataRepository:
         test_repo._bootstrap_finalize = pretend.call_recorder(lambda *a: None)
 
         payload = {
-            "settings": {"services": {"number_of_delegated_bins": 2}},
+            "settings": {
+                "roles": {
+                    "root": {"expiration": 365},
+                    "targets": {"expiration": 365},
+                    "snapshot": {"expiration": 1},
+                    "timestamp": {"expiration": 1},
+                    "bins": {"expiration": 30, "number_of_delegated_bins": 4},
+                }
+            },
             "metadata": {
                 "root": {"md_k1": "md_v1"},
             },
@@ -1607,7 +1615,15 @@ class TestMetadataRepository:
         )
 
         payload = {
-            "settings": {"services": {"number_of_delegated_bins": 2}},
+            "settings": {
+                "roles": {
+                    "root": {"expiration": 365},
+                    "targets": {"expiration": 365},
+                    "snapshot": {"expiration": 1},
+                    "timestamp": {"expiration": 1},
+                    "bins": {"expiration": 30, "number_of_delegated_bins": 4},
+                }
+            },
             "metadata": {
                 "root": {"md_k1": "md_v1"},
             },
@@ -1669,7 +1685,15 @@ class TestMetadataRepository:
         test_repo._validate_signature = pretend.call_recorder(lambda *a: False)
 
         payload = {
-            "settings": {"services": {"number_of_delegated_bins": 2}},
+            "settings": {
+                "roles": {
+                    "root": {"expiration": 365},
+                    "targets": {"expiration": 365},
+                    "snapshot": {"expiration": 1},
+                    "timestamp": {"expiration": 1},
+                    "bins": {"expiration": 30, "number_of_delegated_bins": 4},
+                }
+            },
             "metadata": {
                 "root": {"md_k1": "md_v1"},
             },
@@ -1719,10 +1743,23 @@ class TestMetadataRepository:
 
         payload = {
             "settings": {
-                "services": {"number_of_delegated_bins": 2},
-                "custom_targets": {
-                    "RSTUF": {"expiration": 30, "path_prefixes": "project/a"},
-                },
+                "roles": {
+                    "root": {"expiration": 365},
+                    "targets": {"expiration": 365},
+                    "snapshot": {"expiration": 1},
+                    "timestamp": {"expiration": 1},
+                    "bins": {"expiration": 30, "number_of_delegated_bins": 4},
+                    "delegated_roles": {
+                        "foo": {
+                            "expiration": 30,
+                            "path_patterns": ["project/f"],
+                        },
+                        "bar": {
+                            "expiration": 60,
+                            "path_patterns": ["project/b"],
+                        },
+                    },
+                }
             },
             "metadata": {
                 "root": {"md_k1": "md_v1"},
@@ -1793,7 +1830,15 @@ class TestMetadataRepository:
         )
 
         payload = {
-            "settings": {"services": {"number_of_delegated_bins": 2}},
+            "settings": {
+                "roles": {
+                    "root": {"expiration": 365},
+                    "targets": {"expiration": 365},
+                    "snapshot": {"expiration": 1},
+                    "timestamp": {"expiration": 1},
+                    "bins": {"expiration": 30, "number_of_delegated_bins": 4},
+                }
+            },
             "metadata": {
                 "root": {"md_k1": "md_v1"},
             },
@@ -1849,7 +1894,15 @@ class TestMetadataRepository:
         )
 
         payload = {
-            "settings": {"services": {"number_of_delegated_bins": 2}},
+            "settings": {
+                "roles": {
+                    "root": {"expiration": 365},
+                    "targets": {"expiration": 365},
+                    "snapshot": {"expiration": 1},
+                    "timestamp": {"expiration": 1},
+                    "bins": {"expiration": 30, "number_of_delegated_bins": 4},
+                }
+            },
             "metadata": {
                 "root": {"md_k1": "md_v1"},
             },

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -986,13 +986,11 @@ class TestMetadataRepository:
             lambda *a: None
         )
         payload = {
-            "roles": {
-                "root": {"expiration": 365},
-                "targets": {"expiration": 365},
-                "snapshot": {"expiration": 1},
-                "timestamp": {"expiration": 1},
-                "bins": {"expiration": 30, "number_of_delegated_bins": 4},
-            }
+            "root": {"expiration": 365},
+            "targets": {"expiration": 365},
+            "snapshot": {"expiration": 1},
+            "timestamp": {"expiration": 1},
+            "bins": {"expiration": 30, "number_of_delegated_bins": 4},
         }
 
         result = test_repo.save_settings(fake_root_md, payload)
@@ -1029,16 +1027,14 @@ class TestMetadataRepository:
             lambda *a: None
         )
         payload_settings = {
-            "roles": {
-                "root": {"expiration": 365},
-                "targets": {"expiration": 365},
-                "snapshot": {"expiration": 1},
-                "timestamp": {"expiration": 1},
-                "delegated_roles": {
-                    "foo": {"expiration": 30, "path_patterns": ["project/f"]},
-                    "bar": {"expiration": 60, "path_patterns": ["project/b"]},
-                },
-            }
+            "root": {"expiration": 365},
+            "targets": {"expiration": 365},
+            "snapshot": {"expiration": 1},
+            "timestamp": {"expiration": 1},
+            "delegated_roles": {
+                "foo": {"expiration": 30, "path_patterns": ["project/f"]},
+                "bar": {"expiration": 60, "path_patterns": ["project/b"]},
+            },
         }
 
         result = test_repo.save_settings(fake_root_md, payload_settings)
@@ -1086,8 +1082,8 @@ class TestMetadataRepository:
         )
 
         custom_targets = {
-            "role1": {"expiration": 30, "path_prefixes": "role1/"},
-            "role2": {"expiration": 300, "path_prefixes": "role2/"},
+            "role1": {"expiration": 30, "path_patterns": "role1/"},
+            "role2": {"expiration": 300, "path_patterns": "role2/"},
         }
 
         result = test_repo._setup_targets_delegations(
@@ -1482,10 +1478,9 @@ class TestMetadataRepository:
             lambda *a: None
         )
         fake_roles = pretend.stub(get=pretend.call_recorder(lambda a: None))
-        fake_settings = {"roles": fake_roles}
 
         result = test_repo._bootstrap_finalize(
-            "fake_root", "task_id", fake_settings
+            "fake_root", "task_id", fake_roles
         )
 
         assert result is None
@@ -1574,10 +1569,12 @@ class TestMetadataRepository:
             pretend.call(fake_root_md)
         ]
         assert test_repo.save_settings.calls == [
-            pretend.call(fake_root_md, payload["settings"])
+            pretend.call(fake_root_md, payload["settings"]["roles"])
         ]
         assert test_repo._bootstrap_finalize.calls == [
-            pretend.call(fake_root_md, payload["task_id"], payload["settings"])
+            pretend.call(
+                fake_root_md, payload["task_id"], payload["settings"]["roles"]
+            )
         ]
 
     def test_bootstrap_no_signatures(
@@ -1870,7 +1867,7 @@ class TestMetadataRepository:
             pretend.call(fake_root_md)
         ]
         assert test_repo.save_settings.calls == [
-            pretend.call(fake_root_md, payload["settings"])
+            pretend.call(fake_root_md, payload["settings"]["roles"])
         ]
         assert test_repo._bootstrap_finalize.calls == []
         assert test_repo.write_repository_settings.calls == [

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -995,7 +995,7 @@ class TestMetadataRepository:
             }
         }
 
-        result = test_repo.save_settings(fake_root_md, payload_settings)
+        result = test_repo.save_settings(fake_root_md, payload)
         assert result is None
         assert test_repo.write_repository_settings.calls == [
             pretend.call("ROOT_EXPIRATION", 365),
@@ -1205,6 +1205,16 @@ class TestMetadataRepository:
             test_result.append(role_name)
 
         assert test_result == expected_result
+
+    def test__get_delegation_roles_no_delegation(self, test_repo):
+        targets: Metadata[Targets] = Metadata(Targets())
+        result = []
+        with pytest.raises(ValueError) as e:
+            for delegated_role in test_repo._get_delegation_roles(targets):
+                result.append(delegated_role)
+
+        assert len(result) == 0
+        assert "Targets must have delegation, internal error" in str(e)
 
     def test__bootstrap_online_roles(self, test_repo, monkeypatch):
         fake_root_md = pretend.stub(

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -2006,7 +2006,7 @@ class TestMetadataRepository:
         ]
         assert test_repo._update_timestamp.calls == [pretend.call(3)]
 
-    def test_publish_targets_payload_bins_targets_empty(
+    def test_publish_targets_payload_delegated_targets_empty(
         self, test_repo, monkeypatch, mocked_datetime
     ):
         @contextmanager
@@ -2029,7 +2029,7 @@ class TestMetadataRepository:
         test_repo._update_snapshot = pretend.call_recorder(lambda *a: 3)
         test_repo._update_timestamp = pretend.call_recorder(lambda *a: None)
 
-        payload = {"bins_targets": None}
+        payload = {"delegated_targets": None}
         result = test_repo.publish_targets(payload)
 
         assert result == {


### PR DESCRIPTION
Fixes #438 

Add support for custom delegated targets which could be used by PyPI and other of our users.
This will allow for greater flexibility and we could support special use cases for bigger users.

Note: it's related to pr https://github.com/repository-service-tuf/repository-service-tuf-api/pull/542. When testing use both this and the API pr.