### PR TITLE
Add case for local running of FT tests from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,15 @@ ifeq ($(GITHUB_ACTION),)
 endif
 	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash tests/functional/scripts/run-ft-das.sh $(CLI_VERSION) $(PYTEST_GROUP) $(SLOW)' --rm repository-service-tuf-worker
 
+ft-das-local:
+	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash tests/functional/scripts/run-ft-das.sh $(CLI_VERSION)' --rm repository-service-tuf-worker
+
 ft-signed:
 # Use "GITHUB_ACTION" to identify if we are running from a GitHub action.
 ifeq ($(GITHUB_ACTION),)
 	$(MAKE) clone-umbrella
 endif
 	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash tests/functional/scripts/run-ft-signed.sh $(CLI_VERSION) $(PYTEST_GROUP) $(SLOW)' --rm repository-service-tuf-worker
+
+ft-signed-local:
+	docker compose run --env UMBRELLA_PATH=rstuf-umbrella --entrypoint 'bash tests/functional/scripts/run-ft-signed.sh $(CLI_VERSION)' --rm repository-service-tuf-worker

--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,7 @@ Functional tests
 
 1. Make sure you have a development environment running (``make run-dev``)
 
-2. Run the FT tests ``make ft-das`` or ``make ft-signed``
+2. Run the FT tests ``make ft-das-local`` or ``make ft-signed-local``
 
 
 Managing requirements


### PR DESCRIPTION
If we are not running Functional Tests on GH
actions we don't run the tests in different groups.

Related to https://github.com/repository-service-tuf/repository-service-tuf/pull/684