### PR TITLE
Fix force md update with custom delegations

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1282,16 +1282,12 @@ class MetadataRepository:
                 self._bump_and_persist(targets, Targets.type)
                 roles_diff += [Targets.type]
 
-            target_roles = delegated_roles
             if delegated_roles == [Roles.BINS.value]:
-                # Set the actual names of the bins
-                target_roles = self._settings.get_fresh(
-                    "DELEGATED_ROLES_NAMES"
+                self._update_timestamp(self._update_snapshot(bump_all=True))
+            else:
+                self._update_timestamp(
+                    self._update_snapshot(target_roles=delegated_roles)
                 )
-
-            self._update_timestamp(
-                self._update_snapshot(target_roles=target_roles)
-            )
 
             roles_diff += [*delegated_roles]
 

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1275,34 +1275,25 @@ class MetadataRepository:
         else:
             delegated_roles = [r for r in roles if not Roles.is_role(r)]
 
-        if Targets.type in roles and len(delegated_roles) > 0:
-            self._run_online_roles_bump(force=True)
-            roles_diff = [
-                *delegated_roles,
-                Targets.type,
-                Snapshot.type,
-                Timestamp.type,
-            ]
-
-        elif Targets.type in roles or len(delegated_roles) > 0:
+        if Targets.type in roles or len(delegated_roles) > 0:
+            roles_diff = [Snapshot.type, Timestamp.type]
             if Targets.type in roles:
                 targets = self._storage_backend.get(Targets.type)
                 self._bump_and_persist(targets, Targets.type)
-                self.bump_snapshot(force=True)
-                roles_diff = [Targets.type, Snapshot.type, Timestamp.type]
-            else:
-                target_roles = delegated_roles
-                if delegated_roles == [Roles.BINS.value]:
-                    # Set the actual names of the bins
-                    target_roles = self._settings.get_fresh(
-                        "DELEGATED_ROLES_NAMES"
-                    )
+                roles_diff += [Targets.type]
 
-                self._update_timestamp(
-                    self._update_snapshot(target_roles=target_roles)
+            target_roles = delegated_roles
+            if delegated_roles == [Roles.BINS.value]:
+                # Set the actual names of the bins
+                target_roles = self._settings.get_fresh(
+                    "DELEGATED_ROLES_NAMES"
                 )
 
-                roles_diff = [*delegated_roles, Snapshot.type, Timestamp.type]
+            self._update_timestamp(
+                self._update_snapshot(target_roles=target_roles)
+            )
+
+            roles_diff += [*delegated_roles]
 
         elif Snapshot.type in roles:
             self.bump_snapshot(force=True)

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -3785,21 +3785,13 @@ class TestMetadataRepository:
         assert "Expected 'root', got 'snapshot'" in str(err)
 
     def test__run_force_online_metadata_update_targets_and_bins(
-        self, test_repo, monkeypatch
+        self, test_repo
     ):
         fake_targets = Metadata(Targets())
         test_repo._storage_backend = pretend.stub(
             get=pretend.call_recorder(lambda a: fake_targets)
         )
         test_repo._bump_and_persist = pretend.call_recorder(lambda *a: None)
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(lambda *a: ["bins-a", "bins-b"])
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
         test_repo._update_snapshot = pretend.call_recorder(
             lambda **kw: "version"
         )
@@ -3814,11 +3806,8 @@ class TestMetadataRepository:
         assert test_repo._bump_and_persist.calls == [
             pretend.call(fake_targets, Targets.type)
         ]
-        assert fake_settings.get_fresh.calls == [
-            pretend.call("DELEGATED_ROLES_NAMES")
-        ]
         assert test_repo._update_snapshot.calls == [
-            pretend.call(target_roles=["bins-a", "bins-b"])
+            pretend.call(bump_all=True)
         ]
         assert test_repo._update_timestamp.calls == [pretend.call("version")]
 
@@ -3879,14 +3868,6 @@ class TestMetadataRepository:
     def test__run_force_online_metadata_update_bins(
         self, test_repo, monkeypatch
     ):
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(lambda *a: ["bins-a", "bins-b"])
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
         test_repo._update_snapshot = pretend.call_recorder(
             lambda **kw: "version"
         )
@@ -3894,11 +3875,8 @@ class TestMetadataRepository:
 
         result = test_repo._run_force_online_metadata_update(["bins"])
         assert result == [Snapshot.type, Timestamp.type, "bins"]
-        assert fake_settings.get_fresh.calls == [
-            pretend.call("DELEGATED_ROLES_NAMES")
-        ]
         assert test_repo._update_snapshot.calls == [
-            pretend.call(target_roles=["bins-a", "bins-b"])
+            pretend.call(bump_all=True)
         ]
         assert test_repo._update_timestamp.calls == [pretend.call("version")]
 


### PR DESCRIPTION
Fixes #503 

Fix a bug which happened when we wanted to bump targets and a custom
delegated role at the same time which caused a bump of the target role
and all custom delegated roles at the same time.

**Note**: Merge #501 first.