### PR TITLE
tests: Remove FT Signed SLOW

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -131,29 +131,3 @@ jobs:
       - name: Bootstrap/Setup RSTUF full Signed and run Functional Tests
         run: |
           make ft-signed CLI_VERSION=${{ inputs.cli_version }} PYTEST_GROUP=${{ matrix.pytest-group }} DC=${{ inputs.docker_compose }}
-
-  functional-signed-slow:
-    name: "Signed Slow"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout RSTUF Worker source code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-
-      - name: Checkout RSTUF Umbrella (FT)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          repository: repository-service-tuf/repository-service-tuf
-          path: rstuf-umbrella
-          ref: ${{ inputs.umbrella_branch }}
-
-      - name: Deploy RSTUF with Worker container from source code
-        uses: isbang/compose-action@e5813a5909aca4ae36058edae58f6e52b9c971f8
-        with:
-          compose-file: ${{ inputs.docker_compose }}
-        env:
-          API_VERSION: ${{ inputs.api_version }}
-
-      - name: Bootstrap/Setup RSTUF full Signed and run Functional Tests
-        run: |
-          make ft-signed CLI_VERSION=${{ inputs.cli_version }} PYTEST_GROUP=none SLOW="yes" DC=${{ inputs.docker_compose }}


### PR DESCRIPTION
We don't need to run FT-DAS-SLOW and FT-SIGNED-SLOW.

The FT SLOW, which runs the functional tests for Performance.

The functional tests for performances are related to adding/removing targets and are not affected by the DAS/Signed process