### PR TITLE
hotfix: fix container image startup supervisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,12 @@ COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/pytho
 FROM pre-final
 
 WORKDIR /opt/repository-service-tuf-worker
-RUN mkdir /data
+ENV DATA_DIR=/data
+RUN mkdir $DATA_DIR
 COPY alembic.ini /opt/repository-service-tuf-worker/
 COPY alembic /opt/repository-service-tuf-worker/alembic
 COPY app.py /opt/repository-service-tuf-worker
 COPY entrypoint.sh /opt/repository-service-tuf-worker
-COPY supervisor.conf /opt/repository-service-tuf-worker/
+COPY supervisor.conf ${DATA_DIR}/
 COPY repository_service_tuf_worker /opt/repository-service-tuf-worker/repository_service_tuf_worker
 ENTRYPOINT ["bash", "entrypoint.sh"]


### PR DESCRIPTION
Container Image dev tag is broken

fix the container image startup with supervisor.conf not found
```
│ /usr/local/lib/python3.13/site-packages/pydantic/_internal/_config.py:373: UserWarning: Valid config keys have changed in V2:                    │
│ * 'orm_mode' has been renamed to 'from_attributes'                                                                                               │
│   warnings.warn(message, UserWarning)                                                                                                            │
│ INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.                                                                                   │
│ INFO  [alembic.runtime.migration] Will assume transactional DDL.                                                                                 │
│ Error: could not find config file /supervisor.conf                                                                                               │
│ For help, use /usr/local/bin/supervisord -h
```

Container images tag is used for development and few tests

This error was introduced on PR #715 
