### PR TITLE
perf: fix bump online roles

### DIFF
--- a/alembic/versions/1effe827d0cd_initial_db.py
+++ b/alembic/versions/1effe827d0cd_initial_db.py
@@ -1,8 +1,8 @@
-"""Initial version
+"""initial db
 
-Revision ID: 4b8d450e8360
-Revises: 
-Create Date: 2023-05-10 16:04:43.893667
+Revision ID: 1effe827d0cd
+Revises:
+Create Date: 2025-02-12 15:49:21.927962
 
 """
 
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "4b8d450e8360"
+revision = "1effe827d0cd"
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -23,10 +23,11 @@ def upgrade() -> None:
     op.create_table(
         "rstuf_target_roles",
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("rolename", sa.String(length=512), nullable=False),
+        sa.Column("rolename", sa.String(), nullable=False),
+        sa.Column("expires", sa.DateTime(), nullable=False),
         sa.Column("version", sa.Integer(), nullable=False),
-        sa.Column("last_update", sa.DateTime(), nullable=True),
         sa.Column("active", sa.Boolean(), nullable=False),
+        sa.Column("last_update", sa.DateTime(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
@@ -44,7 +45,7 @@ def upgrade() -> None:
     op.create_table(
         "rstuf_target_files",
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("path", sa.String(length=512), nullable=False),
+        sa.Column("path", sa.String(), nullable=False),
         sa.Column(
             "info", postgresql.JSON(astext_type=sa.Text()), nullable=False
         ),
@@ -86,6 +87,9 @@ def downgrade() -> None:
         op.f("ix_rstuf_target_files_id"), table_name="rstuf_target_files"
     )
     op.drop_table("rstuf_target_files")
+    op.drop_index(
+        op.f("ix_rstuf_target_roles_rolename"), table_name="rstuf_target_roles"
+    )
     op.drop_index(
         op.f("ix_rstuf_target_roles_id"), table_name="rstuf_target_roles"
     )

--- a/app.py
+++ b/app.py
@@ -1,20 +1,25 @@
 #!/bin/env python3
 
-# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
+# SPDX-FileCopyrightText: 2023-2025 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
 
+import itertools
 import json
 import logging
+import time
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import redis
-from celery import Celery, schedules, signals
+from celery import Celery, chain, schedules, signals
 
 from repository_service_tuf_worker import get_worker_settings
-from repository_service_tuf_worker.repository import MetadataRepository
+from repository_service_tuf_worker.repository import (
+    MetadataRepository,
+    MetaFile,
+)
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -29,6 +34,9 @@ logging.basicConfig(
 
 
 worker_settings = get_worker_settings()
+
+BOR_LOCK = "BOR"
+BOR_TTL = worker_settings.get("BUMP_ONLINE_ROLES_TTL", 600)  # Lock expiration
 
 
 class status(Enum):
@@ -53,6 +61,9 @@ redis_backend = redis.StrictRedis.from_url(
 #     "ca_certs": "data/certs/ca_mq.crt",
 #     "cert_reqs": ssl.CERT_REQUIRED,
 # }
+
+repository = MetadataRepository.create_service()
+
 
 app = Celery(
     f"repository_service_tuf_worker_{worker_settings.WORKER_ID}",
@@ -94,6 +105,179 @@ def repository_service_tuf_worker(
         result = repository_action(payload, update_state=self.update_state)
 
     return result
+
+
+@app.task(serializer="json", queue="rstuf_internals")
+def _end_bor_chain_callback(result, start_time: float):
+    """
+    Callback to calculate the total execution time of the chain.
+    Args:
+        result: The result from the previous task in the chain.
+        start_time: The start time captured at the beginning of the chain.
+    Returns:
+        The final result of the chain and the total execution time.
+    """
+    end_time = time.time()
+    total_time = end_time - start_time
+
+    logging.info(
+        f"Total execution time for bump_online_roles: {total_time:.2f} seconds"
+    )
+
+    # Return the final result along with the execution time for reference
+    repository._redis.delete(BOR_LOCK)
+    logging.info("Bump online roles lock removed")
+    return {"result": result, "execution_time_seconds": total_time}
+
+
+@app.task(serializer="json", queue="rstuf_internals")
+def _update_online_role(role: str) -> Optional[str]:
+    """
+    Update online role (DB and JSON)
+    """
+    return repository.update_targets_delegated_role(role)
+
+
+@app.task(serializer="json", queue="rstuf_internals")
+def _update_snapshot_timestamp(*args) -> Dict[str, Any]:
+    """
+    Update the snapshot timestamp with the updated roles data.
+    """
+    updated_roles = list(itertools.chain.from_iterable(args[0]))
+    snapshot_meta = {}
+    database_meta = {}
+    start_time = time.time()
+    for role in updated_roles:
+        if role:
+            # Generate snapshot meta
+            snapshot_meta.update(
+                {f"{k}.json": MetaFile(v["version"]) for k, v in role.items()}
+            )
+            # Generate database meta
+            database_meta.update(
+                {
+                    k: (v["expire"], v["version"])
+                    for k, v in role.items()
+                    if k != "targets"
+                }
+            )
+    logging.info(
+        "Time parsing _update_snapshot_timestamp: "
+        f"{time.time() - start_time} seconds"
+    )
+
+    repository._update_timestamp(
+        repository.update_snapshot(snapshot_meta, database_meta).signed.version
+    )
+    logging.info(
+        "Time updating _update_snapshot_timestamp: "
+        f"{time.time() - start_time} seconds"
+    )
+
+    logging.info(
+        f"Updated snapshot/timestamp with {len(updated_roles)} role(s)"
+    )
+
+
+@app.task(serializer="json", queue="rstuf_internals")
+def bump_online_roles(expired: bool = False) -> List[Optional[str]]:
+    """
+    Bump all online roles.
+    """
+
+    def _calculate_chunk_size(num_roles: int) -> int:
+        chunk_size_cfg = repository._settings.get_fresh(
+            "BUMP_ONLINE_ROLES_CHUNK_SIZE", 500
+        )
+        if num_roles <= chunk_size_cfg:
+            chunk_size = int(num_roles / 2)
+        else:
+            chunk_size = chunk_size_cfg
+
+        return chunk_size
+
+    start_time = time.time()
+
+    # Try to acquire lock
+    if not repository._redis.set(BOR_LOCK, "locked", ex=BOR_TTL, nx=True):
+        logging.info(
+            "Skipping bump_online_roles, another task is already running."
+        )
+        _end_bor_chain_callback(None, start_time)
+        return []
+
+    if repository.bootstrap_state != "finished":
+        logging.info("Skipping bump_online_roles, bootstrap not finished.")
+        # call end within the bump_online_role task
+        _end_bor_chain_callback(None, start_time)
+        return []
+
+    status_lock_targets = False
+    # Lock to avoid race conditions. See `LOCK_TIMEOUT` in the Worker
+    # development guide documentation.
+    try:
+        with repository._redis.lock("LOCK_TARGETS", repository._timeout):
+            roles = repository.get_delegated_rolenames(expired=expired)
+            logging.info(f"Total roles to bump: {len(roles)}")
+
+            # No expired roles, call end within the bump_online_role task
+            if len(roles) == 0:
+                _end_bor_chain_callback(None, start_time)
+                return roles
+
+            chunk_size = _calculate_chunk_size(len(roles))
+
+            # It is a corner cases
+            # We have only one role to be update and chunk_size is 0
+            # _calculate_chunk_size() will return (1 / 2) = 0
+            # Celery chunks cannot have group equal 1, so we execute
+            # without groups, directly.
+            # it also applies when there is one role independet of the chunk
+            # size
+            if chunk_size == 0 and len(roles) == 1:
+                # call the update and end of chain within bump_online_role task
+                _update_snapshot_timestamp(
+                    [[repository.update_targets_delegated_role(roles[0])]]
+                )
+                _end_bor_chain_callback(None, start_time)
+
+                return roles
+
+            else:
+                # Run updates in chain using chunks which improves the
+                # performance.
+                # As a Worker can pick multiple tasks in parallel, more
+                # workers more performance.
+
+                # task groups from the chunk size
+                # ex: 2048 creates 5 task groups of _update_online_role task
+                task_groups = _update_online_role.chunks(
+                    zip(roles), chunk_size
+                ).group()
+                logging.info(
+                    f"Tasks: {len(task_groups)} | Chunk size: {chunk_size}"
+                )
+                # create the chain with task groups and call a task
+                # _update_snapshot_timestamp with the result of
+                # _update_online_role task
+                # when finished, call _end_bor_chain_callback task
+                chain(
+                    task_groups,
+                    _update_snapshot_timestamp.s(task_groups),
+                    _end_bor_chain_callback.s(start_time),
+                )(queue="rstuf_internals")
+
+                return roles
+    except redis.exceptions.LockNotOwnedError:
+        if status_lock_targets is False:
+            logging.error(
+                "The task to bump all online roles exceeded the timeout "
+                f"of {repository._timeout} seconds."
+            )
+            raise redis.exceptions.LockError(
+                f"RSTUF: Task exceed `LOCK_TIMEOUT` ({repository._timeout} "
+                "seconds)"
+            )
 
 
 def _publish_signals(
@@ -138,11 +322,9 @@ def task_received_notifier(**kwargs):
 
 app.conf.beat_schedule = {
     "bump_online_roles": {
-        "task": "app.repository_service_tuf_worker",
-        "schedule": schedules.crontab(minute="*/10"),
-        "kwargs": {
-            "action": "bump_online_roles",
-        },
+        "task": "app.bump_online_roles",
+        "schedule": schedules.crontab(minute="*/5"),
+        "kwargs": {"expired": True},
         "options": {
             "task_id": "bump_online_roles",
             "queue": "rstuf_internals",
@@ -150,5 +332,3 @@ app.conf.beat_schedule = {
         },
     },
 }
-
-repository = MetadataRepository.create_service()

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -113,6 +113,23 @@ Redis Server DB number for Result Backend (tasks). Default: 0
 
 Important: It should use the same db id as used by RSTUF API.
 
+#### (Optional) `RSTUF_BUMP_ONLINE_ROLES_TTL`
+
+Bump Online Roles lock time to lease (TTL) in seconds. Default: 600
+
+This tasks runs every 10 minutes. This is the TTL time in case a task gets
+longer.
+It avoid one or more RSTUF Workers running at the same task.
+
+#### (Optional) `RSTUF_BUMP_ONLINE_ROLES_CHUNK_SIZE`
+
+Define the bump online roles chunk size. Default: 500
+
+RSTUF Worker can have large number of delegations (ex: hash bins).
+
+RSTUF Worker calculates automatically the chunk. Depending on the
+number of Workers and Roles it can be customized.
+
 #### (Optional) `RSTUF_REDIS_SERVER_DB_REPO_SETTINGS`
 
 Redis Server DB number for repository settings. Default: 1

--- a/repository_service_tuf_worker/models/targets/crud.py
+++ b/repository_service_tuf_worker/models/targets/crud.py
@@ -117,6 +117,21 @@ def read_all_roles(db: Session) -> List[models.RSTUFTargetRoles]:
     )
 
 
+def read_all_roles_rolenames(db: Session) -> List[Optional[str]]:
+    """
+    Read a all Target bin roles.
+    """
+    result = (
+        db.query(models.RSTUFTargetRoles.rolename)
+        .filter(models.RSTUFTargetRoles.active == True)  # noqa
+        .all()
+    )
+    if result is None:
+        return []
+    else:
+        return [rolename[0] for rolename in result]
+
+
 def read_roles_joint_files(
     db: Session, rolenames: List[str]
 ) -> List[models.RSTUFTargetRoles]:
@@ -157,22 +172,27 @@ def read_role_joint_files(
     )
 
 
-def read_roles_expired(
+def read_roles_rolenames_expired(
     db: Session, expire_timedelta: timedelta
-) -> List[models.RSTUFTargetRoles]:
+) -> List[Optional[str]]:
     """
     Read all roles that are expired.
     """
     today = datetime.now(timezone.utc)
     # Query roles expiring before the threshold and are active
-    return (
-        db.query(models.RSTUFTargetRoles)
+    result = (
+        db.query(models.RSTUFTargetRoles.rolename)
         .filter(
             (models.RSTUFTargetRoles.expires - today) < expire_timedelta,
             models.RSTUFTargetRoles.active == True,  # noqa
         )
         .all()
     )
+
+    if result is None:
+        return []
+    else:
+        return [rolename[0] for rolename in result]
 
 
 def update_file_path_and_info(

--- a/repository_service_tuf_worker/models/targets/models.py
+++ b/repository_service_tuf_worker/models/targets/models.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
+# SPDX-FileCopyrightText: 2023-2025 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
@@ -36,7 +36,8 @@ class RSTUFTargetFiles(Base):
 class RSTUFTargetRoles(Base):
     __tablename__ = "rstuf_target_roles"
     id = Column(Integer, primary_key=True, index=True)
-    rolename = Column(String, nullable=False, unique=True)
+    rolename = Column(String, nullable=False, unique=True, index=True)
+    expires = Column(DateTime, nullable=False)
     version = Column(Integer, nullable=False)
     active = Column(Boolean, default=True, nullable=False)
     last_update = Column(DateTime, default=datetime.now(timezone.utc))

--- a/repository_service_tuf_worker/models/targets/schemas.py
+++ b/repository_service_tuf_worker/models/targets/schemas.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
+# SPDX-FileCopyrightText: 2023-2025 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
@@ -17,6 +17,9 @@ class TargetAction(enum.Enum):
 class RSTUFTargetRoleCreate(BaseModel):
     rolename: str
     version: int
+    expires: datetime
+    active: Optional[bool] = True
+    last_update: Optional[datetime] = datetime.now(timezone.utc)
 
     class Config:
         orm_mode = True

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023-2024 Repository Service for TUF Contributors
+# SPDX-FileCopyrightText: 2023-2025 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
@@ -137,7 +137,9 @@ class MetadataRepository:
         self._hours_before_expire: int = self._settings.get_fresh(
             "HOURS_BEFORE_EXPIRE", 1
         )
-        self._timeout = int(app_settings.get("LOCK_TIMEOUT", 60.0))
+        self._expire_timedelta = timedelta(hours=self._hours_before_expire)
+        self._timeout = int(app_settings.get("LOCK_TIMEOUT", 500.0))
+        self._uses_succinct_roles: Optional[bool] = None
 
     @property
     def _settings(self) -> Dynaconf:
@@ -165,10 +167,52 @@ class MetadataRepository:
         key_dict["keyid"] = key.keyid
         self.write_repository_settings("ONLINE_KEY", key_dict)
 
+    @property
+    def bootstrap_state(self) -> Optional[str]:
+        bootstrap = self._settings.get_fresh("BOOTSTRAP")
+        if bootstrap is None:
+            return None
+
+        elif bootstrap.startswith("pre-"):
+            return "pre"
+
+        elif bootstrap.startswith("signing"):
+            return "signing"
+
+        else:
+            return "finished"
+
+    @property
+    def uses_succinct_roles(self) -> bool:
+        if self._uses_succinct_roles is None:
+            targets: Metadata[Targets] = self._storage_backend.get(
+                Targets.type
+            )
+            self._uses_succinct_roles = (
+                True if targets.signed.delegations.succinct_roles else False
+            )
+        return self._uses_succinct_roles
+
     @classmethod
     def create_service(cls) -> "MetadataRepository":
         """Class Method for MetadataRepository service creation."""
         return cls()
+
+    def get_delegation_keyids(self, rolename: str) -> List[str]:
+        if self.uses_succinct_roles:
+            logging.debug("delegations using succinct delegations")
+            # we know all roles uses the online key
+            delegation_keyids = [self._online_key.keyid]
+        else:
+            logging.debug("delegations using custom delegations")
+            targets: Metadata[Targets] = self._storage_backend.get(
+                Targets.type
+            )
+            delegation_keyids = targets.signed.delegations.roles[
+                rolename
+            ].keyids
+
+        return delegation_keyids
 
     def refresh_settings(self, worker_settings: Optional[Dynaconf] = None):
         """Refreshes the MetadataRepository settings."""
@@ -272,8 +316,14 @@ class MetadataRepository:
 
         bytes_data = role.to_bytes(JSONSerializer())
         self._storage_backend.put(bytes_data, filename)
-        logging.debug(f"{filename} saved")
         return filename
+
+    def _is_expired(self, role: str) -> Optional[str]:
+        role_md: Metadata[Targets] = self._storage_backend.get(role)
+        today = datetime.now(timezone.utc)
+        if (role_md.signed.expires - today) < self._expire_timedelta:
+            return role
+        return None
 
     def _bump_expiry(
         self, role: Metadata, role_name: str, expire: Optional[int] = None
@@ -295,18 +345,50 @@ class MetadataRepository:
         role.signed.version += 1
 
     def _bump_and_persist(
-        self, role: Metadata, role_name: str, persist: Optional[bool] = True
+        self,
+        role: Metadata,
+        role_name: str,
+        persist: Optional[bool] = True,
+        signer: Optional[Signer] = None,
+        expire: Optional[int] = None,
     ):
         """
         Bump expiry and version, sign and persist 'role' metadata into a new
         file named VERSION.rolename.json where VERSION is the new role version.
         Optionally, if persist is false, then don't persist in a file.
         """
-        self._bump_expiry(role, role_name)
+        self._bump_expiry(role, role_name, expire)
         self._bump_version(role)
-        self._sign(role)
+        self._sign(role, signer)
         if persist:
             self._persist(role, role_name)
+
+    def update_snapshot(
+        self,
+        snapshot_meta: MetaFile,
+        database_meta: Dict[str, Tuple[datetime, int]],
+    ) -> Metadata[Snapshot]:
+        snapshot: Metadata[Snapshot] = self._storage_backend.get(Snapshot.type)
+
+        if bool(snapshot_meta) is True:
+            snapshot.signed.meta.update(snapshot_meta)
+            start_time = time.time()
+            targets_crud.update_roles_expire_version_by_rolenames(
+                self._db, database_meta
+            )
+            logging.info(
+                f"Updated roles expire and version: {time.time() - start_time}"
+            )
+
+        # If snapshot has new meta or snapshot is expired without new meta
+        # we need to bump the snapshot version
+        if bool(snapshot_meta) or self._is_expired(Snapshot.type):
+            start_time = time.time()
+            self._bump_and_persist(snapshot, "snapshot")
+            logging.info(f"Snapshot bumped: {time.time() - start_time}")
+            logging.debug("Bumped version of 'Snapshot' role")
+
+        return snapshot
 
     def _update_timestamp(
         self,
@@ -536,6 +618,29 @@ class MetadataRepository:
 
         return role_name
 
+    def get_delegated_rolenames(self, expired: bool = False) -> List[str]:
+        """
+        Get all delegated roles names.
+
+        expired: If True, return only expired delegated roles.
+        """
+
+        # we don't store Target top level role in the database
+        # we create the object for the metadata update (without action in db)
+        if expired:
+            roles = targets_crud.read_roles_rolenames_expired(
+                self._db, self._expire_timedelta
+            )
+
+            if self._is_expired(Targets.type):
+                roles.append(Targets.type)
+
+        else:
+            roles = targets_crud.read_all_roles_rolenames(self._db)
+            roles.append(Targets.type)
+
+        return roles
+
     def _update_task(
         self,
         roles_to_artifacts: Dict[str, List[targets_models.RSTUFTargetFiles]],
@@ -711,13 +816,18 @@ class MetadataRepository:
         def process_delegated_role(delegated_name: str) -> str:
             targets.signed.add_key(online_key, delegated_name)
             bins_role = Metadata(Targets())
-            db_target_roles.append(
-                targets_schema.RSTUFTargetRoleCreate(
-                    rolename=delegated_name, version=1
-                )
-            )
+
             self._bump_expiry(bins_role, BINS, expire=expire_bins)
             self._sign(bins_role, signer)
+
+            db_target_roles.append(
+                targets_schema.RSTUFTargetRoleCreate(
+                    rolename=delegated_name,
+                    version=1,
+                    expires=bins_role.signed.expires,
+                )
+            )
+
             self._persist(bins_role, delegated_name)
             return delegated_name
 
@@ -892,7 +1002,9 @@ class MetadataRepository:
 
             logging.debug(f"creating role db '{role}' schema")
             db_roles = targets_schema.RSTUFTargetRoleCreate(
-                rolename=role, version=role_metadata.signed.version
+                rolename=role,
+                version=role_metadata.signed.version,
+                expires=datetime.now(timezone.utc) + timedelta(days=expires),
             )
             targets_crud.create_roles(self._db, [db_roles])
 
@@ -1017,6 +1129,116 @@ class MetadataRepository:
             )
 
         return (success, failed)
+
+    def _update_db_role_target_files(self, delegation, db_role):
+        delegation.signed.targets.clear()
+        delegation.signed.targets = {
+            file.path: TargetFile.from_dict(file.info, file.path)
+            for file in db_role.target_files
+            if file.action == targets_schema.TargetAction.ADD
+            # Filtering the files with action 'ADD' cannot be done
+            # in CRUD. If a target role doesn't have any target
+            # files with an action 'ADD' (only 'REMOVE') then using
+            # CRUD will not return the target role and it won't be
+            # updated. An example can be when there is a role with
+            # one target file with action "REMOVE" and the CRUD
+            # will return None for this specific role.
+        }
+
+        return delegation
+
+    def bump_persist_role(
+        self,
+        delegation: Metadata[Targets],
+        rolename: str,
+        from_storage: bool,
+    ):
+
+        delegation_keyids = self.get_delegation_keyids(rolename)
+
+        if (
+            len(delegation_keyids) == 1
+            and self._online_key.keyid in delegation_keyids
+        ):
+            logging.debug(f"role {rolename} full online keys")
+            logging.debug("update expiry, bump version and persist")
+            self._bump_and_persist(
+                delegation,
+                BINS if self.uses_succinct_roles else rolename,
+                persist=False,
+                expire=self._settings.get_fresh(f"{BINS.upper()}_EXPIRATION"),
+            )
+            self._persist(delegation, rolename)
+
+        elif (
+            len(delegation_keyids) > 1
+            and self._online_key.keyid in delegation_keyids
+        ):
+            logging.debug(f"role {rolename} online/offline keys")
+            self._bump_expiry(delegation, rolename)
+            self._sign(delegation)
+            if from_storage:
+                self._bump_version(delegation)
+            self.write_repository_settings(
+                f"{rolename.upper()}_SIGNING", delegation.to_dict()
+            )
+
+        else:
+            logging.debug(f"role {rolename} offline keys")
+            delegation.signatures.clear()
+            self._bump_expiry(delegation, rolename)
+            if from_storage:
+                self._bump_version(delegation)
+            self.write_repository_settings(
+                f"{rolename.upper()}_SIGNING", delegation.to_dict()
+            )
+
+    def update_targets_delegated_role(self, role: str):
+        if role == Targets.type:
+            targets: Metadata[Targets] = self._storage_backend.get(
+                Targets.type
+            )
+            self._bump_and_persist(targets, Targets.type)
+
+            return {
+                Targets.type: {
+                    "version": targets.signed.version,
+                    "expire": targets.signed.expires,
+                    "target_files": [],
+                }
+            }
+
+        db_target_role: targets_crud.models.RSTUFTargetRoles = (
+            targets_crud.read_role_joint_files(self._db, role)
+        )
+        rolename: str = db_target_role.rolename
+        from_storage: bool = True
+        try:
+            delegation: Metadata[Targets] = self._storage_backend.get(
+                rolename, db_target_role.version
+            )
+        except StorageError as err:
+            if delegation_signing := self._settings.get_fresh(
+                f"{role.upper()}_SIGNING"
+            ):
+                delegation = Metadata[Targets].from_dict(delegation_signing)
+                from_storage = False
+            else:
+                raise err
+
+        # update db target files
+        self._update_db_role_target_files(delegation, db_target_role)
+        role_target_files = [file.path for file in db_target_role.target_files]
+
+        self.bump_persist_role(delegation, rolename, from_storage)
+
+        return {
+            rolename: {
+                "version": delegation.signed.version,
+                "expire": delegation.signed.expires,
+                "target_files": role_target_files,
+            }
+        }
 
     def _bootstrap_online_roles(
         self,
@@ -1547,8 +1769,9 @@ class MetadataRepository:
             targets: Metadata[Targets] = self._storage_backend.get(
                 Targets.type
             )
-            if force or (targets.signed.expires - today) < timedelta(
-                hours=self._hours_before_expire
+            if (
+                force
+                or (targets.signed.expires - today) < self._expire_timedelta
             ):
                 self._update_targets_delegations_key(targets)
                 self._bump_and_persist(targets, Targets.type)
@@ -1594,9 +1817,7 @@ class MetadataRepository:
                     else:
                         raise err
 
-                if (role_md.signed.expires - today) < timedelta(
-                    hours=self._hours_before_expire
-                ):
+                if (role_md.signed.expires - today) < self._expire_timedelta:
                     continue
                 else:
                     delegated_roles.remove(role)
@@ -1631,9 +1852,9 @@ class MetadataRepository:
         """
 
         snapshot = self._storage_backend.get(Snapshot.type)
-        if (snapshot.signed.expires - datetime.now(timezone.utc)) < timedelta(
-            hours=self._hours_before_expire
-        ) or force:
+        if (
+            snapshot.signed.expires - datetime.now(timezone.utc)
+        ) < self._expire_timedelta or force:
             timestamp = self._update_timestamp(
                 self._update_snapshot(only_snapshot=True)
             )

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -135,7 +135,7 @@ class MetadataRepository:
             self._worker_settings.REDIS_SERVER
         )
         self._hours_before_expire: int = self._settings.get_fresh(
-            "HOURS_BEFORE_EXPIRE", 23
+            "HOURS_BEFORE_EXPIRE", 1
         )
         self._timeout = int(app_settings.get("LOCK_TIMEOUT", 60.0))
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,11 +1,13 @@
-# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
+# SPDX-FileCopyrightText: 2023-2025 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
 
 import tempfile
+from contextlib import contextmanager
 
 import pretend
+import pytest
 
 
 class TestApp:
@@ -95,3 +97,348 @@ class TestApp:
         assert app._publish_signals.calls == [
             pretend.call(app.status.RECEIVED, "001")
         ]
+
+    @pytest.mark.parametrize(
+        "expired, bor_lock, booststrap_state, mock_delegated_rolenames,"
+        "chunk_size_cfg, expected_log_msg",
+        [
+            # Case 1: Cannot acquire lock
+            (
+                True,
+                False,
+                None,
+                [],
+                None,
+                [
+                    "Skipping bump_online_roles, another task is already "
+                    "running."
+                ],
+            ),
+            # Case 2: No bootstrap finished
+            (
+                True,
+                True,
+                "signing",
+                [],
+                None,
+                ["Skipping bump_online_roles, bootstrap not finished."],
+            ),
+            # Case 3: No delegated roles
+            (
+                True,
+                True,
+                "finished",
+                [],
+                None,
+                ["Total roles to bump: 0"],
+            ),
+            # Case 4: With delegated roles, but only one role
+            (
+                True,
+                True,
+                "finished",
+                ["a"],
+                None,
+                ["Total roles to bump: 1"],
+            ),
+            # Case 5: With delegated roles, but only one role and chunk size
+            # is set to the same number of roles
+            (
+                True,
+                True,
+                "finished",
+                ["a"],
+                1,
+                ["Total roles to bump: 1"],
+            ),
+            # Case 6: With delegated roles and chunk size is set higher than
+            # the number of roles
+            (
+                True,
+                True,
+                "finished",
+                ["a", "b", "c", "d"],
+                10,
+                ["Total roles to bump: 4", "Tasks: 2 | Chunk size: 2"],
+            ),
+            # Case 7: With delegated roles and chunk size is set lower than
+            # the number of roles
+            (
+                True,
+                True,
+                "finished",
+                ["a", "b", "c", "d", "e"],
+                2,
+                ["Total roles to bump: 5", "Tasks: 3 | Chunk size: 2"],
+            ),
+            # Case 8: With delegated roles as 1 and chunk size is set 1000
+            (
+                True,
+                True,
+                "finished",
+                ["a"],
+                1000,
+                ["Total roles to bump: 1"],
+            ),
+        ],
+    )
+    def test_bump_online_roles(
+        self,
+        monkeypatch,
+        app,
+        caplog,
+        expired,
+        bor_lock,
+        booststrap_state,
+        mock_delegated_rolenames,
+        chunk_size_cfg,
+        expected_log_msg,
+    ):
+        caplog.set_level(app.logging.INFO)
+
+        @contextmanager
+        def mocked_lock(lock, timeout):
+            yield lock, timeout
+
+        start_time = 1740472169.0
+        app.time = pretend.stub(
+            time=pretend.call_recorder(lambda *a: start_time),
+        )
+        app.repository = pretend.stub(
+            _timeout=60,
+            _redis=pretend.stub(
+                set=pretend.call_recorder(lambda *a, **kw: bor_lock),
+                lock=pretend.call_recorder(mocked_lock),
+            ),
+            _settings=pretend.stub(
+                get_fresh=pretend.call_recorder(
+                    lambda *a: chunk_size_cfg or 500
+                )
+            ),
+            bootstrap_state=booststrap_state,
+            get_delegated_rolenames=pretend.call_recorder(
+                lambda *a, **kw: mock_delegated_rolenames
+            ),
+            update_targets_delegated_role=pretend.call_recorder(
+                lambda *a, **kw: {
+                    r: {"v": 1, "x": 1} for r in mock_delegated_rolenames
+                }
+            ),
+        )
+
+        monkeypatch.setattr(
+            app,
+            "_update_snapshot_timestamp",
+            pretend.call_recorder(lambda *a: None),
+        )
+        app._update_snapshot_timestamp.s = pretend.call_recorder(
+            lambda *a: None
+        )
+        monkeypatch.setattr(
+            app,
+            "_end_bor_chain_callback",
+            pretend.call_recorder(lambda *a: None),
+        )
+        app._end_bor_chain_callback.s = pretend.call_recorder(lambda *a: None)
+        app.chain = pretend.call_recorder(
+            lambda *a: pretend.call_recorder(lambda **kw: "fake_chain")
+        )
+
+        result = app.bump_online_roles(expired=expired)
+
+        assert result == mock_delegated_rolenames
+        assert expected_log_msg == [rec.message for rec in caplog.records]
+
+        assert app.repository._redis.set.calls == [
+            pretend.call(app.BOR_LOCK, "locked", ex=app.BOR_TTL, nx=True)
+        ]
+
+        if bor_lock is False or booststrap_state != "finished":
+            assert app.repository.get_delegated_rolenames.calls == []
+        else:
+            assert app.repository.get_delegated_rolenames.calls == [
+                pretend.call(expired=expired)
+            ]
+
+        if len(mock_delegated_rolenames) == 1:
+            assert app.repository._settings.get_fresh.calls == [
+                pretend.call("BUMP_ONLINE_ROLES_CHUNK_SIZE", 500)
+            ]
+            assert app.repository.update_targets_delegated_role.calls == [
+                pretend.call(mock_delegated_rolenames[0])
+            ]
+            assert app._update_snapshot_timestamp.calls == [
+                pretend.call(
+                    [[{r: {"v": 1, "x": 1} for r in mock_delegated_rolenames}]]
+                )
+            ]
+            assert app._end_bor_chain_callback.calls == [
+                pretend.call(None, start_time)
+            ]
+
+        if len(mock_delegated_rolenames) > 1:
+            assert app.repository._settings.get_fresh.calls == [
+                pretend.call("BUMP_ONLINE_ROLES_CHUNK_SIZE", 500)
+            ]
+            assert app._update_snapshot_timestamp.s.calls == [
+                pretend.call(
+                    app._update_online_role.chunks(
+                        zip(mock_delegated_rolenames),
+                        int(expected_log_msg[-1].split(":")[-1].strip()),
+                    ).group()
+                )
+            ]
+            assert app._end_bor_chain_callback.s.calls == [
+                pretend.call(start_time)
+            ]
+            assert app.chain.calls == [
+                pretend.call(
+                    app._update_online_role.chunks(
+                        zip(mock_delegated_rolenames),
+                        int(expected_log_msg[-1].split(":")[-1].strip()),
+                    ).group(),
+                    None,
+                    None,
+                )
+            ]
+
+    def test_bump_online_roles_lock_exception(self, app, caplog):
+        caplog.set_level(app.logging.ERROR)
+
+        app.time = pretend.stub(
+            time=pretend.call_recorder(lambda: 1740472169.0)
+        )
+        app.repository = pretend.stub(
+            _timeout=60,
+            _redis=pretend.stub(
+                set=pretend.call_recorder(lambda *a, **kw: True),
+                lock=pretend.raiser(
+                    app.redis.exceptions.LockNotOwnedError("error lock")
+                ),
+            ),
+            bootstrap_state="finished",
+        )
+
+        with pytest.raises(app.redis.exceptions.LockError):
+            app.bump_online_roles(expired=True)
+
+        assert [
+            "The task to bump all online roles exceeded the timeout of 60 "
+            "seconds."
+        ] == [rec.message for rec in caplog.records]
+
+    def test__update_online_role(self, app):
+        app.repository = pretend.stub(
+            update_targets_delegated_role=pretend.call_recorder(
+                lambda *a, **kw: None
+            )
+        )
+
+        result = app._update_online_role("a")
+
+        assert result is None
+        assert app.repository.update_targets_delegated_role.calls == [
+            pretend.call("a")
+        ]
+
+    def test__end_bor_chain_callback(self, app, caplog):
+        caplog.set_level(app.logging.INFO)
+        app.repository._redis = pretend.stub(
+            delete=pretend.call_recorder(lambda *a, **kw: None)
+        )
+
+        app.time = pretend.stub(
+            time=pretend.call_recorder(lambda: 1740472171.0)
+        )
+
+        result = app._end_bor_chain_callback({"some": "result"}, 1740472169.0)
+
+        assert [
+            "Total execution time for bump_online_roles: 2.00 seconds",
+            "Bump online roles lock removed",
+        ] == [rec.message for rec in caplog.records]
+        assert result == {
+            "result": {"some": "result"},
+            "execution_time_seconds": 2.00,
+        }
+        assert app.repository._redis.delete.calls == [
+            pretend.call(app.BOR_LOCK)
+        ]
+
+    @pytest.mark.parametrize(
+        "args, expected_result, expected_logs",
+        [
+            (
+                [
+                    [
+                        {
+                            "a": {
+                                "version": 1,
+                                "expire": "fake data",
+                                "target_files": [],
+                            }
+                        }
+                    ]
+                ],
+                None,
+                [
+                    "Time parsing _update_snapshot_timestamp: 2.0 seconds",
+                    "Time updating _update_snapshot_timestamp: 5.0 seconds",
+                    "Updated snapshot/timestamp with 1 role(s)",
+                ],
+            ),
+            (
+                [
+                    [
+                        {
+                            "a": {
+                                "version": 1,
+                                "expire": "fake data",
+                                "target_files": [],
+                            }
+                        },
+                        {
+                            "b": {
+                                "version": 5,
+                                "expire": "fake data",
+                                "target_files": [],
+                            }
+                        },
+                        {
+                            "targets": {
+                                "version": 3,
+                                "expire": "fake data",
+                                "target_files": [],
+                            }
+                        },
+                    ]
+                ],
+                None,
+                [
+                    "Time parsing _update_snapshot_timestamp: 2.0 seconds",
+                    "Time updating _update_snapshot_timestamp: 5.0 seconds",
+                    "Updated snapshot/timestamp with 3 role(s)",
+                ],
+            ),
+        ],
+    )
+    def test__update_snapshot_timestamp(
+        self, app, caplog, args, expected_result, expected_logs
+    ):
+        caplog.set_level(app.logging.INFO)
+
+        mocked_time = iter((1740472169.0, 1740472171.0, 1740472174.0))
+        app.time = pretend.stub(
+            time=pretend.call_recorder(lambda: next(mocked_time))
+        )
+        app.repository = pretend.stub(
+            _update_timestamp=pretend.call_recorder(lambda *a: None),
+            update_snapshot=pretend.call_recorder(
+                lambda *a: pretend.stub(signed=pretend.stub(version=5))
+            ),
+        )
+
+        result = app._update_snapshot_timestamp(args)
+        assert result is expected_result
+        assert expected_logs == [rec.message for rec in caplog.records]
+        assert app.repository._update_timestamp.calls == [pretend.call(5)]

--- a/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
+++ b/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
@@ -186,6 +186,28 @@ class TestCrud:
         ]
         assert mocked_all.all.calls == [pretend.call()]
 
+    def test_read_all_roles_rolenames(self, monkeypatch):
+        monkeypatch.setattr(
+            crud.models,
+            "RSTUFTargetRoles",
+            pretend.stub(rolename="bins-0", active=True),
+        )
+        mocked_all = pretend.stub(
+            all=pretend.call_recorder(
+                lambda: [(crud.models.RSTUFTargetRoles.rolename,)]
+            )
+        )
+        mocked_filter = pretend.stub(
+            filter=pretend.call_recorder(lambda *a: mocked_all)
+        )
+        mocked_db = pretend.stub(
+            query=pretend.call_recorder(lambda *a: mocked_filter)
+        )
+        test_result = crud.read_all_roles_rolenames(mocked_db)
+        assert test_result == ["bins-0"]
+        assert mocked_db.query.calls == [pretend.call("bins-0")]
+        assert mocked_all.all.calls == [pretend.call()]
+
     def test_read_roles_joint_files(self):
         crud.models.RSTUFTargetRoles = pretend.stub(
             rolename=pretend.stub(in_=pretend.call_recorder(lambda *a: True)),
@@ -249,7 +271,7 @@ class TestCrud:
         ]
         assert mocked_one.one.calls == [pretend.call()]
 
-    def test_read_roles_expired(self, monkeypatch):
+    def test_read_roles_rolenames_expired(self, monkeypatch):
         monkeypatch.setattr(
             crud.models,
             "RSTUFTargetRoles",
@@ -262,7 +284,9 @@ class TestCrud:
             ),
         )
         mocked_all = pretend.stub(
-            all=pretend.call_recorder(lambda: [crud.models.RSTUFTargetRoles])
+            all=pretend.call_recorder(
+                lambda: [(crud.models.RSTUFTargetRoles.rolename,)]
+            )
         )
         mocked_filter = pretend.stub(
             filter=pretend.call_recorder(lambda *a: mocked_all)
@@ -271,11 +295,13 @@ class TestCrud:
             query=pretend.call_recorder(lambda *a: mocked_filter)
         )
         expire_timedelta = datetime.timedelta(hours=-1)
-        test_result = crud.read_roles_expired(mocked_db, expire_timedelta)
+        test_result = crud.read_roles_rolenames_expired(
+            mocked_db, expire_timedelta
+        )
 
-        assert test_result == [crud.models.RSTUFTargetRoles]
+        assert test_result == ["bins-0"]
         assert mocked_db.query.calls == [
-            pretend.call(crud.models.RSTUFTargetRoles)
+            pretend.call(crud.models.RSTUFTargetRoles.rolename)
         ]
         assert mocked_filter.filter.calls == [pretend.call(True, True)]
         assert mocked_all.all.calls == [pretend.call()]

--- a/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
+++ b/tests/unit/tuf_repository_service_worker/models/targets/test_crud.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Repository Service for TUF Contributors
+# SPDX-FileCopyrightText: 2023-2025 Repository Service for TUF Contributors
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
@@ -21,15 +21,22 @@ class TestCrud:
             add_all=pretend.call_recorder(lambda *a: None),
             commit=pretend.call_recorder(lambda: None),
         )
+        datetime_now = datetime.datetime.now(timezone.utc)
         test_target = crud.schemas.RSTUFTargetRoleCreate(
             rolename="bins-0",
             version=1,
+            expires=datetime_now,
+            last_update=datetime_now,
         )
         test_result = crud.create_roles(mocked_db, [test_target])
         assert test_result == ["test_target_roles"]
         assert crud.models.RSTUFTargetRoles.calls == [
             pretend.call(
-                rolename=test_target.rolename, version=test_target.version
+                rolename=test_target.rolename,
+                version=test_target.version,
+                expires=datetime_now,
+                active=True,
+                last_update=datetime_now,
             )
         ]
         assert mocked_db.add_all.calls == [pretend.call(["test_target_roles"])]
@@ -191,25 +198,86 @@ class TestCrud:
             filter=pretend.call_recorder(lambda *a: mocked_all)
         )
         mocked_join = pretend.stub(
-            join=pretend.call_recorder(lambda *a: mocked_filter)
+            join=pretend.call_recorder(lambda *a, **kw: mocked_filter)
         )
         mocked_db = pretend.stub(
             query=pretend.call_recorder(lambda *a: mocked_join)
         )
 
-        test_result = crud.read_roles_joint_files(mocked_db, "bins-0")
+        test_result = crud.read_roles_joint_files(mocked_db, ["bins-0"])
+
+        assert test_result == [crud.models.RSTUFTargetRoles]
+        assert mocked_db.query.calls == [
+            pretend.call(crud.models.RSTUFTargetRoles),
+        ]
+        assert mocked_filter.filter.calls == [pretend.call(True, True)]
+        assert crud.models.RSTUFTargetRoles.rolename.in_.calls == [
+            pretend.call(["bins-0"])
+        ]
+        assert mocked_join.join.calls == [
+            pretend.call(crud.models.RSTUFTargetFiles, isouter=True)
+        ]
+        assert mocked_all.all.calls == [pretend.call()]
+
+    def test_read_role_joint_files(self):
+        crud.models.RSTUFTargetRoles = pretend.stub(
+            rolename="bins-0",
+            active=True,
+        )
+        mocked_one = pretend.stub(
+            one=pretend.call_recorder(lambda: crud.models.RSTUFTargetRoles)
+        )
+        mocked_filter = pretend.stub(
+            filter=pretend.call_recorder(lambda *a: mocked_one)
+        )
+        mocked_join = pretend.stub(
+            join=pretend.call_recorder(lambda *a, **kw: mocked_filter)
+        )
+        mocked_db = pretend.stub(
+            query=pretend.call_recorder(lambda *a: mocked_join)
+        )
+
+        test_result = crud.read_role_joint_files(mocked_db, "bins-0")
+
+        assert test_result == crud.models.RSTUFTargetRoles
+        assert mocked_db.query.calls == [
+            pretend.call(crud.models.RSTUFTargetRoles),
+        ]
+        assert mocked_filter.filter.calls == [pretend.call(True, True)]
+        assert mocked_join.join.calls == [
+            pretend.call(crud.models.RSTUFTargetFiles, isouter=True)
+        ]
+        assert mocked_one.one.calls == [pretend.call()]
+
+    def test_read_roles_expired(self, monkeypatch):
+        monkeypatch.setattr(
+            crud.models,
+            "RSTUFTargetRoles",
+            pretend.stub(
+                rolename="bins-0",
+                active=True,
+                expires=datetime.datetime(
+                    2019, 6, 16, 9, 5, 1, tzinfo=timezone.utc
+                ),
+            ),
+        )
+        mocked_all = pretend.stub(
+            all=pretend.call_recorder(lambda: [crud.models.RSTUFTargetRoles])
+        )
+        mocked_filter = pretend.stub(
+            filter=pretend.call_recorder(lambda *a: mocked_all)
+        )
+        mocked_db = pretend.stub(
+            query=pretend.call_recorder(lambda *a: mocked_filter)
+        )
+        expire_timedelta = datetime.timedelta(hours=-1)
+        test_result = crud.read_roles_expired(mocked_db, expire_timedelta)
 
         assert test_result == [crud.models.RSTUFTargetRoles]
         assert mocked_db.query.calls == [
             pretend.call(crud.models.RSTUFTargetRoles)
         ]
         assert mocked_filter.filter.calls == [pretend.call(True, True)]
-        assert crud.models.RSTUFTargetRoles.rolename.in_.calls == [
-            pretend.call("bins-0")
-        ]
-        assert mocked_join.join.calls == [
-            pretend.call(crud.models.RSTUFTargetFiles)
-        ]
         assert mocked_all.all.calls == [pretend.call()]
 
     def test_update_file_path_and_info(self, monkeypatch):
@@ -353,6 +421,69 @@ class TestCrud:
         assert mocked_db.commit.calls == [pretend.call()]
         assert fake_datetime.now.calls == [pretend.call(timezone.utc)]
 
+    def test_update_roles_expire_version_by_rolenames(self, monkeypatch):
+        new_expire = datetime.datetime(
+            2034, 6, 16, 9, 5, 1, tzinfo=timezone.utc
+        )
+        monkeypatch.setattr(
+            crud.models,
+            "RSTUFTargetRoles",
+            pretend.stub(
+                rolename=pretend.stub(
+                    in_=pretend.call_recorder(lambda *a: True)
+                )
+            ),
+        )
+        test_role1 = crud.schemas.RSTUFTargetRoleCreate(
+            rolename="bins-0",
+            version=3,
+            expires=datetime.datetime(
+                2016, 6, 16, 9, 5, 1, tzinfo=timezone.utc
+            ),
+        )
+        test_role2 = crud.schemas.RSTUFTargetRoleCreate(
+            rolename="bins-1",
+            version=3,
+            expires=datetime.datetime(
+                2016, 6, 16, 9, 5, 1, tzinfo=timezone.utc
+            ),
+        )
+
+        rolename_expire = {
+            "bins-0": (new_expire, 3),
+            "bins-1": (new_expire, 4),
+        }
+
+        mock_all = pretend.stub(
+            all=pretend.call_recorder(lambda: [test_role1, test_role2])
+        )
+        mocked_filter = pretend.stub(
+            filter=pretend.call_recorder(lambda *a: mock_all)
+        )
+        mocked_db = pretend.stub(
+            query=pretend.call_recorder(lambda *a: mocked_filter),
+            commit=pretend.call_recorder(lambda: None),
+            add=pretend.call_recorder(lambda *a: None),
+        )
+
+        result = crud.update_roles_expire_version_by_rolenames(
+            mocked_db, rolename_expire
+        )
+
+        assert result is None
+        assert test_role1.expires == new_expire
+        assert test_role2.expires == new_expire
+        assert test_role1.version == 3
+        assert test_role2.version == 4
+        assert mocked_db.add.calls == [
+            pretend.call(test_role1),
+            pretend.call(test_role2),
+        ]
+        assert mocked_db.commit.calls == [pretend.call()]
+        assert mocked_db.query.calls == [
+            pretend.call(crud.models.RSTUFTargetRoles)
+        ]
+
     def test_update_file_action_to_remove(self, monkeypatch):
         mocked_db = pretend.stub(
             add=pretend.call_recorder(lambda *a: None),
@@ -387,4 +518,66 @@ class TestCrud:
         assert mocked_db.add.calls == [pretend.call(test_target)]
         assert mocked_db.commit.calls == [pretend.call()]
         assert mocked_db.refresh.calls == [pretend.call(test_target)]
+        assert fake_datetime.now.calls == [pretend.call(timezone.utc)]
+
+    def test_read_role_deactivated_by_rolename(self, monkeypatch):
+        monkeypatch.setattr(
+            crud.models,
+            "RSTUFTargetRoles",
+            pretend.stub(rolename="bins-0", active=True),
+        )
+        mocked_first = pretend.stub(
+            first=pretend.call_recorder(lambda: [crud.models.RSTUFTargetRoles])
+        )
+        mocked_filter = pretend.stub(
+            filter=pretend.call_recorder(lambda *a: mocked_first)
+        )
+        mocked_db = pretend.stub(
+            query=pretend.call_recorder(lambda *a: mocked_filter)
+        )
+
+        test_result = crud.read_role_deactivated_by_rolename(
+            mocked_db, "bins-0"
+        )
+
+        assert test_result == [crud.models.RSTUFTargetRoles]
+        assert mocked_db.query.calls == [
+            pretend.call(crud.models.RSTUFTargetRoles)
+        ]
+        assert mocked_filter.filter.calls == [pretend.call(True, False)]
+        assert mocked_first.first.calls == [pretend.call()]
+
+    def test_update_role_to_deactivated(self, monkeypatch):
+        mocked_db = pretend.stub(
+            add=pretend.call_recorder(lambda *a: None),
+            commit=pretend.call_recorder(lambda: None),
+            refresh=pretend.call_recorder(lambda *a: None),
+        )
+
+        fake_lu = datetime.datetime(2019, 6, 16, 9, 5, 1, tzinfo=timezone.utc)
+        fake_datetime = pretend.stub(
+            now=pretend.call_recorder(lambda a: fake_lu)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_worker.models.targets.crud.datetime",
+            fake_datetime,
+        )
+
+        test_target_role = crud.schemas.RSTUFTargetRoleCreate(
+            rolename="bins-0",
+            version=3,
+            expires=datetime.datetime(
+                2016, 6, 16, 9, 5, 1, tzinfo=timezone.utc
+            ),
+        )
+
+        test_result = crud.update_role_to_deactivated(
+            mocked_db, test_target_role
+        )
+
+        assert test_result.last_update == fake_lu
+        assert test_result.active is False
+        assert mocked_db.add.calls == [pretend.call(test_target_role)]
+        assert mocked_db.commit.calls == [pretend.call()]
+        assert mocked_db.refresh.calls == [pretend.call(test_target_role)]
         assert fake_datetime.now.calls == [pretend.call(timezone.utc)]


### PR DESCRIPTION
### The Problem
RSTUF right now has an issue if used the backend storage (TUF metadata) as S3 buckets with large number of delegations roles (example hash bins).

The problem starts with 512 delegation roles and above and it needs to update a large number delegation roles (bump online roles) at the same time.

An example, 2048 roles can tack ~60 min to update it. Usually it will fail due the timeout.

### Solution
Use Celery Chain to create multiple tasks that can be distributed to Workers|

In that PR we propose the use of Celery groups by using chunk feature and create a Chain.

Based in the above example it can bump 2048 roles in ~360 seconds (6 min) without hanging

