### PR TITLE
Updated the Docker images

### DIFF
--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -9,7 +9,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:15.1
+    image: postgres:17.5-alpine3.21
     ports:
       - "5433:5432"
     environment:
@@ -34,7 +34,7 @@ services:
         condition: service_healthy
 
   redis:
-    image: redis:4.0
+    image: redis:8.0.0-alpine3.21
     volumes:
       - repository-service-tuf-redis-data:/data
     ports:

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -45,7 +45,7 @@ services:
       - "8080:8080"
 
   redis:
-    image: redis:4.0
+    image: redis:8.0.0-alpine3.21
     volumes:
       - repository-service-tuf-redis-data:/data
     ports:

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -9,7 +9,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:15.1
+    image: postgres:17.5-alpine3.21
     ports:
       - "5433:5432"
     environment:
@@ -42,7 +42,7 @@ services:
       - "8080:8080"
 
   redis:
-    image: redis:4.0
+    image: redis:8.0.0-alpine3.21
     volumes:
       - repository-service-tuf-redis-data:/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     restart: always
 
   postgres:
-    image: postgres:15.1
+    image: postgres:17.5-alpine3.21
     ports:
       # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"
@@ -56,7 +56,7 @@ services:
       - "8080:8080"
 
   redis:
-    image: redis:4.0
+    image: redis:8.0.0-alpine3.21
     volumes:
       - repository-service-tuf-redis-data:/data
     ports:


### PR DESCRIPTION
### Upgrades the docker containers from:

* Postress 15.1 to 17.5
Both have the same vulnerability scores and none of the other images have a lower vulnerability score.

* redis 4.0 to 8.0
The 4.0 image had vulnerabilities while the 8.0 doesn't have any vulnerabilities until now.