### PR TITLE
feat: Custom Delegation(Target) Roles

### DIFF
--- a/alembic/versions/4b8d450e8360_initial_version.py
+++ b/alembic/versions/4b8d450e8360_initial_version.py
@@ -26,6 +26,7 @@ def upgrade() -> None:
         sa.Column("rolename", sa.String(length=512), nullable=False),
         sa.Column("version", sa.Integer(), nullable=False),
         sa.Column("last_update", sa.DateTime(), nullable=True),
+        sa.Column("active", sa.Boolean(), nullable=False),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
@@ -33,6 +34,12 @@ def upgrade() -> None:
         "rstuf_target_roles",
         ["id"],
         unique=False,
+    )
+    op.create_index(
+        op.f("ix_rstuf_target_roles_rolename"),
+        "rstuf_target_roles",
+        ["rolename"],
+        unique=True,
     )
     op.create_table(
         "rstuf_target_files",

--- a/repository_service_tuf_worker/models/targets/crud.py
+++ b/repository_service_tuf_worker/models/targets/crud.py
@@ -84,6 +84,23 @@ def read_role_by_rolename(
         db.query(models.RSTUFTargetRoles)
         .filter(
             models.RSTUFTargetRoles.rolename == rolename,
+            models.RSTUFTargetRoles.active == True,
+        )
+        .first()
+    )
+
+
+def read_role_deactivated_by_rolename(
+    db: Session, rolename: str
+) -> Optional[models.RSTUFTargetRoles]:
+    """
+    Read a Target role by a given role name.
+    """
+    return (
+        db.query(models.RSTUFTargetRoles)
+        .filter(
+            models.RSTUFTargetRoles.rolename == rolename,
+            models.RSTUFTargetRoles.active == False,
         )
         .first()
     )
@@ -93,7 +110,11 @@ def read_all_roles(db: Session) -> List[models.RSTUFTargetRoles]:
     """
     Read a all Target bin roles.
     """
-    return db.query(models.RSTUFTargetRoles).all()
+    return (
+        db.query(models.RSTUFTargetRoles)
+        .filter(models.RSTUFTargetRoles.active == True)
+        .all()
+    )
 
 
 def read_roles_joint_files(
@@ -109,6 +130,7 @@ def read_roles_joint_files(
         )
         .join(models.RSTUFTargetFiles)
         .filter(
+            models.RSTUFTargetRoles.active == True,
             models.RSTUFTargetRoles.rolename.in_(rolenames),
         )
         .all()
@@ -183,3 +205,18 @@ def update_file_action_to_remove(
     db.refresh(target)
 
     return target
+
+
+def update_role_to_deactivated(
+    db: Session, role: models.RSTUFTargetRoles
+) -> models.RSTUFTargetRoles:
+    """
+    Update Target role `active` to False.
+    """
+    role.active = False
+    role.last_update = datetime.now(timezone.utc)
+    db.add(role)
+    db.commit()
+    db.refresh(role)
+
+    return role

--- a/repository_service_tuf_worker/models/targets/crud.py
+++ b/repository_service_tuf_worker/models/targets/crud.py
@@ -84,7 +84,7 @@ def read_role_by_rolename(
         db.query(models.RSTUFTargetRoles)
         .filter(
             models.RSTUFTargetRoles.rolename == rolename,
-            models.RSTUFTargetRoles.active == True,
+            models.RSTUFTargetRoles.active == True,  # noqa
         )
         .first()
     )
@@ -100,7 +100,7 @@ def read_role_deactivated_by_rolename(
         db.query(models.RSTUFTargetRoles)
         .filter(
             models.RSTUFTargetRoles.rolename == rolename,
-            models.RSTUFTargetRoles.active == False,
+            models.RSTUFTargetRoles.active == False,  # noqa
         )
         .first()
     )
@@ -112,7 +112,7 @@ def read_all_roles(db: Session) -> List[models.RSTUFTargetRoles]:
     """
     return (
         db.query(models.RSTUFTargetRoles)
-        .filter(models.RSTUFTargetRoles.active == True)
+        .filter(models.RSTUFTargetRoles.active == True)  # noqa
         .all()
     )
 
@@ -130,7 +130,7 @@ def read_roles_joint_files(
         )
         .join(models.RSTUFTargetFiles)
         .filter(
-            models.RSTUFTargetRoles.active == True,
+            models.RSTUFTargetRoles.active == True,  # noqa
             models.RSTUFTargetRoles.rolename.in_(rolenames),
         )
         .all()

--- a/repository_service_tuf_worker/models/targets/models.py
+++ b/repository_service_tuf_worker/models/targets/models.py
@@ -36,7 +36,8 @@ class RSTUFTargetFiles(Base):
 class RSTUFTargetRoles(Base):
     __tablename__ = "rstuf_target_roles"
     id = Column(Integer, primary_key=True, index=True)
-    rolename = Column(String, nullable=False)
+    rolename = Column(String, nullable=False, unique=True)
     version = Column(Integer, nullable=False)
+    active = Column(Boolean, default=True, nullable=False)
     last_update = Column(DateTime, default=datetime.now(timezone.utc))
     target_files = relationship(RSTUFTargetFiles, backref="rstuf_target_roles")

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -736,7 +736,7 @@ class MetadataRepository:
             if key not in other_keys:
                 logging.debug(f"removing key id {key}")
                 targets.signed.delegations.keys.delete(key)
-             else:
+            else:
                 logging.debug(f"key {key} used by other role")
 
     def _add_delegated_role_keys(
@@ -899,7 +899,8 @@ class MetadataRepository:
 
         if targets.signed.delegations.succinct_roles:
             raise RepositoryError(
-                "Delegations already using hash-bins, cannot delete custom roles"
+                "Delegations already using hash-bins, cannot delete custom "
+                "roles"
             )
 
         # remove role from Targets delegations and mapping role unique keys
@@ -1034,6 +1035,9 @@ class MetadataRepository:
             logging.debug("verifying delegations threshold")
             for role in success:
                 if self._validate_threshold(success[role], targets, role):
+                    # If the role uses online key it was signed by while
+                    # adding the role by self._add_metadata_delegation.
+                    # if the threshold is met, role is full signed
                     logging.debug(f"role '{role}' uses only online key")
                     snapshot.signed.meta[f"{role}.json"] = MetaFile(
                         success[role].signed.version

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -947,7 +947,8 @@ class MetadataRepository:
 
         if targets.signed.delegations.succinct_roles:
             raise RepositoryError(
-                "Delegations already using hash-bins, cannot update custom roles"
+                "Delegations already using hash-bins, cannot update"
+                "custom roles"
             )
 
         success = {}

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -383,7 +383,7 @@ class MetadataRepository:
             elif bump_all:
                 db_target_roles = targets_crud.read_all_roles(self._db)
             else:
-                ValueError("'bump_all' or 'target_roles")
+                raise ValueError("'bump_all' or 'target_roles")
 
             snapshot_meta_updated = False
             for db_role in db_target_roles:
@@ -497,7 +497,7 @@ class MetadataRepository:
 
             return snapshot.signed.version
         else:
-            None
+            return None
 
     def _update_targets_delegations_key(self, targets: Metadata[Targets]):
         """

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import copy
 import enum
 import logging
 import time
@@ -10,7 +11,7 @@ import warnings
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from math import log
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Tuple
 from urllib.parse import urlparse
 
 import redis
@@ -18,7 +19,7 @@ from celery.app.task import Task
 from celery.exceptions import ChordError
 from celery.result import AsyncResult, states
 from dynaconf.loaders import redis_loader
-from securesystemslib.exceptions import UnverifiedSignatureError
+from securesystemslib.exceptions import StorageError, UnverifiedSignatureError
 from securesystemslib.signer import (
     KEY_FOR_TYPE_AND_SCHEME,
     Key,
@@ -103,6 +104,7 @@ class TaskName(str, enum.Enum):
     PUBLISH_ARTIFACTS = "publish_artifacts"
     FORCE_ONLINE_METADATA_UPDATE = "force_online_metadata_update"
     METADATA_UPDATE = "metadata_update"
+    METADATA_DELEGATION = "metadata_delegation"
     SIGN_METADATA = "sign_metadata"
     DELETE_SIGN_METADATA = "delete_sign_metadata"
 
@@ -273,6 +275,11 @@ class MetadataRepository:
             if role_name == Root.type:
                 self.write_repository_settings("TRUSTED_ROOT", role.to_dict())
 
+            if role_name == Targets.type:
+                self.write_repository_settings(
+                    "TRUSTED_TARGETS", role.to_dict()
+                )
+
         bytes_data = role.to_bytes(JSONSerializer())
         self._storage_backend.put(bytes_data, filename)
         logging.debug(f"{filename} saved")
@@ -308,29 +315,42 @@ class MetadataRepository:
         if persist:
             self._persist(role, role_name)
 
-    def _update_timestamp(self, snapshot_version: int) -> Metadata[Timestamp]:
+    def _update_timestamp(
+        self,
+        snapshot_version: Optional[int] = None,
+        skip: Optional[bool] = False,
+    ) -> Metadata[Timestamp]:
         """
         Loads 'timestamp', updates meta info about passed 'snapshot'
         metadata, bumps version and expiration, signs and persists.
 
         Args:
-            snapshot_version: snapshot version to add to new timestamp.
-            db_targets: RSTUFTarget DB objects will be changed as published in
-                the DB SQL.
+            snapshot_version: Optional snapshot version to new timestamp.
+            skip: Skip bumping version and expiration if snpashot
+            version is not provided
         """
         timestamp: Metadata[Timestamp] = self._storage_backend.get(
             Timestamp.type, None
         )
+        if not snapshot_version and skip:
+            logging.debug(
+                "No snapshot version and skip is True. Not bumping Timestamp"
+            )
+            return timestamp
+
         timestamp.signed.snapshot_meta = MetaFile(version=snapshot_version)
 
         self._bump_and_persist(timestamp, Timestamp.type)
 
+        logging.debug("Bumped version of 'Target' role")
         return timestamp
 
     def _update_snapshot(
         self,
         target_roles: Optional[List[str]] = None,
         bump_all: Optional[bool] = False,
+        only_target: Optional[bool] = False,
+        only_snapshot: Optional[bool] = False,
     ) -> int:
         """
         Loads 'snapshot', updates meta info when 'target_roles' role names are
@@ -342,6 +362,9 @@ class MetadataRepository:
                 will NOT be taken into account.
             bump_all: Wheter to bump all delegated target roles. If provided,
                 then 'target_roles' arg is NOT taken into acount.
+            only_target: Updates only Targets role in the Snapshot Meta.
+                It doesn't Bump and Persist Targets.
+            only_snapshot: Bump and Persist Snapshot Role only.
         """
         snapshot: Metadata[Snapshot] = self._storage_backend.get(Snapshot.type)
         targets: Metadata[Targets] = self._storage_backend.get(Targets.type)
@@ -349,17 +372,39 @@ class MetadataRepository:
             True if targets.signed.delegations.succinct_roles else False
         )
 
-        db_target_roles: List[targets_models.RSTUFTargetRoles] = []
-        if target_roles:
-            db_target_roles = targets_crud.read_roles_joint_files(
-                self._db, target_roles
-            )
+        snapshot_meta_updated = False
 
+        db_target_roles: List[targets_models.RSTUFTargetRoles] = []
+        if target_roles or bump_all:
+            if target_roles:
+                db_target_roles = targets_crud.read_roles_joint_files(
+                    self._db, target_roles
+                )
+            elif bump_all:
+                db_target_roles = targets_crud.read_all_roles(self._db)
+            else:
+                ValueError("'bump_all' or 'target_roles")
+
+            snapshot_meta_updated = False
             for db_role in db_target_roles:
                 rolename = db_role.rolename
-                delegation: Metadata[Targets] = self._storage_backend.get(
-                    rolename
-                )
+                try:
+                    delegation: Metadata[Targets] = self._storage_backend.get(
+                        rolename
+                    )
+                    logging.debug(f"role {rolename} loaded from disk")
+                    source = "storage"
+                except StorageError as err:
+                    if delegation_signing := self._settings.get_fresh(
+                        f"{rolename.upper()}_SIGNING"
+                    ):
+                        delegation = Metadata[Targets].from_dict(
+                            delegation_signing
+                        )
+                        logging.debug(f"role {rolename} loaded from singing")
+                        source = "signing"
+                    else:
+                        raise err
                 delegation.signed.targets.clear()
                 delegation.signed.targets = {
                     file.path: TargetFile.from_dict(file.info, file.path)
@@ -374,59 +419,85 @@ class MetadataRepository:
                     # will return None for this specific role.
                 }
                 delegation_name = BINS if bins_used else rolename
-                # update expiry, bump version and persist to the storage
-                self._bump_and_persist(
-                    delegation, delegation_name, persist=False
-                )
-                self._persist(delegation, rolename)
                 # update targetfile in db
                 # note: It update only if is not published see the CRUD.
                 targets_crud.update_files_to_published(
                     self._db, [file.path for file in db_role.target_files]
                 )
+                delegation_keyids = List[str]
+                if targets.signed.delegations.succinct_roles:
+                    logging.debug("delegations using succinct delegations")
+                    delegation_keyids = (
+                        targets.signed.delegations.succinct_roles.keyids
+                    )
+                else:
+                    logging.debug("delegations using custom delegations")
+                    delegation_keyids = targets.signed.delegations.roles[
+                        delegation_name
+                    ].keyids
 
-                snapshot.signed.meta[f"{rolename}.json"] = MetaFile(
-                    version=delegation.signed.version
-                )
+                if (
+                    len(delegation_keyids) == 1
+                    and self._online_key.keyid in delegation_keyids
+                ):
+                    logging.debug(f"role {rolename} full online keys")
+                    logging.debug("update expiry, bump version and persist")
+                    self._bump_and_persist(
+                        delegation, delegation_name, persist=False
+                    )
+                    self._persist(delegation, rolename)
+                    snapshot.signed.meta[f"{rolename}.json"] = MetaFile(
+                        version=delegation.signed.version
+                    )
+                    snapshot_meta_updated = True
 
-            roles = "".join(target_roles)
-            msg = f"Bumped all expired target delegation roles: {roles}"
-            logging.info(msg)
+                elif (
+                    len(delegation_keyids) > 1
+                    and self._online_key.keyid in delegation_keyids
+                ):
+                    logging.debug(f"role {rolename} online/offline keys")
+                    self._bump_expiry(delegation, rolename)
+                    if source == "storage":
+                        self._bump_version(delegation)
+                    self._sign(delegation)
+                    self.write_repository_settings(
+                        f"{rolename.upper()}_SIGNING", delegation.to_dict()
+                    )
 
-        elif bump_all:
-            db_target_roles = targets_crud.read_all_roles(self._db)
-            for db_role in db_target_roles:
-                rolename = db_role.rolename
-                delegation: Metadata[Targets] = self._storage_backend.get(
-                    db_role.rolename
-                )
-                delegation_name = BINS if bins_used else rolename
-                # update expiry, bump version and persist to the storage
-                self._bump_and_persist(
-                    delegation, delegation_name, persist=False
-                )
-                self._persist(delegation, db_role.rolename)
+                else:
+                    logging.debug(f"role {rolename} offline keys")
+                    delegation.signatures.clear()
+                    self._bump_expiry(delegation, rolename)
+                    if source == "storage":
+                        self._bump_version(delegation)
+                    self.write_repository_settings(
+                        f"{rolename.upper()}_SIGNING", delegation.to_dict()
+                    )
 
-                snapshot.signed.meta[f"{rolename}.json"] = MetaFile(
-                    version=delegation.signed.version
-                )
+        if only_target:
+            snapshot.signed.meta[f"{Targets.type}.json"] = MetaFile(
+                version=targets.signed.version
+            )
+            self._bump_and_persist(snapshot, Snapshot.type)
+            logging.debug("Bumped version of 'Snapshot' role")
+            snapshot_meta_updated = True
 
-            logging.info("Bumped all target delegation roles")
+        if only_snapshot:
+            self._bump_and_persist(snapshot, Snapshot.type)
+            logging.debug("Bumped version of 'Snapshot' role")
 
-        if len(db_target_roles) > 0:
+        if len(db_target_roles) > 0 and snapshot_meta_updated:
             targets_crud.update_roles_version(
                 self._db, [int(db_role.id) for db_role in db_target_roles]
             )
 
-        snapshot.signed.meta[f"{Targets.type}.json"] = MetaFile(
-            version=targets.signed.version
-        )
+        if snapshot_meta_updated:
+            self._bump_and_persist(snapshot, Snapshot.type)
+            logging.debug("Bumped version of 'Snapshot' role")
 
-        # update expiry, bump version and persist to the storage
-        self._bump_and_persist(snapshot, Snapshot.type)
-        logging.info("Bumped version of 'Snapshot' role")
-
-        return snapshot.signed.version
+            return snapshot.signed.version
+        else:
+            None
 
     def _update_targets_delegations_key(self, targets: Metadata[Targets]):
         """
@@ -449,8 +520,9 @@ class MetadataRepository:
 
         else:
             for role in targets.signed.delegations.roles.values():
-                targets.signed.revoke_key(old_online_keyid, role.name)
-                targets.signed.add_key(new_online_key, role.name)
+                if old_online_keyid in role.keyids:
+                    targets.signed.revoke_key(old_online_keyid, role.name)
+                    targets.signed.add_key(new_online_key, role.name)
 
     def _get_role_for_artifact_path(self, artifact_path: str) -> Optional[str]:
         """
@@ -607,108 +679,383 @@ class MetadataRepository:
             )
 
         else:
-            delegated_roles = roles_info["delegated_roles"]
             self.write_repository_settings(
-                "CUSTOM_DELEGATED_ROLES", delegated_roles
+                "DELEGATIONS", roles_info.get("delegations")
             )
-            for deleg_name, deleg_info in delegated_roles.items():
-                name = deleg_name.upper()
-                self.write_repository_settings(
-                    f"{name}_EXPIRATION", deleg_info["expiration"]
-                )
-                self.write_repository_settings(f"{name}_THRESHOLD", 1)
-                self.write_repository_settings(f"{name}_NUM_KEYS", 1)
-                self.write_repository_settings(
-                    f"{name}_PATH_PATTERNS",
-                    delegated_roles[deleg_name]["path_patterns"],
-                )
 
-    def _setup_targets_delegations(
+    def _add_metadata_hashbin_delegations(
         self,
-        online_pub_key: Key,
         targets: Metadata[Targets],
-        custom_targets: Optional[Dict[str, Any]] = None,
     ):
         """Setup target delegations no matter if succinct hash bin or custom"""
         delegated_roles: List[str] = []
-        if custom_targets:
-            # Using custom Target roles delegations with path prefixes.
-            targets.signed.delegations = Delegations({}, {})
-            for role_name, role_info in custom_targets.items():
-                keyid = online_pub_key.keyid
-                targets.signed.delegations.roles[role_name] = DelegatedRole(
-                    role_name, [keyid], 1, True, role_info["path_patterns"]
-                )
-                targets.signed.add_key(online_pub_key, role_name)
-                custom_target = Metadata(Targets())
-                self._bump_expiry(custom_target, role_name)
-                self._sign(custom_target)
-                self._persist(custom_target, role_name)
-                delegated_roles.append(role_name)
-        else:
-            # Using succinct hash bin delegations.
-            # Calculate the bit length (Number of bits between 1 and 32)
-            # Calculate the bit length (Number of bits between 1 and 32)
-            bit_length = int(
-                log(self._settings.get_fresh("NUMBER_OF_DELEGATED_BINS"), 2)
-            )
-            # Succinct delegated roles (`bins`)
-            succinct_roles = SuccinctRoles([], 1, bit_length, BINS)
-            targets.signed.delegations = Delegations(
-                keys={}, succinct_roles=succinct_roles
-            )
-            # Initialize all succinct delegated roles (`bins`), update expire,
-            # sign, add to `Snapshot` meta and persist in the backend storage
-            # service.
-            for delegated_name in succinct_roles.get_roles():
-                targets.signed.add_key(online_pub_key, delegated_name)
-                bins_role = Metadata(Targets())
-                self._bump_expiry(bins_role, BINS)
-                self._sign(bins_role)
-                self._persist(bins_role, delegated_name)
-                delegated_roles.append(delegated_name)
 
-        self.write_repository_settings(
-            "DELEGATED_ROLES_NAMES", delegated_roles
+        # Using succinct hash bin delegations.
+        # Calculate the bit length (Number of bits between 1 and 32)
+        # Calculate the bit length (Number of bits between 1 and 32)
+        bit_length = int(
+            log(self._settings.get_fresh("NUMBER_OF_DELEGATED_BINS"), 2)
         )
+        # Succinct delegated roles (`bins`)
+        succinct_roles = SuccinctRoles([], 1, bit_length, BINS)
+        targets.signed.delegations = Delegations(
+            keys={}, succinct_roles=succinct_roles
+        )
+        # Initialize all succinct delegated roles (`bins`), update expire,
+        # sign, add to `Snapshot` meta and persist in the backend storage
+        # service.
+        db_target_roles: List[targets_schema.RSTUFTargetRoleCreate] = []
+
+        for delegated_name in succinct_roles.get_roles():
+            targets.signed.add_key(self._online_key, delegated_name)
+            bins_role = Metadata(Targets())
+            db_target_roles.append(
+                targets_schema.RSTUFTargetRoleCreate(
+                    rolename=delegated_name, version=1
+                )
+            )
+            self._bump_expiry(bins_role, BINS)
+            self._sign(bins_role)
+            self._persist(bins_role, delegated_name)
+            delegated_roles.append(delegated_name)
+
+        targets_crud.create_roles(self._db, db_target_roles)
+
+    def _remove_delegated_role_keys(
+        self, targets: Metadata[Targets], delegated: DelegatedRole
+    ):
+        other_keys = []
+        logging.debug("mapping keys")
+        for not_delete in targets.signed.delegations.roles:
+            if not_delete == delegated:
+                continue
+            other_keys += targets.signed.delegations.roles[not_delete].keyids
+
+        role_keys = targets.signed.delegations.roles[delegated.name].keyids
+        for key in role_keys:
+            if key not in other_keys:
+                logging.debug(f"removing key id {key}")
+                targets.signed.delegations.keys.delete(key)
+            logging.debug(f"key {key} used by other role")
+
+    def _add_delegated_role_keys(
+        self,
+        targets: Metadata[Targets],
+        delegations: Delegations,
+        role_name: str,
+        role_metadata: Optional[Metadata[Targets]] = None,
+    ):
+        if len(delegations.roles[role_name].keyids) == 0:
+            logging.debug(f"role '{role_name}' without key, adding online key")
+            delegations.roles[role_name].keyids.append(self._online_key.keyid)
+
+        for keyid in delegations.roles[role_name].keyids:
+            if keyid not in targets.signed.delegations.keys.keys():
+                logging.debug(f"added key id {keyid}")
+                if delegation_key := delegations.keys[keyid]:
+                    targets.signed.delegations.keys[keyid] = delegation_key
+                else:
+                    raise ValueError(f"role {role_name} has inconsistent keys")
+            if keyid == self._online_key.keyid and role_metadata:
+                logging.debug(f"role '{role_name}' using online key, signing")
+                self._sign(role_metadata)
+
+    def _update_delegated_roles(
+        self,
+        targets: Metadata[Targets],
+        updated_delegated: DelegatedRole,
+        old_delegated: DelegatedRole,
+    ):
+        # NOTE: we don't support renaming and we verify it before
+        role_name = updated_delegated.name
+        # we can detect if keys are different, remove and add
+        if updated_delegated.keyids != old_delegated.keyids:
+            logging.debug("Identified different keys remove and add")
+
+            # remove keys
+            self._remove_delegated_role_keys(targets, old_delegated)
+        else:
+            logging.debug(f"role {role_name} has same keys")
+
+        targets.signed.delegations.roles.pop(role_name)
+        targets.signed.delegations.roles[role_name] = updated_delegated
+
+        # update expire policy
+        expires = updated_delegated.unrecognized_fields[
+            "x-rstuf-expire-policy"
+        ]
+        if expires != self._settings.get_fresh(
+            f"{role_name.upper()}_EXPIRATION"
+        ):
+            logging.debug(f"updating expire policy for role {role_name} ")
+            self.write_repository_settings(
+                f"{role_name.upper()}_EXPIRATION", expires
+            )
+
+    def _add_metadata_delegation(
+        self,
+        delegations: Delegations,
+        targets: Optional[Metadata[Targets]] = None,
+        persist_targets: Optional[bool] = True,
+    ) -> Tuple[Dict[str, Metadata[Targets]], List[str]]:
+        """Create a custom delegation role"""
+
+        if targets is None:
+            targets = self._storage_backend.get(Targets.type)
+
+        if targets.signed.delegations.succinct_roles:
+            raise RepositoryError(
+                "Delegations already using hash-bins, cannot add custom roles"
+            )
+
+        success = {}
+        failed = []
+        db_roles = []
+
+        logging.debug("adding roles to Targets delegations")
+        for role in delegations.roles:
+            if targets.signed.delegations.roles is None:
+                logging.debug("initializing Target delegations")
+                targets.signed.delegations.roles = {}
+
+            if (
+                role in targets.signed.delegations.roles
+                or targets_crud.read_role_deactivated_by_rolename(
+                    self._db, role
+                )
+            ):
+                logging.info(f"Role '{role}' already exists, skipping")
+                failed.append(
+                    {
+                        "role": role,
+                        "reason": (
+                            "role already exists or name used in the past",
+                        ),
+                    }
+                )
+                continue
+
+            # create delegated target role
+            role_metadata = Metadata(Targets(version=1))
+
+            # save expiration settings
+            expires = delegations.roles[role].unrecognized_fields[
+                "x-rstuf-expire-policy"
+            ]
+            self.write_repository_settings(
+                f"{role.upper()}_EXPIRATION", expires
+            )
+
+            # add keys to the delegated target role
+            # if no key is assigned, use the online key
+            if (
+                len(delegations.roles[role].keyids) == 0
+                and delegations.roles[role].threshold > 1
+            ):
+                failed.append(
+                    {
+                        "role": role,
+                        "reason": "If no keys assigned threshold must be 1",
+                    }
+                )
+
+            self._add_delegated_role_keys(
+                targets, delegations, role, role_metadata
+            )
+
+            if role not in targets.signed.delegations.roles:
+                logging.info(f"Role '{role}' added to Targets delegations")
+                targets.signed.delegations.roles[role] = delegations.roles[
+                    role
+                ]
+
+            success[role] = role_metadata
+
+            logging.debug(f"creating role db '{role}' schema")
+            db_roles = targets_schema.RSTUFTargetRoleCreate(
+                rolename=role, version=role_metadata.signed.version
+            )
+            targets_crud.create_roles(self._db, [db_roles])
+
+        if persist_targets and len(success) > 0:
+            self._bump_and_persist(targets, Targets.type)
+            self._update_timestamp(
+                self._update_snapshot(only_target=True), skip=True
+            )
+
+        return (success, failed)
+
+    def _delete_metadata_delegation(
+        self,
+        delegations: List[str],
+    ) -> Tuple[Dict[str, Metadata[Targets]], List[str]]:
+        """Create a custom delegation role"""
+
+        targets = self._storage_backend.get(Targets.type)
+        snapshot = self._storage_backend.get(Snapshot.type)
+        success = []
+        failed = []
+
+        if targets.signed.delegations.succinct_roles:
+            raise RepositoryError(
+                "Delegations already using hash-bins, cannot add custom roles"
+            )
+
+        # remove role from Targets delegations and mapping role unique keys
+        for role in delegations.get("roles"):
+            rolename = role["name"]
+            if rolename not in targets.signed.delegations.roles:
+                logging.info(f"Role '{rolename}' does not exists, skipping")
+                failed.append(
+                    {
+                        "role": rolename,
+                        "reason": f"Role '{rolename}' does not exists",
+                    }
+                )
+                continue
+            delegated_role = targets.signed.delegations.roles[rolename]
+            self._remove_delegated_role_keys(targets, delegated_role)
+
+            logging.debug(f"removing role '{rolename}'")
+            targets.signed.delegations.roles.pop(rolename)
+            logging.debug(
+                f"role '{rolename}' removed from Targets delegations"
+            )
+            snapshot.signed.meta.pop(f"{rolename}.json", None)
+            self.write_repository_settings(f"{rolename.upper()}_SIGNING", None)
+            db_role = targets_crud.read_role_by_rolename(self._db, rolename)
+            targets_crud.update_role_to_deactivated(self._db, db_role)
+            success.append(rolename)
+
+        if success:
+            self._bump_and_persist(targets, Targets.type)
+            self._update_timestamp(
+                self._update_snapshot(only_target=True), skip=True
+            )
+
+        return (success, failed)
+
+    def _update_metadata_delegation(
+        self,
+        delegations: Delegations,
+    ) -> Tuple[Dict[str, Metadata[Targets]], List[str]]:
+        """Create a custom delegation role"""
+
+        targets = self._storage_backend.get(Targets.type)
+
+        if targets.signed.delegations.succinct_roles:
+            raise RepositoryError(
+                "Delegations already using hash-bins, cannot add custom roles"
+            )
+
+        success = {}
+        failed = []
+        u_role: DelegatedRole  # updated role
+        o_role: DelegatedRole  # old role
+        logging.debug("adding roles to Targets delegations")
+        current_delegations = copy.deepcopy(targets.signed.delegations)
+        for u_role in delegations.roles.values():
+            for o_role in current_delegations.roles.values():
+                if u_role.name == o_role.name:
+                    if len(u_role.keyids) == 0 and u_role.threshold > 1:
+                        logging.debug(f"failed {u_role} due invalid threshold")
+                        failed.append(
+                            {
+                                "role": u_role.name,
+                                "reason": (
+                                    "If no keys assigned threshold must be 1"
+                                ),
+                            }
+                        )
+                        continue
+
+                    self._update_delegated_roles(targets, u_role, o_role)
+
+                    self._add_delegated_role_keys(
+                        targets, delegations, u_role.name
+                    )
+
+                    # not need the role metadata (update later by timestamp)
+                    success[u_role.name] = None
+                else:
+                    logging.debug(f"failed role {u_role.name} doesn't exist")
+                    failed.append(
+                        {
+                            "role": u_role.name,
+                            "reason": f"role {u_role} doesn't exist.",
+                        }
+                    )
+
+        if success:
+            self._bump_and_persist(targets, Targets.type)
+            self._update_timestamp(
+                self._update_snapshot(
+                    target_roles=[r for r in success], only_target=True
+                ),
+                skip=True,
+            )
+
+        return (success, failed)
 
     def _bootstrap_online_roles(
         self,
-        root: Metadata[Root],
-        custom_targets: Optional[Dict[str, Any]] = None,
+        delegations: Optional[Delegations] = None,
     ):
         """
         Bootstrap the roles that uses the online key
         """
         # Top level roles (`Targets`, `Timestamp``, `Snapshot`) initialization
+        logging.info("Bootstrap online roles")
         targets: Metadata[Targets] = Metadata(Targets())
+        targets.signed.delegations = Delegations({}, {})
         snapshot: Metadata[Snapshot] = Metadata(Snapshot())
+        snapshot.signed.meta[f"{Targets.type}.json"] = MetaFile()
         timestamp: Metadata[Timestamp] = Metadata(Timestamp())
 
-        _keyid: str = root.signed.roles[Timestamp.type].keyids[0]
-        public_key = root.signed.keys[_keyid]
-        self._setup_targets_delegations(public_key, targets, custom_targets)
-
-        db_target_roles: List[targets_schema.RSTUFTargetRoleCreate] = []
-        delegated_names = self._settings.get_fresh("DELEGATED_ROLES_NAMES")
-        for role_name in delegated_names:
-            snapshot.signed.meta[f"{role_name}.json"] = MetaFile()
-
-            db_target_roles.append(
-                targets_schema.RSTUFTargetRoleCreate(
-                    rolename=role_name, version=1
-                )
+        if self._online_key.keyid not in targets.signed.delegations.keys:
+            logging.debug("online key not in targets, adding key")
+            targets.signed.delegations.keys[self._online_key.keyid] = (
+                self._online_key
             )
 
-        targets_crud.create_roles(self._db, db_target_roles)
-        snapshot.signed.meta[f"{Targets.type}.json"] = MetaFile()
+        online_roles = {
+            Targets.type: targets,
+            Snapshot.type: snapshot,
+            Timestamp.type: timestamp,
+        }
+
+        if delegations:
+            logging.info("Bootstrap using custom delegations")
+            success, _ = self._add_metadata_delegation(
+                delegations, targets, persist_targets=False
+            )
+
+            logging.debug("verifying delegations threshold")
+            for role in success:
+                if self._validate_threshold(success[role], targets, role):
+                    logging.debug(f"role '{role}' uses only online key")
+                    snapshot.signed.meta[f"{role}.json"] = MetaFile(
+                        success[role].signed.version
+                    )
+                    online_roles[role] = success[role]
+
+                else:
+                    logging.debug(f"adding role '{role}'for signing")
+                    self.write_repository_settings(
+                        f"{role.upper()}_SIGNING",
+                        success[role].to_dict(),
+                    )
+
+        else:
+            logging.info("Bootstrap using custom hash bin delegations")
+            self._add_metadata_hashbin_delegations(targets)
 
         # Update expire, sign and persist the top level roles (`Targets`,
         # `Timestamp``, `Snapshot`) in the backend storage service.
-        for role in [targets, snapshot, timestamp]:
-            self._bump_expiry(role, role.signed.type)
-            self._sign(role)
-            self._persist(role, role.signed.type)
+        for role in online_roles:
+            self._bump_expiry(online_roles[role], role)
+            self._sign(online_roles[role])
+            self._persist(online_roles[role], role)
 
     @staticmethod
     def _task_result(
@@ -736,14 +1083,16 @@ class MetadataRepository:
         """
         Register the bootstrap finished.
         """
-        custom_delegated_roles: Dict[str, Any] = self._settings.get_fresh(
-            "CUSTOM_DELEGATED_ROLES"
-        )
+        pending_delegations = self._settings.get_fresh("DELEGATIONS")
+        if pending_delegations:
+            delegations = Delegations.from_dict(pending_delegations)
+        else:
+            delegations = None
         # All roles except root share the same one key and it doesn't matter
         # from which role we will get the key.
         keyid: str = root.signed.roles["timestamp"].keyids[0]
         self._online_key = root.signed.keys[keyid]
-        self._bootstrap_online_roles(root, custom_delegated_roles)
+        self._bootstrap_online_roles(delegations=delegations)
         self.write_repository_settings("ROOT_SIGNING", None)
         self._persist(root, Root.type)
         self.write_repository_settings("BOOTSTRAP", task_id)
@@ -947,7 +1296,8 @@ class MetadataRepository:
                     )
 
                 self._update_timestamp(
-                    self._update_snapshot(delegated_targets),
+                    self._update_snapshot(target_roles=delegated_targets),
+                    skip=True,
                 )
 
             # context lock finished
@@ -1160,8 +1510,7 @@ class MetadataRepository:
             force: force all target roles bump even if they have more than
             `self._hours_before_expire` hours to expire.
         """
-        timestamp: Metadata
-        snapshot_bump = False
+
         today = datetime.now(timezone.utc)
         if self._settings.get_fresh("TARGETS_ONLINE_KEY") is None:
             logging.critical("No configuration found for TARGETS_ONLINE_KEY")
@@ -1171,39 +1520,69 @@ class MetadataRepository:
                 f"{Targets.type} don't use online key, skipping 'Targets' role"
             )
         else:
-            targets: Metadata = self._storage_backend.get(Targets.type)
+            targets: Metadata[Targets] = self._storage_backend.get(
+                Targets.type
+            )
             if force or (targets.signed.expires - today) < timedelta(
                 hours=self._hours_before_expire
             ):
                 self._update_targets_delegations_key(targets)
                 self._bump_and_persist(targets, Targets.type)
                 logging.info("Bumped version of 'Targets' role")
-                snapshot_bump = True
 
         if force:
             # Updating all delegated target roles.
-            timestamp = self._update_timestamp(
-                self._update_snapshot(bump_all=True)
+            self._update_timestamp(
+                self._update_snapshot(bump_all=True, only_target=True)
             )
-            snapshot_bump = True
             logging.info("Targets and delegated Targets roles version bumped")
         else:
             # Updating only those delegated roles that have expired.
+            targets: Metadata[Targets] = self._storage_backend.get(
+                Targets.type
+            )
             delegated_roles: List[str] = []
-            delegated_names = self._settings.get_fresh("DELEGATED_ROLES_NAMES")
-            for role in delegated_names:
-                role_md: Metadata[Targets] = self._storage_backend.get(role)
+            if targets.signed.delegations.succinct_roles:
+                s_roles = targets.signed.delegations.succinct_roles.get_roles()
+                delegated_roles = [r for r in s_roles]
+            else:
+                delegated_roles = list(targets.signed.delegations.roles.keys())
+
+            for role in delegated_roles:
+                if targets_crud.read_role_deactivated_by_rolename(
+                    self._db, role
+                ):
+                    delegated_roles.remove(role)
+                    logging.debug(f"Role '{role}' is deactivated, skipping")
+                    continue
+
+                try:
+                    role_md: Metadata[Targets] = self._storage_backend.get(
+                        role
+                    )
+                except StorageError as err:
+                    if delegation_signing := self._settings.get_fresh(
+                        f"{role.upper()}_SIGNING"
+                    ):
+                        role_md = Metadata[Targets].from_dict(
+                            delegation_signing
+                        )
+                    else:
+                        raise err
+
                 if (role_md.signed.expires - today) < timedelta(
                     hours=self._hours_before_expire
                 ):
-                    delegated_roles.append(role)
+                    continue
+                else:
+                    delegated_roles.remove(role)
 
             if len(delegated_roles) > 0:
-                timestamp = self._update_timestamp(
-                    self._update_snapshot(target_roles=delegated_roles)
+                self._update_timestamp(
+                    self._update_snapshot(target_roles=delegated_roles),
+                    skip=True,
                 )
-                snapshot_bump = True
-                roles = "".join(delegated_roles)
+                roles = ",".join(delegated_roles)
                 logging.info(f"Bumped versions of expired roles: {roles}")
             else:
                 logging.debug(
@@ -1211,16 +1590,6 @@ class MetadataRepository:
                     f"{self._hours_before_expire} hour(s) to expire, "
                     "skipping"
                 )
-
-        if snapshot_bump:
-            snapshot_v = timestamp.signed.snapshot_meta.version
-            logging.info(
-                f"[scheduled bump] Snapshot version bumped: {snapshot_v}"
-            )
-            timestamp_v = timestamp.signed.version
-            logging.info(
-                f"[scheduled bump] Timestamp version bumped: {timestamp_v}"
-            )
 
     def bump_snapshot(self, force: Optional[bool] = False):
         """
@@ -1241,7 +1610,9 @@ class MetadataRepository:
         if (snapshot.signed.expires - datetime.now(timezone.utc)) < timedelta(
             hours=self._hours_before_expire
         ) or force:
-            timestamp = self._update_timestamp(self._update_snapshot())
+            timestamp = self._update_timestamp(
+                self._update_snapshot(only_snapshot=True)
+            )
             logging.info(
                 "[scheduled snapshot bump] Snapshot version bumped: "
                 f"{snapshot.signed.version + 1}"
@@ -1584,11 +1955,101 @@ class MetadataRepository:
 
         return self.metadata_update(payload, update_state)
 
+    def metadata_delegation(
+        self,
+        payload: Dict[str, Any],
+        targets: Optional[Metadata[Targets]] = None,
+        update_state: Optional[
+            Task.update_state
+        ] = None,  # It is required (see: app.py)
+    ):
+        """
+        Add delegation roles to the metadata.
+
+        Args:
+            payload: contains new metadata
+                Supported metadata types: Targets
+                example: {"metadata": {"targets": Any}}
+
+            targets: optional argument to pass the current targets metadata
+        """
+        action = payload.get("action")
+
+        match action:
+            case "add":
+                delegations: Delegations = Delegations.from_dict(
+                    payload["delegations"]
+                )
+                targets = self._storage_backend.get(Targets.type)
+                snapshot = self._storage_backend.get(Snapshot.type)
+                success, failed = self._add_metadata_delegation(
+                    delegations, targets, persist_targets=True
+                )
+                # NOTE: this portion of logic below cannot be part of the
+                # helper function `_add_metadata_delegation` because while
+                # running `_bootstrap_online_roles` targets still not exist
+                # and require to be persisted before
+                for role in success:
+                    if self._validate_threshold(success[role], targets, role):
+                        logging.debug(f"role '{role}' uses only online key")
+                        snapshot.signed.meta[f"{role}.json"] = MetaFile(
+                            success[role].signed.version
+                        )
+                        self._persist(success[role])
+
+                    else:
+                        logging.debug(f"adding role '{role}'for signing")
+                        self.write_repository_settings(
+                            f"{role.upper()}_SIGNING",
+                            success[role].to_dict(),
+                        )
+
+            case "delete":
+                delegations = payload["delegations"]
+                try:
+                    status_lock_targets = False
+                    with self._redis.lock(LOCK_TARGETS, timeout=self._timeout):
+                        success, failed = self._delete_metadata_delegation(
+                            payload["delegations"]
+                        )
+                except redis.exceptions.LockNotOwnedError:
+                    if status_lock_targets is False:
+                        logging.error(
+                            "The task to bump all online roles exceeded the "
+                            f"timeout of {self._timeout} seconds."
+                        )
+                        raise redis.exceptions.LockError(
+                            "RSTUF: Task exceed `LOCK_TIMEOUT` "
+                            f"({self._timeout} seconds)"
+                        )
+
+            case "update":
+                delegations: Delegations = Delegations.from_dict(
+                    payload["delegations"]
+                )
+                success, failed = self._update_metadata_delegation(delegations)
+
+            case _:
+                raise ValueError(
+                    "metadata delegation supports 'add', 'update', 'remove'"
+                )
+
+        return self._task_result(
+            task=TaskName.METADATA_DELEGATION,
+            message="Metadata Delegation Processed",
+            error=None,
+            details={
+                "delegated_roles": [sd for sd in success] or success,
+                "failed_roles": failed,
+            },
+        )
+
     @staticmethod
     def _validate_signature(
         metadata: Metadata,
         signature: Signature,
         delegator: Optional[Metadata] = None,
+        rolename: Optional[str] = Root.type,
     ) -> bool:
         """
         Validate signature over metadata using appropriate delegator.
@@ -1598,11 +2059,24 @@ class MetadataRepository:
             delegator = metadata
 
         keyid = signature.keyid
-        if keyid not in delegator.signed.roles[Root.type].keyids:
+        keyids: List[str] = []
+        if metadata.signed.type == Root.type:
+            keyids = delegator.signed.roles.get(rolename).keyids
+            key = delegator.signed.keys.get(signature.keyid)
+
+        elif metadata.signed.type == Targets.type:
+            keyids = delegator.signed.delegations.roles.get(rolename).keyids
+            key = delegator.signed.delegations.keys.get(signature.keyid)
+
+        else:
+            raise RepositoryError(
+                f"Unsupported metadata type: {metadata.signed.Type}"
+            )
+
+        if keyid not in keyids:
             logging.info(f"signature '{keyid}' not authorized")
             return False
 
-        key = delegator.signed.keys.get(signature.keyid)
         if not key:
             logging.info(f"no key for signature '{keyid}'")
             return False
@@ -1620,7 +2094,9 @@ class MetadataRepository:
 
     @staticmethod
     def _validate_threshold(
-        metadata: Metadata, delegator: Optional[Metadata] = None
+        metadata: Metadata,
+        delegator: Optional[Metadata] = None,
+        delegated_role: Optional[str] = Root.type,
     ) -> bool:
         """
         Validate signature threshold using appropriate delegator(s).
@@ -1630,7 +2106,7 @@ class MetadataRepository:
             delegator = metadata
 
         try:
-            delegator.verify_delegate(Root.type, metadata)
+            delegator.verify_delegate(delegated_role, metadata)
 
         except UnsignedMetadataError as e:
             logging.info(e)
@@ -1680,42 +2156,36 @@ class MetadataRepository:
         signature = Signature.from_dict(payload["signature"])
         rolename = payload["role"]
 
-        # Assert requested metadata type is root
-        if rolename != Root.type:
-            msg = f"Expected '{Root.type}', got '{rolename}'"
-            return _result(False, error=msg)
-
         # Assert pending signing event exists
-        metadata_dict = self._settings.get_fresh("ROOT_SIGNING")
+        metadata_dict = self._settings.get_fresh(f"{rolename.upper()}_SIGNING")
         if metadata_dict is None:
-            msg = "No signatures pending for root"
+            msg = f"No signatures pending for {rolename}"
             return _result(False, error=msg)
 
         # Assert metadata type is root
-        root = Metadata.from_dict(metadata_dict)
-        if not isinstance(root.signed, Root):
-            msg = f"Expected 'root', got '{root.signed.type}'"
-            return _result(False, error=msg)
+        metadata = Metadata.from_dict(metadata_dict)
 
         # If it isn't a "bootstrap" signing event, it must be "update metadata"
         bootstrap_state = self._settings.get_fresh("BOOTSTRAP")
-        if "signing" in bootstrap_state:
+        if metadata.signed.type == Root.type and "signing" in bootstrap_state:
             # Signature and threshold of initial root can only self-validate,
             # there is no "trusted root" at bootstrap time yet.
-            if not self._validate_signature(root, signature):
+            if not self._validate_signature(metadata, signature):
                 return _result(False, error="Invalid signature")
 
-            root.signatures[signature.keyid] = signature
-            if not self._validate_threshold(root):
-                self.write_repository_settings("ROOT_SIGNING", root.to_dict())
-                msg = f"Root v{root.signed.version} is pending signatures"
+            metadata.signatures[signature.keyid] = signature
+            if not self._validate_threshold(metadata):
+                self.write_repository_settings(
+                    "ROOT_SIGNING", metadata.to_dict()
+                )
+                msg = f"Root v{metadata.signed.version} is pending signatures"
                 return _result(True, bootstrap=msg)
 
             bootstrap_task_id = bootstrap_state.split("signing-")[1]
-            self._bootstrap_finalize(root, bootstrap_task_id)
+            self._bootstrap_finalize(metadata, bootstrap_task_id)
             return _result(True, bootstrap="Bootstrap Finished")
 
-        else:
+        elif metadata.signed.type == Root.type:
             # We need the "trusted root" when updating to a new root:
             # - signature could come from a key, which is only in the trusted
             #   root, OR from a key, which is only in the new root
@@ -1723,25 +2193,64 @@ class MetadataRepository:
             #   in the trusted root AND as defined in the new root
             trusted_root = self._storage_backend.get("root")
             is_valid_trusted = self._validate_signature(
-                root, signature, trusted_root
+                metadata, signature, trusted_root
             )
-            is_valid_new = self._validate_signature(root, signature)
+            is_valid_new = self._validate_signature(metadata, signature)
 
             if not (is_valid_trusted or is_valid_new):
                 return _result(False, error="Invalid signature")
 
-            root.signatures[signature.keyid] = signature
-            trusted_threshold = self._validate_threshold(root, trusted_root)
-            new_threshold = self._validate_threshold(root)
+            metadata.signatures[signature.keyid] = signature
+            trusted_threshold = self._validate_threshold(
+                metadata, trusted_root
+            )
+            new_threshold = self._validate_threshold(metadata)
             if not (trusted_threshold and new_threshold):
-                self.write_repository_settings("ROOT_SIGNING", root.to_dict())
-                msg = f"Root v{root.signed.version} is pending signatures"
+                self.write_repository_settings(
+                    "ROOT_SIGNING", metadata.to_dict()
+                )
+                msg = f"Root v{metadata.signed.version} is pending signatures"
                 return _result(True, update=msg)
 
             # Threshold reached -> finalize event
-            self._root_metadata_update_finalize(trusted_root, root)
+            self._root_metadata_update_finalize(trusted_root, metadata)
             self.write_repository_settings("ROOT_SIGNING", None)
             return _result(True, update="Metadata update finished")
+
+        else:
+            targets = self._storage_backend.get(Targets.type)
+            is_valid_trusted = self._validate_signature(
+                metadata, signature, targets, rolename
+            )
+
+            if not is_valid_trusted:
+                return _result(False, error="Invalid signature")
+
+            metadata.signatures[signature.keyid] = signature
+            trusted_threshold = self._validate_threshold(
+                metadata, targets, rolename
+            )
+            if not trusted_threshold:
+                self.write_repository_settings(
+                    f"{rolename.upper()}_SIGNING", metadata.to_dict()
+                )
+                msg = (
+                    f"{rolename} v{metadata.signed.version} is "
+                    "pending signatures"
+                )
+                return _result(True, update=msg)
+
+            # Threshold reached -> finalize event
+            logging.debug(f"finalizing '{rolename}' metadata signing")
+            snapshot = self._storage_backend.get(Snapshot.type)
+            snapshot.signed.meta[f"{rolename}.json"] = MetaFile(
+                version=metadata.signed.version,
+            )
+            self._bump_and_persist(snapshot, Snapshot.type)
+            self._update_timestamp(snapshot.signed.version)
+            self._persist(metadata, rolename)
+            self.write_repository_settings(f"{rolename.upper()}_SIGNING", None)
+            return _result(True, update=f"Role {rolename} signing complete")
 
     def delete_sign_metadata(
         self,

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -898,7 +898,7 @@ class MetadataRepository:
 
         if targets.signed.delegations.succinct_roles:
             raise RepositoryError(
-                "Delegations already using hash-bins, cannot add custom roles"
+                "Delegations already using hash-bins, cannot delete custom roles"
             )
 
         # remove role from Targets delegations and mapping role unique keys

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -736,7 +736,8 @@ class MetadataRepository:
             if key not in other_keys:
                 logging.debug(f"removing key id {key}")
                 targets.signed.delegations.keys.delete(key)
-            logging.debug(f"key {key} used by other role")
+             else:
+                logging.debug(f"key {key} used by other role")
 
     def _add_delegated_role_keys(
         self,

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -941,20 +941,20 @@ class MetadataRepository:
         self,
         delegations: Delegations,
     ) -> Tuple[Dict[str, Metadata[Targets]], List[str]]:
-        """Create a custom delegation role"""
+        """Update a custom delegation role"""
 
         targets = self._storage_backend.get(Targets.type)
 
         if targets.signed.delegations.succinct_roles:
             raise RepositoryError(
-                "Delegations already using hash-bins, cannot add custom roles"
+                "Delegations already using hash-bins, cannot update custom roles"
             )
 
         success = {}
         failed = []
         u_role: DelegatedRole  # updated role
         o_role: DelegatedRole  # old role
-        logging.debug("adding roles to Targets delegations")
+        logging.debug("updating roles in Targets delegations")
         current_delegations = copy.deepcopy(targets.signed.delegations)
         for u_role in delegations.roles.values():
             for o_role in current_delegations.roles.values():
@@ -2167,7 +2167,6 @@ class MetadataRepository:
             msg = f"No signatures pending for {rolename}"
             return _result(False, error=msg)
 
-        # Assert metadata type is root
         metadata = Metadata.from_dict(metadata_dict)
 
         # If it isn't a "bootstrap" signing event, it must be "update metadata"

--- a/repository_service_tuf_worker/services/storage/awss3.py
+++ b/repository_service_tuf_worker/services/storage/awss3.py
@@ -134,7 +134,9 @@ class AWSS3(IStorage):
             )
             file_object = s3_object.get("Body")
             return Metadata.from_bytes(file_object.read())
-        except DeserializationError as e:
+        except (DeserializationError, ClientError) as e:
+            if "NoSuchKey" in str(e):
+                raise StorageError(f"Role '{role}' not found") from e
             raise StorageError(f"Can't open Role '{role}'") from e
         finally:
             if file_object is not None:

--- a/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
+++ b/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
@@ -139,7 +139,9 @@ class TestCrud:
 
     def test_read_role_by_rolename(self, monkeypatch):
         monkeypatch.setattr(
-            crud.models, "RSTUFTargetRoles", pretend.stub(rolename="bins-0")
+            crud.models,
+            "RSTUFTargetRoles",
+            pretend.stub(rolename="bins-0", active=True),
         )
         mocked_first = pretend.stub(
             first=pretend.call_recorder(lambda: [crud.models.RSTUFTargetRoles])
@@ -157,15 +159,18 @@ class TestCrud:
         assert mocked_db.query.calls == [
             pretend.call(crud.models.RSTUFTargetRoles)
         ]
-        assert mocked_filter.filter.calls == [pretend.call(True)]
+        assert mocked_filter.filter.calls == [pretend.call(True, True)]
         assert mocked_first.first.calls == [pretend.call()]
 
     def test_read_all_roles(self):
         mocked_all = pretend.stub(
             all=pretend.call_recorder(lambda: [crud.models.RSTUFTargetRoles])
         )
+        mocked_filter = pretend.stub(
+            filter=pretend.call_recorder(lambda *a: mocked_all)
+        )
         mocked_db = pretend.stub(
-            query=pretend.call_recorder(lambda *a: mocked_all)
+            query=pretend.call_recorder(lambda *a: mocked_filter)
         )
         test_result = crud.read_all_roles(mocked_db)
         assert test_result == [crud.models.RSTUFTargetRoles]
@@ -176,7 +181,8 @@ class TestCrud:
 
     def test_read_roles_joint_files(self):
         crud.models.RSTUFTargetRoles = pretend.stub(
-            rolename=pretend.stub(in_=pretend.call_recorder(lambda *a: True))
+            rolename=pretend.stub(in_=pretend.call_recorder(lambda *a: True)),
+            active=True,
         )
         mocked_all = pretend.stub(
             all=pretend.call_recorder(lambda: [crud.models.RSTUFTargetRoles])
@@ -197,7 +203,7 @@ class TestCrud:
         assert mocked_db.query.calls == [
             pretend.call(crud.models.RSTUFTargetRoles)
         ]
-        assert mocked_filter.filter.calls == [pretend.call(True)]
+        assert mocked_filter.filter.calls == [pretend.call(True, True)]
         assert crud.models.RSTUFTargetRoles.rolename.in_.calls == [
             pretend.call("bins-0")
         ]

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -7,21 +7,13 @@ import datetime
 from contextlib import contextmanager
 from copy import copy
 from datetime import timezone
-from math import log
 
 import pretend
 import pytest
 from celery.exceptions import ChordError
 from celery.result import states
 from securesystemslib.exceptions import StorageError
-from tuf.api.metadata import (
-    Metadata,
-    MetaFile,
-    Root,
-    Snapshot,
-    Targets,
-    Timestamp,
-)
+from tuf.api.metadata import Metadata, Root, Snapshot, Targets, Timestamp
 
 from repository_service_tuf_worker import Dynaconf, repository
 from repository_service_tuf_worker.models import targets_schema
@@ -481,483 +473,14 @@ class TestMetadataRepository:
 
         result = test_repo._update_snapshot()
 
-        assert result == snapshot_version + 1
-        assert mocked_snapshot.signed.version == snapshot_version + 1
-        assert mocked_snapshot.signed.meta == {
-            "targets.json": MetaFile(version=targets_version)
-        }
+        assert result is None
+        assert mocked_snapshot.signed.version == snapshot_version
+        assert mocked_snapshot.signed.meta == {}
         assert test_repo._storage_backend.get.calls == [
             pretend.call(repository.Roles.SNAPSHOT.value),
             pretend.call(repository.Roles.TARGETS.value),
         ]
-        assert test_repo._bump_and_persist.calls == [
-            pretend.call(mocked_snapshot, repository.Roles.SNAPSHOT.value)
-        ]
-
-    def test__update_snapshot_specific_targets(self, test_repo, monkeypatch):
-        test_repo._db = pretend.stub()
-        repository.TargetFile.from_dict = pretend.call_recorder(
-            lambda *a: a[0]
-        )
-        snapshot_version = 3
-        bins_a_version = 4
-        bins_e_version = 4
-        targets_version = 3
-        # Test that only "bins-e" is updated. "bins-a" doesn't require update.
-        mocked_snapshot = pretend.stub(
-            signed=pretend.stub(
-                meta={
-                    "bins-a.json": bins_a_version,
-                    "bins-e.json": bins_e_version,
-                },
-                version=snapshot_version,
-            )
-        )
-        mocked_bins_md = pretend.stub(
-            signed=pretend.stub(targets={"k": "v"}, version=bins_e_version)
-        )
-        mocked_targets = pretend.stub(
-            signed=pretend.stub(
-                version=targets_version,
-                delegations=pretend.stub(succinct_roles=True),
-            )
-        )
-
-        def get(rolename: str):
-            if rolename == Snapshot.type:
-                return mocked_snapshot
-            elif rolename == Targets.type:
-                return mocked_targets
-            else:
-                return mocked_bins_md
-
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda rolename: get(rolename)
-        )
-        fake_bins_e = pretend.stub(
-            rolename="bins-e",
-            target_files=[
-                pretend.stub(
-                    path="k1",
-                    info="f1",
-                    action=repository.targets_schema.TargetAction.ADD,
-                ),
-                pretend.stub(
-                    path="k2",
-                    info="f2",
-                    action=repository.targets_schema.TargetAction.REMOVE,
-                ),
-            ],
-            id=5,
-        )
-        fake_bins_targets = [fake_bins_e]
-
-        monkeypatch.setattr(
-            repository.targets_crud,
-            "read_roles_joint_files",
-            pretend.call_recorder(lambda *a: fake_bins_targets),
-        )
-        monkeypatch.setattr(
-            repository.targets_crud,
-            "update_files_to_published",
-            pretend.call_recorder(lambda *a: None),
-        )
-        repository.MetaFile = pretend.call_recorder(lambda **kw: kw["version"])
-        monkeypatch.setattr(
-            repository.targets_crud,
-            "update_roles_version",
-            pretend.call_recorder(lambda *a: None),
-        )
-
-        def fake__bump_and_persist(md, role, **kw):
-            md.signed.version += 1
-
-        test_repo._bump_and_persist = pretend.call_recorder(
-            fake__bump_and_persist
-        )
-        test_repo._persist = pretend.call_recorder(lambda *a: None)
-
-        targets = ["bins-e"]
-        result = test_repo._update_snapshot(targets)
-
-        assert result == snapshot_version + 1
-        assert mocked_snapshot.signed.version == snapshot_version + 1
-        assert mocked_snapshot.signed.meta == {
-            "bins-a.json": bins_a_version,
-            "bins-e.json": bins_a_version + 1,
-            "targets.json": targets_version,
-        }
-        assert mocked_bins_md.signed.targets == {"k1": "f1"}
-        assert repository.targets_crud.read_roles_joint_files.calls == [
-            pretend.call(test_repo._db, targets)
-        ]
-        assert repository.TargetFile.from_dict.calls == [
-            pretend.call("f1", "k1"),
-        ]
-        assert repository.targets_crud.update_files_to_published.calls == [
-            pretend.call(
-                test_repo._db, [file.path for file in fake_bins_e.target_files]
-            )
-        ]
-        assert repository.MetaFile.calls == [
-            pretend.call(version=mocked_bins_md.signed.version),
-            pretend.call(version=mocked_targets.signed.version),
-        ]
-        assert repository.targets_crud.update_roles_version.calls == [
-            pretend.call(
-                test_repo._db, [int(bins.id) for bins in fake_bins_targets]
-            )
-        ]
-        assert test_repo._storage_backend.get.calls == [
-            pretend.call(repository.Roles.SNAPSHOT.value),
-            pretend.call(repository.Roles.TARGETS.value),
-            pretend.call("bins-e"),
-        ]
-        assert test_repo._bump_and_persist.calls == [
-            pretend.call(
-                mocked_bins_md, repository.Roles.BINS.value, persist=False
-            ),
-            pretend.call(mocked_snapshot, repository.Roles.SNAPSHOT.value),
-        ]
-        assert test_repo._persist.calls == [
-            pretend.call(mocked_bins_md, "bins-e"),
-        ]
-
-    def test__update_snapshot_specific_targets_custom_delegation_used(
-        self, test_repo, monkeypatch
-    ):
-        test_repo._db = pretend.stub()
-        repository.TargetFile.from_dict = pretend.call_recorder(
-            lambda *a: a[0]
-        )
-        snapshot_version = 3
-        foo_project_version = 4
-        second_project_version = 4
-        targets_version = 3
-        # Test that only "second_project" is updated. "foo_project" doesn't
-        # require update.
-        mocked_snapshot = pretend.stub(
-            signed=pretend.stub(
-                meta={
-                    "foo_project.json": foo_project_version,
-                    "second_project.json": second_project_version,
-                },
-                version=snapshot_version,
-            )
-        )
-        mocked_delegation_md = pretend.stub(
-            signed=pretend.stub(
-                targets={"k": "v"},
-                version=second_project_version,
-            )
-        )
-        mocked_targets = pretend.stub(
-            signed=pretend.stub(
-                version=targets_version,
-                delegations=pretend.stub(succinct_roles=None),
-            )
-        )
-
-        def get(rolename: str):
-            if rolename == Snapshot.type:
-                return mocked_snapshot
-            elif rolename == Targets.type:
-                return mocked_targets
-            else:
-                return mocked_delegation_md
-
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda rolename: get(rolename)
-        )
-        fake_delegation = pretend.stub(
-            rolename="second_project",
-            target_files=[
-                pretend.stub(
-                    path="k1",
-                    info="f1",
-                    action=repository.targets_schema.TargetAction.ADD,
-                ),
-                pretend.stub(
-                    path="k2",
-                    info="f2",
-                    action=repository.targets_schema.TargetAction.REMOVE,
-                ),
-            ],
-            id=5,
-        )
-        fake_delegations = [fake_delegation]
-
-        monkeypatch.setattr(
-            repository.targets_crud,
-            "read_roles_joint_files",
-            pretend.call_recorder(lambda *a: fake_delegations),
-        )
-        monkeypatch.setattr(
-            repository.targets_crud,
-            "update_files_to_published",
-            pretend.call_recorder(lambda *a: None),
-        )
-        repository.MetaFile = pretend.call_recorder(lambda **kw: kw["version"])
-        monkeypatch.setattr(
-            repository.targets_crud,
-            "update_roles_version",
-            pretend.call_recorder(lambda *a: None),
-        )
-
-        def fake__bump_and_persist(md, role, **kw):
-            md.signed.version += 1
-
-        test_repo._bump_and_persist = pretend.call_recorder(
-            fake__bump_and_persist
-        )
-        test_repo._persist = pretend.call_recorder(lambda *a: None)
-
-        targets = ["second_project"]
-        result = test_repo._update_snapshot(targets)
-
-        assert result == snapshot_version + 1
-        assert mocked_snapshot.signed.version == snapshot_version + 1
-        assert mocked_snapshot.signed.meta == {
-            "foo_project.json": foo_project_version,
-            "second_project.json": second_project_version + 1,
-            "targets.json": targets_version,
-        }
-        assert mocked_delegation_md.signed.targets == {"k1": "f1"}
-        assert repository.targets_crud.read_roles_joint_files.calls == [
-            pretend.call(test_repo._db, targets)
-        ]
-        assert repository.TargetFile.from_dict.calls == [
-            pretend.call("f1", "k1"),
-        ]
-        assert repository.targets_crud.update_files_to_published.calls == [
-            pretend.call(
-                test_repo._db,
-                [file.path for file in fake_delegation.target_files],
-            )
-        ]
-        assert repository.MetaFile.calls == [
-            pretend.call(version=mocked_delegation_md.signed.version),
-            pretend.call(version=mocked_targets.signed.version),
-        ]
-        assert repository.targets_crud.update_roles_version.calls == [
-            pretend.call(
-                test_repo._db, [int(deleg.id) for deleg in fake_delegations]
-            )
-        ]
-        assert test_repo._storage_backend.get.calls == [
-            pretend.call(repository.Roles.SNAPSHOT.value),
-            pretend.call(repository.Roles.TARGETS.value),
-            pretend.call("second_project"),
-        ]
-        assert test_repo._bump_and_persist.calls == [
-            pretend.call(
-                mocked_delegation_md, "second_project", persist=False
-            ),
-            pretend.call(mocked_snapshot, repository.Roles.SNAPSHOT.value),
-        ]
-        assert test_repo._persist.calls == [
-            pretend.call(mocked_delegation_md, "second_project"),
-        ]
-
-    def test__update_snapshot_bump_all(self, test_repo, monkeypatch):
-        snapshot_version = 3
-        targets_version = 4
-        mocked_snapshot = pretend.stub(
-            signed=pretend.stub(
-                meta={"bins-e.json": 2, "bins-f.json": 6},
-                version=snapshot_version,
-            )
-        )
-        mocked_bins = {
-            "bins-e": pretend.stub(
-                signed=pretend.stub(targets={"k": "v"}, version=2)
-            ),
-            "bins-f": pretend.stub(
-                signed=pretend.stub(targets={"k": "v"}, version=6)
-            ),
-        }
-        mocked_targets = pretend.stub(
-            signed=pretend.stub(
-                version=targets_version,
-                delegations=pretend.stub(succinct_roles=True),
-            )
-        )
-
-        def get(rolename: str):
-            if rolename == Snapshot.type:
-                return mocked_snapshot
-            elif rolename == Targets.type:
-                return mocked_targets
-            else:
-                return mocked_bins[rolename]
-
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda rolename: get(rolename)
-        )
-        fake_bins = [
-            pretend.stub(rolename="bins-e", id=3),
-            pretend.stub(rolename="bins-f", id=4),
-        ]
-        fake_read_all_roles = pretend.call_recorder(lambda *a: fake_bins)
-        test_repo._db = pretend.stub()
-        repository.MetaFile = pretend.call_recorder(lambda **kw: kw["version"])
-        monkeypatch.setattr(
-            repository.targets_crud,
-            "read_all_roles",
-            fake_read_all_roles,
-        )
-
-        def fake__bump_and_persist(md, role, **kw):
-            md.signed.version += 1
-
-        test_repo._bump_and_persist = pretend.call_recorder(
-            fake__bump_and_persist
-        )
-        test_repo._persist = pretend.call_recorder(lambda *a: None)
-        fake_update_roles_version = pretend.call_recorder(lambda *a: None)
-        monkeypatch.setattr(
-            repository.targets_crud,
-            "update_roles_version",
-            fake_update_roles_version,
-        )
-        result = test_repo._update_snapshot(bump_all=True)
-
-        assert result == snapshot_version + 1
-        assert mocked_snapshot.signed.version == snapshot_version + 1
-        assert mocked_snapshot.signed.meta == {
-            "bins-e.json": mocked_bins["bins-e"].signed.version,
-            "bins-f.json": mocked_bins["bins-f"].signed.version,
-            "targets.json": mocked_targets.signed.version,
-        }
-        assert fake_read_all_roles.calls == [pretend.call(test_repo._db)]
-        assert test_repo._bump_and_persist.calls == [
-            pretend.call(mocked_bins["bins-e"], "bins", persist=False),
-            pretend.call(mocked_bins["bins-f"], "bins", persist=False),
-            pretend.call(mocked_snapshot, "snapshot"),
-        ]
-        assert test_repo._storage_backend.get.calls == [
-            pretend.call(Snapshot.type),
-            pretend.call(Targets.type),
-            pretend.call("bins-e"),
-            pretend.call("bins-f"),
-        ]
-        assert test_repo._persist.calls == [
-            pretend.call(mocked_bins["bins-e"], "bins-e"),
-            pretend.call(mocked_bins["bins-f"], "bins-f"),
-        ]
-        assert fake_update_roles_version.calls == [
-            pretend.call(test_repo._db, [3, 4])
-        ]
-        assert repository.MetaFile.calls == [
-            pretend.call(version=mocked_bins["bins-e"].signed.version),
-            pretend.call(version=mocked_bins["bins-f"].signed.version),
-            pretend.call(version=mocked_targets.signed.version),
-        ]
-
-    def test__update_snapshot_bump_all_custom_delegation(
-        self, test_repo, monkeypatch
-    ):
-        snapshot_version = 3
-        targets_version = 4
-        mocked_snapshot = pretend.stub(
-            signed=pretend.stub(
-                meta={"project_1.json": 2, "project_2.json": 6},
-                version=snapshot_version,
-            )
-        )
-        mocked_delegations = {
-            "project_1": pretend.stub(
-                signed=pretend.stub(targets={"k": "v"}, version=2)
-            ),
-            "project_2": pretend.stub(
-                signed=pretend.stub(targets={"k": "v"}, version=6)
-            ),
-        }
-        mocked_targets = pretend.stub(
-            signed=pretend.stub(
-                version=targets_version,
-                delegations=pretend.stub(succinct_roles=True),
-            )
-        )
-
-        def get(rolename: str):
-            if rolename == Snapshot.type:
-                return mocked_snapshot
-            elif rolename == Targets.type:
-                return mocked_targets
-            else:
-                return mocked_delegations[rolename]
-
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda rolename: get(rolename)
-        )
-        fake_bins = [
-            pretend.stub(rolename="project_1", id=3),
-            pretend.stub(rolename="project_2", id=4),
-        ]
-        fake_read_all_roles = pretend.call_recorder(lambda *a: fake_bins)
-        test_repo._db = pretend.stub()
-        repository.MetaFile = pretend.call_recorder(lambda **kw: kw["version"])
-        monkeypatch.setattr(
-            repository.targets_crud,
-            "read_all_roles",
-            fake_read_all_roles,
-        )
-
-        def fake__bump_and_persist(md, role, **kw):
-            md.signed.version += 1
-
-        test_repo._bump_and_persist = pretend.call_recorder(
-            fake__bump_and_persist
-        )
-        test_repo._persist = pretend.call_recorder(lambda *a: None)
-        fake_update_roles_version = pretend.call_recorder(lambda *a: None)
-        monkeypatch.setattr(
-            repository.targets_crud,
-            "update_roles_version",
-            fake_update_roles_version,
-        )
-        result = test_repo._update_snapshot(bump_all=True)
-
-        assert result == snapshot_version + 1
-        assert mocked_snapshot.signed.version == snapshot_version + 1
-        assert mocked_snapshot.signed.meta == {
-            "project_1.json": mocked_delegations["project_1"].signed.version,
-            "project_2.json": mocked_delegations["project_2"].signed.version,
-            "targets.json": mocked_targets.signed.version,
-        }
-        assert fake_read_all_roles.calls == [pretend.call(test_repo._db)]
-        assert test_repo._bump_and_persist.calls == [
-            pretend.call(
-                mocked_delegations["project_1"], "bins", persist=False
-            ),
-            pretend.call(
-                mocked_delegations["project_2"], "bins", persist=False
-            ),
-            pretend.call(mocked_snapshot, "snapshot"),
-        ]
-        assert test_repo._storage_backend.get.calls == [
-            pretend.call(Snapshot.type),
-            pretend.call(Targets.type),
-            pretend.call("project_1"),
-            pretend.call("project_2"),
-        ]
-        assert test_repo._persist.calls == [
-            pretend.call(mocked_delegations["project_1"], "project_1"),
-            pretend.call(mocked_delegations["project_2"], "project_2"),
-        ]
-        assert fake_update_roles_version.calls == [
-            pretend.call(test_repo._db, [3, 4])
-        ]
-        assert repository.MetaFile.calls == [
-            pretend.call(
-                version=mocked_delegations["project_1"].signed.version
-            ),
-            pretend.call(
-                version=mocked_delegations["project_2"].signed.version
-            ),
-            pretend.call(version=mocked_targets.signed.version),
-        ]
+        assert test_repo._bump_and_persist.calls == []
 
     def test__update_targets_delegations_key_bins(
         self, test_repo, monkeypatch
@@ -1005,69 +528,6 @@ class TestMetadataRepository:
             pretend.call("old_keyid")
         ]
         assert fake_targets.signed.add_key.calls == [pretend.call(fake_key)]
-
-    def test__update_targets_delegations_key_custom_delegations(
-        self, test_repo, monkeypatch
-    ):
-        fake_key_dict = {"keyval": "foo", "keyid": "keyid"}
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(lambda a: copy(fake_key_dict))
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
-        fake_key = pretend.stub(keyid="new_key")
-        fake_key_obj = pretend.stub(
-            from_dict=pretend.call_recorder(lambda *a: fake_key)
-        )
-        monkeypatch.setattr(f"{REPOSITORY_PATH}.Key", fake_key_obj)
-        fake_root = pretend.stub(
-            signed=pretend.stub(
-                roles={Targets.type: pretend.stub(keyids=["old_keyid"])}
-            )
-        )
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda a: fake_root
-        )
-        fake_role1 = pretend.stub(name="role1")
-        fake_role2 = pretend.stub(name="role2")
-        fake_targets = pretend.stub(
-            signed=pretend.stub(
-                delegations=pretend.stub(
-                    succinct_roles=None,
-                    roles=pretend.stub(
-                        values=pretend.call_recorder(
-                            lambda: [fake_role1, fake_role2]
-                        )
-                    ),
-                ),
-                revoke_key=pretend.call_recorder(lambda *a: None),
-                add_key=pretend.call_recorder(lambda *a: None),
-            )
-        )
-
-        result = test_repo._update_targets_delegations_key(fake_targets)
-        assert result is None
-        assert test_repo._storage_backend.get.calls == [
-            pretend.call(Root.type)
-        ]
-        assert fake_settings.get_fresh.calls == [pretend.call("ONLINE_KEY")]
-        assert fake_key_obj.from_dict.calls == [
-            pretend.call(fake_key_dict.pop("keyid"), fake_key_dict)
-        ]
-        assert fake_targets.signed.delegations.roles.values.calls == [
-            pretend.call(),
-        ]
-        assert fake_targets.signed.revoke_key.calls == [
-            pretend.call("old_keyid", "role1"),
-            pretend.call("old_keyid", "role2"),
-        ]
-        assert fake_targets.signed.add_key.calls == [
-            pretend.call(fake_key, "role1"),
-            pretend.call(fake_key, "role2"),
-        ]
 
     def test__update_targets_delegations_online_key_not_changed(
         self, test_repo, monkeypatch
@@ -1297,9 +757,9 @@ class TestMetadataRepository:
 
     def test_save_settings_bins(self, test_repo):
         fake_root_md = pretend.stub(
-            type="root",
             signatures=[{"keyid": "sig1"}, {"keyid": "sig2"}],
             signed=pretend.stub(
+                type="root",
                 roles={"root": pretend.stub(threshold=1)},
             ),
         )
@@ -1335,258 +795,6 @@ class TestMetadataRepository:
             pretend.call("BINS_NUM_KEYS", 1),
             pretend.call("NUMBER_OF_DELEGATED_BINS", 4),
         ]
-
-    def test_save_settings_custom_targets(self, test_repo):
-        fake_root_md = pretend.stub(
-            type="root",
-            signatures=[{"keyid": "sig1"}, {"keyid": "sig2"}],
-            signed=pretend.stub(
-                roles={"root": pretend.stub(threshold=1)},
-            ),
-        )
-        test_repo.write_repository_settings = pretend.call_recorder(
-            lambda *a: None
-        )
-        payload_settings = {
-            "root": {"expiration": 365},
-            "targets": {"expiration": 365},
-            "snapshot": {"expiration": 1},
-            "timestamp": {"expiration": 1},
-            "delegated_roles": {
-                "foo": {"expiration": 30, "path_patterns": ["project/f"]},
-                "bar": {"expiration": 60, "path_patterns": ["project/b"]},
-            },
-        }
-
-        result = test_repo.save_settings(fake_root_md, payload_settings)
-        assert result is None
-        assert test_repo.write_repository_settings.calls == [
-            pretend.call("ROOT_EXPIRATION", 365),
-            pretend.call("ROOT_THRESHOLD", 1),
-            pretend.call("ROOT_NUM_KEYS", 2),
-            pretend.call("SNAPSHOT_EXPIRATION", 1),
-            pretend.call("SNAPSHOT_THRESHOLD", 1),
-            pretend.call("SNAPSHOT_NUM_KEYS", 1),
-            pretend.call("TARGETS_EXPIRATION", 365),
-            pretend.call("TARGETS_THRESHOLD", 1),
-            pretend.call("TARGETS_NUM_KEYS", 1),
-            pretend.call("TIMESTAMP_EXPIRATION", 1),
-            pretend.call("TIMESTAMP_THRESHOLD", 1),
-            pretend.call("TIMESTAMP_NUM_KEYS", 1),
-            pretend.call("TARGETS_ONLINE_KEY", True),
-            pretend.call(
-                "CUSTOM_DELEGATED_ROLES", payload_settings["delegated_roles"]
-            ),
-            pretend.call("FOO_EXPIRATION", 30),
-            pretend.call("FOO_THRESHOLD", 1),
-            pretend.call("FOO_NUM_KEYS", 1),
-            pretend.call("FOO_PATH_PATTERNS", ["project/f"]),
-            pretend.call("BAR_EXPIRATION", 60),
-            pretend.call("BAR_THRESHOLD", 1),
-            pretend.call("BAR_NUM_KEYS", 1),
-            pretend.call("BAR_PATH_PATTERNS", ["project/b"]),
-        ]
-
-    def test__setup_targets_delegations_custom_targets(self, test_repo):
-        fake_pub_online_key = pretend.stub(
-            key_dict={"keyid": "id", "keytype": "rsa"}, keyid="id"
-        )
-
-        repository.Targets.add_key = pretend.call_recorder(lambda *a: None)
-
-        test_repo._bump_expiry = pretend.call_recorder(lambda *a: None)
-        test_repo._sign = pretend.call_recorder(lambda *a: None)
-        test_repo._persist = pretend.call_recorder(lambda *a: None)
-        test_repo.write_repository_settings = pretend.call_recorder(
-            lambda *a: None
-        )
-
-        fake_targets = pretend.stub(
-            signed=pretend.stub(
-                delegations=pretend.stub(roles={}),
-                add_key=pretend.call_recorder(lambda *a: None),
-            )
-        )
-
-        custom_targets = {
-            "role1": {"expiration": 30, "path_patterns": "role1/"},
-            "role2": {"expiration": 300, "path_patterns": "role2/"},
-        }
-
-        result = test_repo._setup_targets_delegations(
-            fake_pub_online_key, fake_targets, custom_targets
-        )
-        assert result is None
-        assert fake_targets.signed.add_key.calls == [
-            pretend.call(fake_pub_online_key, "role1"),
-            pretend.call(fake_pub_online_key, "role2"),
-        ]
-        call_id = 0
-        for role_name in custom_targets.keys():
-            call = test_repo._bump_expiry.calls[call_id]
-            assert len(call.args) == 2
-            assert isinstance(call.args[0], repository.Metadata)
-            assert call.args[1] == role_name
-
-            call = test_repo._sign.calls[call_id]
-            assert len(call.args) == 1
-            assert isinstance(call.args[0], repository.Metadata)
-
-            call = test_repo._persist.calls[call_id]
-            assert len(call.args) == 2
-            assert isinstance(call.args[0], repository.Metadata)
-            assert call.args[1] == role_name
-
-            call_id += 1
-
-        assert test_repo.write_repository_settings.calls == [
-            pretend.call("DELEGATED_ROLES_NAMES", ["role1", "role2"])
-        ]
-
-    def test__setup_targets_delegations_hash_bins_delegations(
-        self, test_repo, monkeypatch
-    ):
-        fake_pub_online_key = pretend.stub(
-            key_dict={"keyid": "id", "keytype": "rsa"}, keyid="id"
-        )
-        repository.Targets.add_key = pretend.call_recorder(lambda *a: None)
-
-        get_fresh_resp = 2
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(lambda *a: get_fresh_resp)
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
-        test_repo._bump_expiry = pretend.call_recorder(lambda *a: None)
-        test_repo._sign = pretend.call_recorder(lambda *a: None)
-        test_repo._persist = pretend.call_recorder(lambda *a: None)
-        test_repo.write_repository_settings = pretend.call_recorder(
-            lambda *a: None
-        )
-
-        fake_targets = pretend.stub(
-            signed=pretend.stub(
-                delegations=None,
-                add_key=pretend.call_recorder(lambda *a: None),
-            )
-        )
-
-        result = test_repo._setup_targets_delegations(
-            fake_pub_online_key,
-            fake_targets,
-        )
-        assert result is None
-        assert fake_settings.get_fresh.calls == [
-            pretend.call("NUMBER_OF_DELEGATED_BINS")
-        ]
-        for idx, call in enumerate(repository.Targets.add_key.calls):
-            assert call.args[1] == fake_pub_online_key
-            assert call.args[2] == f"bins-{idx}"
-
-        bit_length = log(get_fresh_resp, 2)
-        call_id = 0
-        while call_id < bit_length:
-            call = test_repo._bump_expiry.calls[call_id]
-            assert len(call.args) == 2
-            assert isinstance(call.args[0], repository.Metadata)
-            assert call.args[1] == repository.BINS
-
-            call = test_repo._sign.calls[call_id]
-            assert len(call.args) == 1
-            assert isinstance(call.args[0], repository.Metadata)
-
-            call = test_repo._persist.calls[call_id]
-            assert len(call.args) == 2
-            assert isinstance(call.args[0], repository.Metadata)
-            assert call.args[1] == f"{repository.BINS}-{call_id}"
-
-            call_id += 1
-
-        assert test_repo.write_repository_settings.calls == [
-            pretend.call("DELEGATED_ROLES_NAMES", ["bins-0", "bins-1"])
-        ]
-
-    def test__bootstrap_online_roles(self, test_repo, monkeypatch):
-        fake_root_md = pretend.stub(
-            type="root",
-            signed=pretend.stub(
-                roles={"timestamp": pretend.stub(keyids=["online_key_id"])},
-                keys={"online_key_id": "online_public_key"},
-            ),
-        )
-        test_repo._setup_targets_delegations = pretend.call_recorder(
-            lambda *a: None
-        )
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(lambda a: ["bins-0", "bins-1"])
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
-        repository.MetaFile = pretend.call_recorder(lambda: "name")
-
-        monkeypatch.setattr(
-            repository.targets_crud,
-            "create_roles",
-            pretend.call_recorder(lambda *a: None),
-        )
-        test_repo._db = "db_session"
-        test_repo._bump_expiry = pretend.call_recorder(lambda *a: None)
-        test_repo._sign = pretend.call_recorder(lambda *a: None)
-        test_repo._persist = pretend.call_recorder(lambda *a: None)
-
-        result = test_repo._bootstrap_online_roles(fake_root_md)
-        assert result is None
-        assert len(test_repo._setup_targets_delegations.calls) == 1
-        call = test_repo._setup_targets_delegations.calls[0]
-        assert call.args[0] == "online_public_key"
-        assert isinstance(call.args[1], Metadata)
-        assert call.args[2] is None
-        assert test_repo._settings.get_fresh.calls == [
-            pretend.call("DELEGATED_ROLES_NAMES")
-        ]
-
-        assert repository.targets_crud.create_roles.calls == [
-            pretend.call(
-                "db_session",
-                [
-                    repository.targets_schema.RSTUFTargetRoleCreate(
-                        rolename="bins-0", version=1
-                    ),
-                    repository.targets_schema.RSTUFTargetRoleCreate(
-                        rolename="bins-1", version=1
-                    ),
-                ],
-            )
-        ]
-        # Special checks as calls use metadata object instances
-        # Assert that calls contain two args and 'role' argument is a
-        # 'Metadata'.
-        call_id = 0
-        for md_cls in [Targets, Snapshot, Timestamp]:
-            call = test_repo._bump_expiry.calls[call_id]
-            assert len(call.args) == 2
-            assert isinstance(call.args[0], repository.Metadata)
-            assert isinstance(call.args[0].signed, md_cls)
-            assert call.args[1] == md_cls.type
-
-            call = test_repo._sign.calls[call_id]
-            assert len(call.args) == 1
-            assert isinstance(call.args[0], repository.Metadata)
-            assert isinstance(call.args[0].signed, md_cls)
-
-            call = test_repo._persist.calls[call_id]
-            assert len(call.args) == 2
-            assert isinstance(call.args[0], repository.Metadata)
-            assert isinstance(call.args[0].signed, md_cls)
-            assert call.args[1] == md_cls.type
-
-            call_id += 1
 
     def test_update_settings(self, test_repo, mocked_datetime, monkeypatch):
         test_repo.write_repository_settings = pretend.call_recorder(
@@ -1765,55 +973,6 @@ class TestMetadataRepository:
             pretend.call(f"{Snapshot.type.upper()}_EXPIRATION", SNAPSHOT_EXP),
         ]
 
-    def test__bootstrap_finalize(self, test_repo, monkeypatch):
-        fake_key_dict = {"keyval": "foo"}
-        fake_key = pretend.stub(
-            to_dict=pretend.call_recorder(lambda: fake_key_dict), keyid="keyid"
-        )
-        fake_role = pretend.stub(keyids=["keyid"])
-        fake_root = pretend.stub(
-            signatures=pretend.stub(clear=pretend.call_recorder(lambda: None)),
-            sign=pretend.call_recorder(lambda *a, **kw: None),
-            signed=pretend.stub(
-                roles={"timestamp": fake_role},
-                keys={"keyid": fake_key},
-            ),
-        )
-        test_repo._persist = pretend.call_recorder(lambda *a: None)
-        test_repo.write_repository_settings = pretend.call_recorder(
-            lambda *a: None
-        )
-        test_repo._bootstrap_online_roles = pretend.call_recorder(
-            lambda *a: None
-        )
-        fake_delegated_roles = pretend.stub()
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(lambda a: fake_delegated_roles)
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
-        result = test_repo._bootstrap_finalize(fake_root, "task_id")
-
-        assert result is None
-        assert fake_settings.get_fresh.calls == [
-            pretend.call("CUSTOM_DELEGATED_ROLES")
-        ]
-        assert fake_key.to_dict.calls == [pretend.call()]
-        assert test_repo._persist.calls == [
-            pretend.call(fake_root, repository.Root.type)
-        ]
-        assert test_repo.write_repository_settings.calls == [
-            pretend.call("ONLINE_KEY", fake_key_dict),
-            pretend.call("ROOT_SIGNING", None),
-            pretend.call("BOOTSTRAP", "task_id"),
-        ]
-        assert test_repo._bootstrap_online_roles.calls == [
-            pretend.call(fake_root, fake_delegated_roles)
-        ]
-
     def test_bootstrap(self, monkeypatch, test_repo, mocked_datetime):
         fake_settings = pretend.stub(
             get_fresh=pretend.call_recorder(lambda *a: "pre-<task-id>")
@@ -1825,8 +984,8 @@ class TestMetadataRepository:
         )
         fake_root_md = pretend.stub(
             signatures={"keyid1": "sig1", "key2": "sig2"},
-            type="root",
             signed=pretend.stub(
+                type="root",
                 roles={
                     "root": pretend.stub(
                         keyids=["keyid1", "keyid2"], threshold=2
@@ -1906,8 +1065,8 @@ class TestMetadataRepository:
         )
         fake_root_md = pretend.stub(
             signatures=[],
-            type="root",
             signed=pretend.stub(
+                type="root",
                 roles={
                     "root": pretend.stub(
                         keyids=["keyid1", "keyid2"], threshold=2
@@ -1976,8 +1135,8 @@ class TestMetadataRepository:
         )
         fake_root_md = pretend.stub(
             signatures={"keyid1": "sig1", "key2": "sig2"},
-            type="root",
             signed=pretend.stub(
+                type="root",
                 roles={
                     "root": pretend.stub(
                         keyids=["keyid1", "keyid2"], threshold=2
@@ -2116,8 +1275,8 @@ class TestMetadataRepository:
         )
         fake_root_md = pretend.stub(
             signatures={"keyid1": "sig1", "key2": "sig2"},
-            type="root",
             signed=pretend.stub(
+                type="root",
                 roles={
                     "root": pretend.stub(
                         keyids=["keyid1", "keyid2"], threshold=2
@@ -2285,7 +1444,9 @@ class TestMetadataRepository:
         def mocked_lock(lock, timeout):
             yield lock, timeout
 
-        test_repo._db = pretend.stub()
+        test_repo._db = pretend.stub(
+            bind=pretend.stub(url=pretend.stub(drivername="postgresql"))
+        )
         test_repo._redis = pretend.stub(
             lock=pretend.call_recorder(mocked_lock),
         )
@@ -2298,8 +1459,10 @@ class TestMetadataRepository:
             "read_roles_with_unpublished_files",
             fake_crud_read_roles_with_unpublished_files,
         )
-        test_repo._update_snapshot = pretend.call_recorder(lambda *a: 3)
-        test_repo._update_timestamp = pretend.call_recorder(lambda *a: None)
+        test_repo._update_snapshot = pretend.call_recorder(lambda *a, **kw: 3)
+        test_repo._update_timestamp = pretend.call_recorder(
+            lambda *a, **kw: None
+        )
 
         result = test_repo.publish_artifacts()
 
@@ -2320,9 +1483,11 @@ class TestMetadataRepository:
             pretend.call(test_repo._db)
         ]
         assert test_repo._update_snapshot.calls == [
-            pretend.call(["bins-0", "bins-e"])
+            pretend.call(target_roles=["bins-0", "bins-e"])
         ]
-        assert test_repo._update_timestamp.calls == [pretend.call(3)]
+        assert test_repo._update_timestamp.calls == [
+            pretend.call(3, skip=True)
+        ]
 
     def test_publish_artifacts_payload_delegated_targets(
         self, test_repo, mocked_datetime
@@ -2331,13 +1496,17 @@ class TestMetadataRepository:
         def mocked_lock(lock, timeout):
             yield lock, timeout
 
-        test_repo._db = pretend.stub()
+        test_repo._db = pretend.stub(
+            bind=pretend.stub(url=pretend.stub(drivername="postgresql"))
+        )
         test_repo._redis = pretend.stub(
             lock=pretend.call_recorder(mocked_lock),
         )
 
-        test_repo._update_snapshot = pretend.call_recorder(lambda *a: 3)
-        test_repo._update_timestamp = pretend.call_recorder(lambda *a: None)
+        test_repo._update_snapshot = pretend.call_recorder(lambda *a, **kw: 3)
+        test_repo._update_timestamp = pretend.call_recorder(
+            lambda *a, **kw: None
+        )
 
         payload = {"delegated_targets": ["bins-0", "bins-e"]}
         result = test_repo.publish_artifacts(payload)
@@ -2356,9 +1525,11 @@ class TestMetadataRepository:
             pretend.call(repository.LOCK_TARGETS, timeout=60.0),
         ]
         assert test_repo._update_snapshot.calls == [
-            pretend.call(["bins-0", "bins-e"])
+            pretend.call(target_roles=["bins-0", "bins-e"])
         ]
-        assert test_repo._update_timestamp.calls == [pretend.call(3)]
+        assert test_repo._update_timestamp.calls == [
+            pretend.call(3, skip=True)
+        ]
 
     def test_publish_artifacts_payload_with_delegated_targets_empty(
         self, test_repo, monkeypatch, mocked_datetime
@@ -2367,7 +1538,9 @@ class TestMetadataRepository:
         def mocked_lock(lock, timeout):
             yield lock, timeout
 
-        test_repo._db = pretend.stub()
+        test_repo._db = pretend.stub(
+            bind=pretend.stub(url=pretend.stub(drivername="postgresql"))
+        )
         test_repo._redis = pretend.stub(
             lock=pretend.call_recorder(mocked_lock),
         )
@@ -2380,8 +1553,10 @@ class TestMetadataRepository:
             "read_roles_with_unpublished_files",
             fake_crud_read_roles_with_unpublished_files,
         )
-        test_repo._update_snapshot = pretend.call_recorder(lambda *a: 3)
-        test_repo._update_timestamp = pretend.call_recorder(lambda *a: None)
+        test_repo._update_snapshot = pretend.call_recorder(lambda *a, **kw: 3)
+        test_repo._update_timestamp = pretend.call_recorder(
+            lambda *a, **kw: None
+        )
 
         payload = {"delegated_targets": None}
         result = test_repo.publish_artifacts(payload)
@@ -2403,9 +1578,11 @@ class TestMetadataRepository:
             pretend.call(test_repo._db)
         ]
         assert test_repo._update_snapshot.calls == [
-            pretend.call(["bins-0", "bins-e"])
+            pretend.call(target_roles=["bins-0", "bins-e"])
         ]
-        assert test_repo._update_timestamp.calls == [pretend.call(3)]
+        assert test_repo._update_timestamp.calls == [
+            pretend.call(3, skip=True)
+        ]
 
     def test_publish_artifacts_exception_LockNotOwnedError(self, test_repo):
         @contextmanager
@@ -2431,7 +1608,9 @@ class TestMetadataRepository:
         def mocked_lock(lock, timeout):
             yield lock, timeout
 
-        test_repo._db = pretend.stub()
+        test_repo._db = pretend.stub(
+            bind=pretend.stub(url=pretend.stub(drivername="postgresql"))
+        )
         test_repo._redis = pretend.stub(
             lock=pretend.call_recorder(mocked_lock),
         )
@@ -2464,7 +1643,9 @@ class TestMetadataRepository:
         )
 
     def test_add_artifacts(self, test_repo, monkeypatch, mocked_datetime):
-        test_repo._db = pretend.stub()
+        test_repo._db = pretend.stub(
+            bind=pretend.stub(url=pretend.stub(drivername="postgresql"))
+        )
         test_repo._get_role_for_artifact_path = pretend.call_recorder(
             lambda *a: "bins-e"
         )
@@ -2569,7 +1750,9 @@ class TestMetadataRepository:
     def test_add_artifacts_exists(
         self, test_repo, monkeypatch, mocked_datetime
     ):
-        test_repo._db = pretend.stub()
+        test_repo._db = pretend.stub(
+            bind=pretend.stub(url=pretend.stub(drivername="postgresql"))
+        )
         test_repo._get_role_for_artifact_path = pretend.call_recorder(
             lambda *a: "bins-e"
         )
@@ -2668,7 +1851,9 @@ class TestMetadataRepository:
     def test_add_artifacts_skip_publishing(
         self, test_repo, monkeypatch, mocked_datetime
     ):
-        test_repo._db = pretend.stub()
+        test_repo._db = pretend.stub(
+            bind=pretend.stub(url=pretend.stub(drivername="postgresql"))
+        )
         test_repo._get_role_for_artifact_path = pretend.call_recorder(
             lambda *a: "bins-e"
         )
@@ -2766,7 +1951,9 @@ class TestMetadataRepository:
     def test_add_artifacts_invalid_path(
         self, test_repo, monkeypatch, mocked_datetime
     ):
-        test_repo._db = pretend.stub()
+        test_repo._db = pretend.stub(
+            bind=pretend.stub(url=pretend.stub(drivername="postgresql"))
+        )
         test_repo._get_role_for_artifact_path = pretend.call_recorder(
             lambda *a: None
         )
@@ -3076,7 +2263,14 @@ class TestMetadataRepository:
         test_repo._get_role_for_artifact_path = pretend.call_recorder(
             lambda *a: "bin-e"
         )
-
+        test_repo._db = pretend.stub(
+            refresh=pretend.call_recorder(lambda *a: None),
+            bind=pretend.stub(
+                url=pretend.stub(
+                    drivername="postgresql",
+                )
+            ),
+        )
         monkeypatch.setattr(
             repository.targets_crud,
             "read_file_by_path",
@@ -3127,9 +2321,18 @@ class TestMetadataRepository:
         test_repo._get_role_for_artifact_path = pretend.call_recorder(
             lambda *a: "bin-e"
         )
-
+        test_repo._db = pretend.stub(
+            refresh=pretend.call_recorder(lambda *a: None),
+            bind=pretend.stub(
+                url=pretend.stub(
+                    drivername="postgresql",
+                )
+            ),
+        )
         fake_db_target = pretend.stub(
-            action=targets_schema.TargetAction.REMOVE, published=True
+            bind=pretend.stub(url=pretend.stub(drivename="postgresql")),
+            action=targets_schema.TargetAction.REMOVE,
+            published=True,
         )
         monkeypatch.setattr(
             repository.targets_crud,
@@ -3210,306 +2413,6 @@ class TestMetadataRepository:
             "details": None,
         }
 
-    def test__run_online_roles_bump_only_expired(
-        self, monkeypatch, test_repo, mocked_datetime, caplog
-    ):
-        caplog.set_level(repository.logging.INFO)
-        fake_targets = pretend.stub(
-            signed=pretend.stub(
-                expires=mocked_datetime.now(),
-                version=1,
-            )
-        )
-
-        fake_bins = pretend.stub(
-            signed=pretend.stub(
-                targets={}, version=6, expires=mocked_datetime.now()
-            )
-        )
-
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda rolename: (
-                fake_targets if rolename == Targets.type else fake_bins
-            )
-        )
-
-        def fake_get_fresh(setting: str):
-            if setting == "TARGETS_ONLINE_KEY":
-                return True
-            elif setting == "DELEGATED_ROLES_NAMES":
-                return ["bin-a"]
-
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(lambda a: fake_get_fresh(a))
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
-        test_repo._update_targets_delegations_key = pretend.call_recorder(
-            lambda a: None
-        )
-        test_repo._bump_and_persist = pretend.call_recorder(lambda *a: None)
-        test_repo._update_snapshot = pretend.call_recorder(
-            lambda **kw: "fake_snapshot"
-        )
-        test_repo._update_timestamp = pretend.call_recorder(
-            lambda a: pretend.stub(
-                signed=pretend.stub(
-                    snapshot_meta=pretend.stub(version=79),
-                    version=87,
-                    expires=datetime.datetime(2028, 6, 16, 9, 5, 1),
-                )
-            )
-        )
-        test_repo._run_online_roles_bump()
-        assert test_repo._storage_backend.get.calls == [
-            pretend.call(Targets.type),
-            pretend.call("bin-a"),
-        ]
-        assert fake_settings.get_fresh.calls == [
-            pretend.call("TARGETS_ONLINE_KEY"),
-            pretend.call("TARGETS_ONLINE_KEY"),
-            pretend.call("DELEGATED_ROLES_NAMES"),
-        ]
-        assert test_repo._update_targets_delegations_key.calls == [
-            pretend.call(fake_targets)
-        ]
-        assert test_repo._bump_and_persist.calls == [
-            pretend.call(fake_targets, Targets.type),
-        ]
-        assert test_repo._update_snapshot.calls == [
-            pretend.call(target_roles=["bin-a"])
-        ]
-        assert test_repo._update_timestamp.calls == [
-            pretend.call("fake_snapshot")
-        ]
-        assert "Bumped version of 'Targets' role" == caplog.messages[0]
-        msg_2 = "Bumped versions of expired roles: bin-a"
-        assert msg_2 == caplog.messages[1]
-        assert "Snapshot version bumped: 79" in caplog.messages[2]
-        assert "Timestamp version bumped: 87" in caplog.messages[3]
-
-    def test__run_online_roles_bump_force(
-        self, monkeypatch, test_repo, caplog
-    ):
-        caplog.set_level(repository.logging.INFO)
-        fake_targets = pretend.stub(
-            signed=pretend.stub(
-                version=1,
-            )
-        )
-
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda a: fake_targets
-        )
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(lambda a: True)
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
-        test_repo._update_targets_delegations_key = pretend.call_recorder(
-            lambda a: None
-        )
-        test_repo._bump_and_persist = pretend.call_recorder(lambda *a: None)
-        test_repo._update_snapshot = pretend.call_recorder(
-            lambda **kw: "fake_snapshot"
-        )
-        test_repo._update_timestamp = pretend.call_recorder(
-            lambda *a: pretend.stub(
-                signed=pretend.stub(
-                    snapshot_meta=pretend.stub(version=79),
-                    version=87,
-                    expires=datetime.datetime(2028, 6, 16, 9, 5, 1),
-                )
-            )
-        )
-        test_repo._run_online_roles_bump(force=True)
-        assert test_repo._storage_backend.get.calls == [
-            pretend.call(Targets.type),
-        ]
-        assert test_repo._update_targets_delegations_key.calls == [
-            pretend.call(fake_targets)
-        ]
-        assert test_repo._bump_and_persist.calls == [
-            pretend.call(fake_targets, Targets.type),
-        ]
-        assert test_repo._update_snapshot.calls == [
-            pretend.call(bump_all=True)
-        ]
-        assert test_repo._update_timestamp.calls == [
-            pretend.call("fake_snapshot")
-        ]
-        assert "Bumped version of 'Targets' role" == caplog.messages[0]
-        msg_2 = "Targets and delegated Targets roles version bumped"
-        assert msg_2 == caplog.messages[1]
-        assert "Snapshot version bumped: 79" in caplog.messages[2]
-        assert "Timestamp version bumped: 87" in caplog.messages[3]
-
-    def test__run_online_roles_bump_target_targets_online_key_config_false(
-        self, monkeypatch, caplog, test_repo, mocked_datetime
-    ):
-        caplog.set_level(repository.logging.WARNING)
-        fake_bins = pretend.stub(
-            signed=pretend.stub(
-                targets={}, version=6, expires=mocked_datetime.now()
-            )
-        )
-
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda a: fake_bins
-        )
-
-        def fake_get_fresh(setting: str):
-            if setting == "TARGETS_ONLINE_KEY":
-                return False
-            elif setting == "DELEGATED_ROLES_NAMES":
-                return ["bin-a"]
-
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(lambda a: fake_get_fresh(a))
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
-        test_repo._update_snapshot = pretend.call_recorder(
-            lambda **kw: "fake_snapshot"
-        )
-        test_repo._update_timestamp = pretend.call_recorder(
-            lambda *a: pretend.stub(
-                signed=pretend.stub(
-                    snapshot_meta=pretend.stub(version=79),
-                    version=87,
-                    expires=datetime.datetime(2028, 6, 16, 9, 5, 1),
-                )
-            )
-        )
-        test_repo._run_online_roles_bump()
-        msg = "targets don't use online key, skipping 'Targets' role"
-        assert msg == caplog.messages[0]
-        assert test_repo._storage_backend.get.calls == [
-            pretend.call("bin-a"),
-        ]
-        assert test_repo._update_snapshot.calls == [
-            pretend.call(target_roles=["bin-a"])
-        ]
-        assert test_repo._update_timestamp.calls == [
-            pretend.call("fake_snapshot")
-        ]
-        assert fake_settings.get_fresh.calls == [
-            pretend.call("TARGETS_ONLINE_KEY"),
-            pretend.call("TARGETS_ONLINE_KEY"),
-            pretend.call("DELEGATED_ROLES_NAMES"),
-        ]
-
-    def test__run_online_roles_bump_warning_missing_config(
-        self, caplog, test_repo, mocked_datetime, monkeypatch
-    ):
-        caplog.set_level(repository.logging.CRITICAL)
-        fake_bins = pretend.stub(
-            signed=pretend.stub(
-                targets={}, version=6, expires=mocked_datetime.now()
-            )
-        )
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda a: fake_bins
-        )
-
-        def fake_get_fresh(setting: str):
-            if setting == "TARGETS_ONLINE_KEY":
-                return None
-            elif setting == "DELEGATED_ROLES_NAMES":
-                return ["bin-a"]
-
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(lambda a: fake_get_fresh(a))
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda a: fake_bins
-        )
-        test_repo._update_snapshot = pretend.call_recorder(
-            lambda *a, **kw: "fake_snapshot"
-        )
-        test_repo._update_timestamp = pretend.call_recorder(
-            lambda *a: pretend.stub(
-                signed=pretend.stub(
-                    snapshot_meta=pretend.stub(version=79),
-                    version=87,
-                    expires=mocked_datetime.now(),
-                )
-            )
-        )
-        test_repo._run_online_roles_bump()
-        msg = "No configuration found for TARGETS_ONLINE_KEY"
-        assert msg == caplog.messages[0]
-        assert test_repo._storage_backend.get.calls == [
-            pretend.call("bin-a"),
-        ]
-        assert test_repo._update_snapshot.calls == [
-            pretend.call(target_roles=["bin-a"])
-        ]
-        assert test_repo._update_timestamp.calls == [
-            pretend.call("fake_snapshot")
-        ]
-        assert fake_settings.get_fresh.calls == [
-            pretend.call("TARGETS_ONLINE_KEY"),
-            pretend.call("DELEGATED_ROLES_NAMES"),
-        ]
-
-    def test__run_online_roles_bump_no_changes(
-        self, test_repo, caplog, monkeypatch
-    ):
-        caplog.set_level(repository.logging.DEBUG)
-        fake_exp = datetime.datetime(2054, 6, 16, 8, 5, 1, tzinfo=timezone.utc)
-        fake_bins = pretend.stub(
-            signed=pretend.stub(targets={}, version=6, expires=fake_exp)
-        )
-
-        test_repo._storage_backend.get = pretend.call_recorder(
-            lambda a: fake_bins
-        )
-
-        def fake_get_fresh(setting: str):
-            if setting == "TARGETS_ONLINE_KEY":
-                return None
-            elif setting == "DELEGATED_ROLES_NAMES":
-                return ["bin-a"]
-
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(lambda a: fake_get_fresh(a))
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
-
-        test_repo._run_online_roles_bump()
-        assert test_repo._storage_backend.get.calls == [
-            pretend.call("bin-a"),
-        ]
-        msg_1 = "No configuration found for TARGETS_ONLINE_KEY"
-        assert msg_1 == caplog.messages[0]
-        msg_2 = "All delegated roles have more than 1 hour(s) to expire"
-        assert msg_2 in caplog.messages[1]
-        assert "Snapshot version bumped:" not in caplog.messages
-        assert "Timestamp version bumped:" not in caplog.messages
-        assert fake_settings.get_fresh.calls == [
-            pretend.call("TARGETS_ONLINE_KEY"),
-            pretend.call("DELEGATED_ROLES_NAMES"),
-        ]
-
     def test__run_online_roles_bump_StorageError(self, test_repo, monkeypatch):
         def fake_get_fresh(setting: str):
             if setting == "TARGETS_ONLINE_KEY":
@@ -3534,7 +2437,6 @@ class TestMetadataRepository:
 
         assert fake_settings.get_fresh.calls == [
             pretend.call("TARGETS_ONLINE_KEY"),
-            pretend.call("DELEGATED_ROLES_NAMES"),
         ]
 
     def test_bump_snapshot(self, test_repo, mocked_datetime):
@@ -3549,7 +2451,7 @@ class TestMetadataRepository:
             lambda *a: fake_snapshot
         )
         test_repo._update_snapshot = pretend.call_recorder(
-            lambda *a: "fake_snapshot"
+            lambda *a, **kw: "fake_snapshot"
         )
         test_repo._update_timestamp = pretend.call_recorder(
             lambda *a: pretend.stub(
@@ -3565,7 +2467,9 @@ class TestMetadataRepository:
         assert test_repo._storage_backend.get.calls == [
             pretend.call("snapshot")
         ]
-        assert test_repo._update_snapshot.calls == [pretend.call()]
+        assert test_repo._update_snapshot.calls == [
+            pretend.call(only_snapshot=True)
+        ]
         assert test_repo._update_timestamp.calls == [
             pretend.call("fake_snapshot")
         ]
@@ -3615,7 +2519,7 @@ class TestMetadataRepository:
             lambda *a: fake_snapshot
         )
         test_repo._update_snapshot = pretend.call_recorder(
-            lambda *a: "fake_snapshot"
+            lambda *a, **kw: "fake_snapshot"
         )
         test_repo._update_timestamp = pretend.call_recorder(
             lambda *a: pretend.stub(
@@ -3631,7 +2535,9 @@ class TestMetadataRepository:
         assert test_repo._storage_backend.get.calls == [
             pretend.call(Snapshot.type)
         ]
-        assert test_repo._update_snapshot.calls == [pretend.call()]
+        assert test_repo._update_snapshot.calls == [
+            pretend.call(only_snapshot=True)
+        ]
         assert test_repo._update_timestamp.calls == [
             pretend.call("fake_snapshot")
         ]
@@ -4566,8 +3472,8 @@ class TestMetadataRepository:
     def test__validate_signature(self, test_repo):
         fake_root_md = pretend.stub(
             signatures=[{"keyid": "k1", "sig": "s1"}],
-            type="root",
             signed=pretend.stub(
+                type="root",
                 roles={"root": pretend.stub(keyids={"k1": "s1", "k2": "s2"})},
                 keys={
                     "k1": pretend.stub(
@@ -4594,8 +3500,8 @@ class TestMetadataRepository:
         caplog.set_level(repository.logging.INFO)
         fake_root_md = pretend.stub(
             signatures=[{"keyid": "k1", "sig": "s1"}],
-            type="root",
             signed=pretend.stub(
+                type="root",
                 roles={"root": pretend.stub(keyids={"k1": "s1", "k2": "s2"})},
                 keys={
                     "k1": pretend.stub(
@@ -4622,8 +3528,8 @@ class TestMetadataRepository:
         caplog.set_level(repository.logging.INFO)
         fake_root_md = pretend.stub(
             signatures=[{"keyid": "k1", "sig": "s1"}],
-            type="root",
             signed=pretend.stub(
+                type="root",
                 roles={"root": pretend.stub(keyids={"k1": "s1", "k2": "s2"})},
                 keys={
                     "k3": pretend.stub(
@@ -4650,8 +3556,8 @@ class TestMetadataRepository:
         caplog.set_level(repository.logging.INFO)
         fake_root_md = pretend.stub(
             signatures=[{"keyid": "k1", "sig": "s1"}],
-            type="root",
             signed=pretend.stub(
+                type="root",
                 roles={"root": pretend.stub(keyids={"k1": "s1", "k2": "s2"})},
                 keys={
                     "k1": pretend.stub(
@@ -4791,47 +3697,6 @@ class TestMetadataRepository:
             pretend.call("ROOT_SIGNING"),
         ]
 
-    def test_sign_metadata_invalid_role_type(
-        self, test_repo, monkeypatch, mocked_datetime
-    ):
-        def fake_get_fresh(key):
-            if key == "BOOTSTRAP":
-                return "signing-<task-id>"
-            if key == "ROOT_SIGNING":
-                return {"metadata": "fake"}
-
-        fake_settings = pretend.stub(
-            get_fresh=pretend.call_recorder(fake_get_fresh),
-        )
-        monkeypatch.setattr(
-            repository,
-            "get_repository_settings",
-            lambda *a, **kw: fake_settings,
-        )
-        fake_root_md = repository.Targets(version=2)
-        fake_root_md.signed = repository.Targets()
-        repository.Metadata.from_dict = pretend.call_recorder(
-            lambda *a: fake_root_md
-        )
-
-        payload = {
-            "role": "root",
-            "signature": {"keyid": "keyid2", "sig": "sig2"},
-        }
-        result = test_repo.sign_metadata(payload)
-
-        assert result == {
-            "task": "sign_metadata",
-            "status": False,
-            "last_update": mocked_datetime.now(),
-            "message": "Signature Failed",
-            "error": "Expected 'root', got 'targets'",
-            "details": None,
-        }
-        assert fake_settings.get_fresh.calls == [
-            pretend.call("ROOT_SIGNING"),
-        ]
-
     def test_sign_metadata_invalid_signature(
         self, test_repo, monkeypatch, mocked_datetime
     ):
@@ -4952,7 +3817,7 @@ class TestMetadataRepository:
             pretend.call("ROOT_SIGNING", "fake_metadata")
         ]
 
-    def test_sign_metadata_update_bad_role_type(
+    def test_sign_metadata_update_no_pending_signatures(
         self, test_repo, monkeypatch, mocked_datetime
     ):
         fake_signature = pretend.stub(keyid="fake")
@@ -4967,7 +3832,7 @@ class TestMetadataRepository:
             "status": False,
             "last_update": mocked_datetime.now(),
             "message": "Signature Failed",
-            "error": "Expected 'root', got 'foo'",
+            "error": "No signatures pending for foo",
             "details": None,
         }
 


### PR DESCRIPTION
It starts with a simple fix in the Database Schema:

- Include rolename as unique to avoid duplications
- Include column to set Target Role as active
- Implement several CRUD to handle inactive roles

Implements the Custom Delegation Roles
- Add support to custom delegation roles during bootstrap
- Add support for using offline and online keys in the custom delegations roles
- Add support for adding extra delegation roles afterwards
- Add support for updating delegation roles
- Add support for deleting delegation roles

TODO:
- [ ]  Unit Tests: It just fixes errors for the tests, it requires a re-implementation of tests.

### NOTE:

We will prioritize the functions tests (FT) for this feature, preventing regrations or breaking compatibility with BINS.
We will implement unit tests to improve the development process.

[Functional Tests without breaking BINS deployment.](https://github.com/repository-service-tuf/repository-service-tuf-worker/actions/runs/10756018985)