### PR TITLE
Force UTC timezone for all datetime objects

### DIFF
--- a/repository_service_tuf_worker/models/targets/crud.py
+++ b/repository_service_tuf_worker/models/targets/crud.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy.orm import Session
@@ -128,7 +128,7 @@ def update_file_path_and_info(
     target.published = False
     target.path = new_path
     target.info = new_info
-    target.last_update = datetime.now()
+    target.last_update = datetime.now(timezone.utc)
     db.add(target)
     db.commit()
     db.refresh(target)
@@ -147,7 +147,7 @@ def update_files_to_published(db: Session, paths: List[str]) -> None:
     ).update(
         {
             models.RSTUFTargetFiles.published: True,
-            models.RSTUFTargetFiles.last_update: datetime.now(),
+            models.RSTUFTargetFiles.last_update: datetime.now(timezone.utc),
         }
     )
     db.commit()
@@ -163,7 +163,7 @@ def update_roles_version(db: Session, bins_ids: List[int]) -> None:
         {
             models.RSTUFTargetRoles.version: models.RSTUFTargetRoles.version
             + 1,
-            models.RSTUFTargetRoles.last_update: datetime.now(),
+            models.RSTUFTargetRoles.last_update: datetime.now(timezone.utc),
         }
     )
     db.commit()
@@ -177,7 +177,7 @@ def update_file_action_to_remove(
     """
     target.published = False
     target.action = schemas.TargetAction.REMOVE
-    target.last_update = datetime.now()
+    target.last_update = datetime.now(timezone.utc)
     db.add(target)
     db.commit()
     db.refresh(target)

--- a/repository_service_tuf_worker/models/targets/models.py
+++ b/repository_service_tuf_worker/models/targets/models.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import (
     Boolean,
@@ -29,7 +29,7 @@ class RSTUFTargetFiles(Base):
         Enum(schemas.TargetAction),
         nullable=False,
     )
-    last_update = Column(DateTime, default=datetime.now())
+    last_update = Column(DateTime, default=datetime.now(timezone.utc))
     targets_role = Column(Integer, ForeignKey("rstuf_target_roles.id"))
 
 
@@ -38,5 +38,5 @@ class RSTUFTargetRoles(Base):
     id = Column(Integer, primary_key=True, index=True)
     rolename = Column(String, nullable=False)
     version = Column(Integer, nullable=False)
-    last_update = Column(DateTime, default=datetime.now())
+    last_update = Column(DateTime, default=datetime.now(timezone.utc))
     target_files = relationship(RSTUFTargetFiles, backref="rstuf_target_roles")

--- a/repository_service_tuf_worker/models/targets/schemas.py
+++ b/repository_service_tuf_worker/models/targets/schemas.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 import enum
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from pydantic import BaseModel
@@ -27,7 +27,7 @@ class RSTUFTargetFileCreate(BaseModel):
     info: Dict[str, Any]
     published: bool
     action: TargetAction
-    last_update: Optional[datetime] = datetime.now()
+    last_update: Optional[datetime] = datetime.now(timezone.utc)
 
     class Config:
         orm_mode = True

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 import datetime
+from datetime import timezone
 from types import ModuleType
 
 import pretend
@@ -35,8 +36,10 @@ def app(test_repo: MetadataRepository) -> ModuleType:
 
 @pytest.fixture()
 def mocked_datetime(monkeypatch):
-    fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
-    fake_datetime = pretend.stub(now=pretend.call_recorder(lambda: fake_time))
+    fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1, tzinfo=timezone.utc)
+    fake_datetime = pretend.stub(
+        now=pretend.call_recorder(lambda *а: fake_time)
+    )
     monkeypatch.setattr(
         "repository_service_tuf_worker.repository.datetime", fake_datetime
     )

--- a/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
+++ b/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 import datetime
+from datetime import timezone
 
 import pretend
 
@@ -45,7 +46,7 @@ class TestCrud:
             commit=pretend.call_recorder(lambda: None),
             refresh=pretend.call_recorder(lambda *a: None),
         )
-        last_updated = datetime.datetime.now()
+        last_updated = datetime.datetime.now(timezone.utc)
         test_target_file = crud.schemas.RSTUFTargetFileCreate(
             path="file1.tar.gz",
             info={"info": {"k": "v"}},
@@ -212,9 +213,9 @@ class TestCrud:
             refresh=pretend.call_recorder(lambda *a: None),
         )
 
-        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_exp = datetime.datetime(2019, 6, 16, 9, 5, 1, tzinfo=timezone.utc)
         fake_datetime = pretend.stub(
-            now=pretend.call_recorder(lambda: fake_time)
+            now=pretend.call_recorder(lambda a: fake_exp)
         )
         monkeypatch.setattr(
             "repository_service_tuf_worker.models.targets.crud.datetime",
@@ -238,13 +239,13 @@ class TestCrud:
 
         assert test_result.path == new_path
         assert test_result.info == new_info
-        assert test_result.last_update == fake_time
+        assert test_result.last_update == fake_exp
         assert test_result.action == crud.schemas.TargetAction.ADD
         assert test_result.published is False
         assert mocked_db.add.calls == [pretend.call(test_target_file)]
         assert mocked_db.commit.calls == [pretend.call()]
         assert mocked_db.refresh.calls == [pretend.call(test_target_file)]
-        assert fake_datetime.now.calls == [pretend.call()]
+        assert fake_datetime.now.calls == [pretend.call(timezone.utc)]
 
     def test_update_files_to_published(self, monkeypatch):
         test_targets = ["path/file1", "path.file2"]
@@ -271,9 +272,9 @@ class TestCrud:
             query=pretend.call_recorder(lambda *a: mocked_filter),
             commit=pretend.call_recorder(lambda: None),
         )
-        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_exp = datetime.datetime(2019, 6, 16, 9, 5, 1, tzinfo=timezone.utc)
         fake_datetime = pretend.stub(
-            now=pretend.call_recorder(lambda: fake_time)
+            now=pretend.call_recorder(lambda a: fake_exp)
         )
         monkeypatch.setattr(
             "repository_service_tuf_worker.models.targets.crud.datetime",
@@ -293,10 +294,10 @@ class TestCrud:
             pretend.call(False, test_targets)
         ]
         assert mocked_update.update.calls == [
-            pretend.call({"published": True, "last_update": fake_time})
+            pretend.call({"published": True, "last_update": fake_exp})
         ]
         assert mocked_db.commit.calls == [pretend.call()]
-        assert fake_datetime.now.calls == [pretend.call()]
+        assert fake_datetime.now.calls == [pretend.call(timezone.utc)]
 
     def test_update_roles_version(self, monkeypatch):
         monkeypatch.setattr(
@@ -308,9 +309,9 @@ class TestCrud:
                 last_update="last_update",
             ),
         )
-        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_exp = datetime.datetime(2019, 6, 16, 9, 5, 1, tzinfo=timezone.utc)
         fake_datetime = pretend.stub(
-            now=pretend.call_recorder(lambda: fake_time)
+            now=pretend.call_recorder(lambda a: fake_exp)
         )
         monkeypatch.setattr(
             "repository_service_tuf_worker.models.targets.crud.datetime",
@@ -339,12 +340,12 @@ class TestCrud:
             pretend.call(
                 {
                     19: crud.models.RSTUFTargetRoles.version + 1,
-                    "last_update": fake_time,
+                    "last_update": fake_exp,
                 }
             )
         ]
         assert mocked_db.commit.calls == [pretend.call()]
-        assert fake_datetime.now.calls == [pretend.call()]
+        assert fake_datetime.now.calls == [pretend.call(timezone.utc)]
 
     def test_update_file_action_to_remove(self, monkeypatch):
         mocked_db = pretend.stub(
@@ -353,9 +354,9 @@ class TestCrud:
             refresh=pretend.call_recorder(lambda *a: None),
         )
 
-        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_exp = datetime.datetime(2019, 6, 16, 9, 5, 1, tzinfo=timezone.utc)
         fake_datetime = pretend.stub(
-            now=pretend.call_recorder(lambda: fake_time)
+            now=pretend.call_recorder(lambda a: fake_exp)
         )
         monkeypatch.setattr(
             "repository_service_tuf_worker.models.targets.crud.datetime",
@@ -375,9 +376,9 @@ class TestCrud:
         assert test_result.path == "file1.tar.gz"
         assert test_result.info == {"info": {"k": "v"}}
         assert test_result.action == crud.schemas.TargetAction.REMOVE
-        assert test_result.last_update == fake_time
+        assert test_result.last_update == fake_exp
         assert test_result.published is False
         assert mocked_db.add.calls == [pretend.call(test_target)]
         assert mocked_db.commit.calls == [pretend.call()]
         assert mocked_db.refresh.calls == [pretend.call(test_target)]
-        assert fake_datetime.now.calls == [pretend.call()]
+        assert fake_datetime.now.calls == [pretend.call(timezone.utc)]

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -5,6 +5,7 @@
 
 import datetime
 from contextlib import contextmanager
+from datetime import timezone
 from math import log
 from typing import Iterator
 
@@ -276,7 +277,7 @@ class TestMetadataRepository:
         result = test_repo._bump_expiry(fake_role, "root")
         assert result is None
         assert fake_role.signed.expires == datetime.datetime(
-            2023, 6, 15, 9, 5, 1
+            2023, 6, 15, 9, 5, 1, tzinfo=timezone.utc
         )
 
     def test__bump_version(self, test_repo):
@@ -3170,7 +3171,7 @@ class TestMetadataRepository:
 
     def test__run_online_roles_bump_no_changes(self, test_repo, caplog):
         caplog.set_level(repository.logging.DEBUG)
-        fake_time = datetime.datetime(2054, 6, 16, 8, 5, 1)
+        fake_exp = datetime.datetime(2054, 6, 16, 8, 5, 1, tzinfo=timezone.utc)
         fake_targets = pretend.stub(
             signed=pretend.stub(
                 delegations=pretend.stub(
@@ -3178,13 +3179,13 @@ class TestMetadataRepository:
                         get_roles=pretend.call_recorder(lambda *a: ["bin-a"])
                     )
                 ),
-                expires=fake_time,
+                expires=fake_exp,
                 version=1,
             )
         )
 
         fake_bins = pretend.stub(
-            signed=pretend.stub(targets={}, version=6, expires=fake_time)
+            signed=pretend.stub(targets={}, version=6, expires=fake_exp)
         )
 
         test_repo._storage_backend.get = pretend.call_recorder(
@@ -3247,10 +3248,11 @@ class TestMetadataRepository:
         ]
 
     def test_bump_snapshot_unexpired(self, test_repo):
+        fake_exp = datetime.datetime(2080, 6, 16, 9, 5, 1, tzinfo=timezone.utc)
         fake_snapshot = pretend.stub(
             signed=pretend.stub(
                 meta={},
-                expires=datetime.datetime(2080, 6, 16, 9, 5, 1),
+                expires=fake_exp,
                 version=87,
             )
         )
@@ -3278,10 +3280,11 @@ class TestMetadataRepository:
         # because we pass "force=True" we expect that snapshot must be updated.
         # The current situation as described in the previous comment is that
         # in this case snapshot won't be updated.
+        fake_exp = datetime.datetime(2080, 6, 16, 9, 5, 1, tzinfo=timezone.utc)
         caplog.set_level(repository.logging.DEBUG)
         fake_snapshot = pretend.stub(
             signed=pretend.stub(
-                expires=datetime.datetime(2080, 6, 16, 9, 5, 1),
+                expires=fake_exp,
                 version=87,
             )
         )
@@ -3296,7 +3299,7 @@ class TestMetadataRepository:
                 signed=pretend.stub(
                     snapshot_meta=pretend.stub(version=79),
                     version=87,
-                    expires=datetime.datetime(2028, 6, 16, 9, 5, 1),
+                    expires=fake_exp,
                 )
             )
         )


### PR DESCRIPTION
The specification defines `datetime` as UTC time zone:
https://theupdateframework.github.io/specification/latest/#file-formats-date-time
The python-tuf project updated all their datetime objects,  so it's time we do it now as well.
I updated everywhere to replace `datetime.utc()` to `datetime.now(timezone.utc)`
as `datetime.utc()`  is documented for
deprecation and is officially deprecated from python 12:
https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
Also, I added to all `datetime.now()` calls the argument `timezone.utc` to make sure that
we are consistent with python-tuf as python-tuf did that change as well: https://github.com/theupdateframework/python-tuf/pull/2573

Signed-off-by: Martin Vrachev <martin.vrachev@broadcom.com>