### PR TITLE
Following PR#794 to fix snapshot incosistency

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -566,7 +566,6 @@ class MetadataRepository:
             snapshot.signed.meta[f"{Targets.type}.json"] = MetaFile(
                 version=targets.signed.version
             )
-            logging.debug("Bumped version of 'Snapshot' role")
             snapshot_meta_updated = True
 
         if only_snapshot:
@@ -2217,10 +2216,10 @@ class MetadataRepository:
                     payload["delegations"]
                 )
                 targets = self._storage_load_targets()
-                snapshot = self._storage_load_snapshot()
                 success, failed = self._add_metadata_delegation(
                     delegations, targets, persist_targets=True
                 )
+                snapshot = self._storage_load_snapshot()
                 # NOTE: this portion of logic below cannot be part of the
                 # helper function `_add_metadata_delegation` because while
                 # running `_bootstrap_online_roles` targets still not exist


### PR DESCRIPTION
## Description
This PR follows up on #794, in which I missed an important detail.

### Changes
- Changed the `self._storage_load_snapshot()` call to being called after the `_add_metadata_delegation` function which updates and persists the snapshot with the correct targets meta. Previously, this change was not reflected as the `metadata_delegation` function used the local copy of the `snapshot` instead of the latest updated snapshot after `_add_metadata_delegation` function. Therefore, causing inconsistency.
- Removed a debug call for the logger

### Testing
Locally verified using the development environment. System behaves as expected.

@kairoaraujo 