### PR TITLE
fix: celery hostname for the instance

### DIFF
--- a/supervisor-dev.conf
+++ b/supervisor-dev.conf
@@ -1,5 +1,5 @@
 [program:rstuf_worker]
-command = celery -A app worker -l debug -Q metadata_repository -n rstuf_%(ENV_RSTUF_WORKER_ID)s@dev
+command = celery -A app worker -l debug -Q metadata_repository -n rstuf@%(ENV_RSTUF_WORKER_ID)s
 directory = %(here)s
 startsecs = 5
 autostart = true
@@ -11,7 +11,7 @@ stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
 [program:rstuf_worker_jobs]
-command = celery -A app worker -B -l debug -Q rstuf_internals -n rstuf_jobs_%(ENV_RSTUF_WORKER_ID)s@dev
+command = celery -A app worker -B -l debug -Q rstuf_internals -n rstuf_jobs@%(ENV_RSTUF_WORKER_ID)s
 directory = %(here)s
 startsecs = 5
 autostart = true

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,5 +1,5 @@
 [program:rstuf_worker]
-command = celery -A app worker -l info -Q metadata_repository -n rstuf_%(ENV_RSTUF_WORKER_ID)s@dev
+command = celery -A app worker -l info -Q metadata_repository -n rstuf@%(ENV_RSTUF_WORKER_ID)s
 directory = /opt/repository-service-tuf-worker
 startsecs = 5
 autostart = true
@@ -11,7 +11,7 @@ stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
 [program:rstuf_worker_jobs]
-command = celery -A app worker -B -l info -Q rstuf_internals -n rstuf_jobs_%(ENV_RSTUF_WORKER_ID)s@dev
+command = celery -A app worker -B -l info -Q rstuf_internals -n rstuf_jobs@%(ENV_RSTUF_WORKER_ID)s
 directory = /opt/repository-service-tuf-worker
 startsecs = 5
 autostart = true


### PR DESCRIPTION
It fixes the celery hotname instance.

We use this hostname to check the livenessprobe and readninessprobe in the helm charts.

https://github.com/repository-service-tuf/helm-charts/blob/176fa84eed2ed34a7ce22eabf7469425fdb42881/charts/rstuf-worker/values.yaml#L12

[skip slow]