### PR TITLE
Remove deprecated and warn users for MySQL/MariaDB

### DIFF
--- a/.github/workflows/review-approved.yml
+++ b/.github/workflows/review-approved.yml
@@ -31,11 +31,12 @@ jobs:
       api_version: dev
       cli_version: dev
 
-  functional-tests-mysql:
-    name: Deploy MySQL Server as DB
-    if: github.event.review.state == 'approved'
-    uses: ./.github/workflows/functional-tests.yml
-    with:
-      docker_compose: docker-compose-mysql.yml
-      api_version: dev
-      cli_version: dev
+  # disabled until MySQL is supported
+  # functional-tests-mysql:
+  #   name: Deploy MySQL Server as DB
+  #   if: github.event.review.state == 'approved'
+  #   uses: ./.github/workflows/functional-tests.yml
+  #   with:
+  #     docker_compose: docker-compose-mysql.yml
+  #     api_version: dev
+  #     cli_version: dev

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -70,7 +70,7 @@ services:
       - RSTUF_ONLINE_KEY_DIR=/var/opt/repository-service-tuf/key_storage
       - RSTUF_BROKER_SERVER=redis://redis
       - RSTUF_REDIS_SERVER=redis://redis
-      - RSTUF_DB_SERVER=postgres:secret@postgres:5432
+      - RSTUF_DB_SERVER=postgresql://postgres:secret@postgres:5432
       - METADATA_BASE_URL="http://localstack:4566/tuf-metadata/"
     volumes:
       - ./:/opt/repository-service-tuf-worker:z

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -62,7 +62,7 @@ services:
       - RSTUF_ONLINE_KEY_DIR=/var/opt/repository-service-tuf/key_storage
       - RSTUF_BROKER_SERVER=redis://redis
       - RSTUF_REDIS_SERVER=redis://redis
-      - RSTUF_DB_SERVER=postgres:secret@postgres:5432
+      - RSTUF_DB_SERVER=postgresql://postgres:secret@postgres:5432
     volumes:
       - ./:/opt/repository-service-tuf-worker:z
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -68,46 +68,20 @@ The result backend must to be compatible with Celery. See
 
 Example: `redis://redis`
 
-#### (Deprecated see `RSTUF_DB_SERVER`) `RSTUF_SQL_SERVER`
-
-RSTUF requires [PostgreSQL](https://www.postgresql.org) or [MySQL/MariaDB](https://mariadb.org).
-
-Scheme
-  - PostgreSQL: `postgresql://`
-  - MySQL/MariaDB: `mysql+pymysql://`
-
-Example: `postgresql://mypgsql:5432` or `mysql+pymysql://mymysql:3306`
-
-* Optional variables:
-
-  * `RSTUF_SQL_USER` (Deprecated see `RSTUF_DB_USER`) optional information
-    about the user name
-
-    If using this optional variable:
-    - Do not include the user in the `RSTUF_SQL_SERVER`.
-    - The `RSTUF_SQL_PASSWORD` becomes required
-
-  * `RSTUF_SQL_PASSWORD` (Deprecated see `RSTUF_DB_PASSWORD`) use this variable to provide the password separately.
-    - Do not include the password in the `RSTUF_SQL_SERVER`
-    - This environment variable supports container secrets when the `/run/secrets`
-      volume is added to the path.
-
-  Example:
-  ```
-  RSTUF_SQL_SERVER=sqlserver:5432
-  RSTUF_SQL_USER=postgres
-  RSTUF_SQL_PASSWORD=/run/secrets/POSTGRES_PASSWORD
-  ```
-
 #### (Required) `RSTUF_DB_SERVER`
 
-RSTUF requires [PostgreSQL](https://www.postgresql.org) or [MySQL/MariaDB](https://mariadb.org).
+RSTUF requires [PostgreSQL](https://www.postgresql.org)
+
+> **Note:** [MySQL/MariaDB](https://mariadb.org) is also supported, but is not recommended
+> for production use at this time. We still have an opened issue to solve.
+> See https://github.com/repository-service-tuf/repository-service-tuf-worker/issues/598
+
 
 Scheme
   - PostgreSQL: `postgresql://`
-  - MySQL/MariaDB: `mysql+pymysql://`
+  - MySQL/MariaDB: `mysql+pymysql://` (not recommended for production)
 
-Example: `postgresql://mypgsql:5432` or `mysql+pymysql://mymysql:3306`
+Example: `postgresql://mypgsql:5432`
 
 * Optional variables:
 


### PR DESCRIPTION
- remove deprecated code previously announced
- add note in the documentation for MySQL/MariaDB support
- disable tests for MySQL/MariaDB