### PR TITLE
build: group dependenbot gha PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
       prefix: "build"
       include: "scope"
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
It will help maintainers to review and merge dependabot for GHA as the Functional Tests is quite expensive in time.