### PR TITLE
Fix two bugs & do a small refactoring

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -138,7 +138,11 @@ class MetadataRepository:
             # All roles except root share the same one key and it doesn't
             # matter from which role we will get the key.
             keyid: str = root.signed.roles["timestamp"].keyids[0]
-            return root.signed.keys[keyid]
+            key = root.signed.keys[keyid]
+            key_dict = key.to_dict()
+            key_dict["keyid"] = key.keyid
+            self.write_repository_settings("ONLINE_KEY", key_dict)
+            return key
 
     @_online_key.setter
     def _online_key(self, key: Key):

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -115,7 +115,6 @@ class MetadataRepository:
         app_settings = self.refresh_settings()
         self._storage_backend: IStorage = app_settings.STORAGE
         self._signer_store = SignerStore(app_settings)
-        self._online_key: Key
         self._db = app_settings.SQL
         self._redis = redis.StrictRedis.from_url(
             self._worker_settings.REDIS_SERVER

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1330,7 +1330,7 @@ class MetadataRepository:
             },
         )
 
-    def _trusted_root_update(
+    def _verify_new_root_signing(
         self, current_root: Metadata[Root], new_root: Metadata[Root]
     ):
         """Verify if the new metadata is a trusted Root metadata"""
@@ -1361,7 +1361,7 @@ class MetadataRepository:
         current_root: Metadata[Root] = self._storage_backend.get(Root.type)
 
         try:
-            self._trusted_root_update(current_root, new_root)
+            self._verify_new_root_signing(current_root, new_root)
 
         except UnsignedMetadataError:
             # TODO: Add missing sanity check - new root must have at least 1

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -3443,7 +3443,7 @@ class TestMetadataRepository:
             pretend.call(repository.LOCK_TARGETS, timeout=60)
         ]
 
-    def test__trusted_root_update(self, test_repo):
+    def test__verify_new_root_signing(self, test_repo):
         fake_new_root_md = pretend.stub(
             signed=pretend.stub(
                 roles={"timestamp": pretend.stub(keyids={"k1": "v1"})},
@@ -3460,7 +3460,7 @@ class TestMetadataRepository:
             verify_delegate=pretend.call_recorder(lambda *a: None),
         )
 
-        result = test_repo._trusted_root_update(
+        result = test_repo._verify_new_root_signing(
             fake_old_root_md, fake_new_root_md
         )
         assert result is None
@@ -3471,7 +3471,7 @@ class TestMetadataRepository:
             pretend.call(repository.Root.type, fake_new_root_md)
         ]
 
-    def test__trusted_root_update_fail_current_verify_delegate(
+    def test__verify_new_root_signing_fail_current_verify_delegate(
         self, test_repo
     ):
         fake_new_root_md = pretend.stub(
@@ -3493,10 +3493,12 @@ class TestMetadataRepository:
         )
 
         with pytest.raises(TypeError) as err:
-            test_repo._trusted_root_update(fake_old_root_md, fake_new_root_md)
+            test_repo._verify_new_root_signing(
+                fake_old_root_md, fake_new_root_md
+            )
         assert "Call is valid only on delegator metadata" in str(err)
 
-    def test__trusted_root_update_bad_version(self, test_repo):
+    def test__verify_new_root_signing_bad_version(self, test_repo):
         fake_new_root_md = pretend.stub(
             signed=pretend.stub(
                 roles={"timestamp": pretend.stub(keyids={"k1": "v1"})},
@@ -3512,10 +3514,12 @@ class TestMetadataRepository:
         )
 
         with pytest.raises(repository.BadVersionNumberError) as err:
-            test_repo._trusted_root_update(fake_old_root_md, fake_new_root_md)
+            test_repo._verify_new_root_signing(
+                fake_old_root_md, fake_new_root_md
+            )
         assert "Expected root version 2 instead got version 4" in str(err)
 
-    def test__trusted_root_update_bad_type(self, test_repo):
+    def test__verify_new_root_signing_bad_type(self, test_repo):
         fake_new_root_md = pretend.stub(
             signed=pretend.stub(
                 roles={"timestamp": pretend.stub(keyids={"k1": "v1"})},
@@ -3531,7 +3535,9 @@ class TestMetadataRepository:
         )
 
         with pytest.raises(repository.RepositoryError) as err:
-            test_repo._trusted_root_update(fake_old_root_md, fake_new_root_md)
+            test_repo._verify_new_root_signing(
+                fake_old_root_md, fake_new_root_md
+            )
         assert "Expected 'root', got 'snapshot'" in str(err)
 
     def test_run_force_online_metadata_update_targets_and_bins(
@@ -3751,7 +3757,9 @@ class TestMetadataRepository:
         test_repo._storage_backend.get = pretend.call_recorder(
             lambda *a: fake_old_root_md
         )
-        test_repo._trusted_root_update = pretend.call_recorder(lambda *a: None)
+        test_repo._verify_new_root_signing = pretend.call_recorder(
+            lambda *a: None
+        )
         test_repo._persist = pretend.call_recorder(lambda *a: None)
 
         result = test_repo._root_metadata_update(fake_new_root_md)
@@ -3769,7 +3777,7 @@ class TestMetadataRepository:
         assert test_repo._storage_backend.get.calls == [
             pretend.call(repository.Root.type)
         ]
-        assert test_repo._trusted_root_update.calls == [
+        assert test_repo._verify_new_root_signing.calls == [
             pretend.call(fake_old_root_md, fake_new_root_md)
         ]
         assert test_repo._persist.calls == [
@@ -3794,7 +3802,7 @@ class TestMetadataRepository:
         test_repo._storage_backend.get = pretend.call_recorder(
             lambda *a: fake_old_root_md
         )
-        test_repo._trusted_root_update = pretend.raiser(
+        test_repo._verify_new_root_signing = pretend.raiser(
             repository.UnsignedMetadataError()
         )
 
@@ -3841,7 +3849,7 @@ class TestMetadataRepository:
         test_repo._storage_backend.get = pretend.call_recorder(
             lambda *a: fake_old_root_md
         )
-        test_repo._trusted_root_update = pretend.raiser(
+        test_repo._verify_new_root_signing = pretend.raiser(
             repository.BadVersionNumberError("Version v3 instead v2")
         )
 
@@ -3878,7 +3886,9 @@ class TestMetadataRepository:
         test_repo._storage_backend.get = pretend.call_recorder(
             lambda *a: fake_old_root_md
         )
-        test_repo._trusted_root_update = pretend.call_recorder(lambda *a: None)
+        test_repo._verify_new_root_signing = pretend.call_recorder(
+            lambda *a: None
+        )
 
         @contextmanager
         def mocked_lock(lock, timeout):
@@ -3908,7 +3918,7 @@ class TestMetadataRepository:
         assert test_repo._storage_backend.get.calls == [
             pretend.call(repository.Root.type)
         ]
-        assert test_repo._trusted_root_update.calls == [
+        assert test_repo._verify_new_root_signing.calls == [
             pretend.call(fake_old_root_md, fake_new_root_md)
         ]
         assert test_repo._redis.lock.calls == [
@@ -3948,7 +3958,9 @@ class TestMetadataRepository:
         test_repo._storage_backend.get = pretend.call_recorder(
             lambda *a: fake_old_root_md
         )
-        test_repo._trusted_root_update = pretend.call_recorder(lambda *a: None)
+        test_repo._verify_new_root_signing = pretend.call_recorder(
+            lambda *a: None
+        )
 
         @contextmanager
         def mocked_lock(lock, timeout):
@@ -3964,7 +3976,7 @@ class TestMetadataRepository:
         assert test_repo._storage_backend.get.calls == [
             pretend.call(repository.Root.type)
         ]
-        assert test_repo._trusted_root_update.calls == [
+        assert test_repo._verify_new_root_signing.calls == [
             pretend.call(fake_old_root_md, fake_new_root_md)
         ]
 

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -26,7 +26,7 @@ from tuf.api.metadata import (
 from repository_service_tuf_worker import Dynaconf, repository
 from repository_service_tuf_worker.models import targets_schema
 
-REPOSITORY_PATH = f"repository_service_tuf_worker.repository"
+REPOSITORY_PATH = "repository_service_tuf_worker.repository"
 
 
 class TestRoles:
@@ -103,7 +103,6 @@ class TestMetadataRepository:
         ]
 
     def test_online_key_property_from_storage(self, test_repo, monkeypatch):
-        fake_key_dict = {"keyval": "foo", "keyid": "key_id"}
         fake_settings = pretend.stub(
             get_fresh=pretend.call_recorder(lambda a: None)
         )


### PR DESCRIPTION
In this pr I address two bugs and one refactoring:

1. Don't persist root if the online roles bump fails. This makes sure that the root is stored last when all online roles are bumped.
2. Give a `trusted_root_update()` with a more telling name. As we don't update trusted root with `_trusted_root_update()` and this makes the function name misleading.
3.  Fix: update the delegation key when bumping targets. Strangely, we forgot to change the key referenced in top level targets role when bumping targets with an online key change. This caused a bug that was reported: https://github.com/repository-service-tuf/repository-service-tuf-worker/issues/491

Fixes #491 