### PR TITLE
fix: reject delegation roles with overlapping paths

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -952,6 +952,12 @@ class MetadataRepository:
         failed = []
         db_roles = []
 
+        existing_paths: set = set()
+        if targets.signed.delegations.roles:
+            for existing_role in targets.signed.delegations.roles.values():
+                if existing_role.paths:
+                    existing_paths.update(existing_role.paths)
+
         logging.debug("adding roles to Targets delegations")
         for role in delegations.roles:
             if targets.signed.delegations.roles is None:
@@ -971,6 +977,23 @@ class MetadataRepository:
                         "reason": (
                             "role already exists or name used in the past",
                         ),
+                    }
+                )
+                continue
+
+            overlapping = existing_paths.intersection(
+                delegations.roles[role].paths or []
+            )
+            if overlapping:
+                logging.info(
+                    f"Role '{role}' paths overlap with existing delegated "
+                    f"roles: {sorted(overlapping)}, skipping"
+                )
+                failed.append(
+                    {
+                        "role": role,
+                        "reason": f"paths overlap with existing delegated "
+                        f"roles: {sorted(overlapping)}",
                     }
                 )
                 continue
@@ -1010,6 +1033,8 @@ class MetadataRepository:
                 ]
 
             success[role] = role_metadata
+            if delegations.roles[role].paths:
+                existing_paths.update(delegations.roles[role].paths)
 
             logging.debug(f"creating role db '{role}' schema")
             db_roles = targets_schema.RSTUFTargetRoleCreate(

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -5634,3 +5634,149 @@ class TestMetadataRepository:
             if call.args[1] == "snapshot"
         ]
         assert len(snapshot_persist_calls) == 1
+
+    def test__add_metadata_delegation_rejects_overlapping_paths(
+        self, test_repo, monkeypatch
+    ):
+        existing_role = DelegatedRole(
+            name="project-a",
+            keyids=["online_keyid"],
+            threshold=1,
+            terminating=True,
+            paths=["project-a/*"],
+            unrecognized_fields={"x-rstuf-expire-policy": 5},
+        )
+        targets = Metadata(Targets())
+        targets.signed.delegations = Delegations(
+            keys={}, roles={"project-a": existing_role}
+        )
+
+        new_role = DelegatedRole(
+            name="project-b",
+            keyids=[],
+            threshold=1,
+            terminating=True,
+            paths=["project-a/*"],
+            unrecognized_fields={"x-rstuf-expire-policy": 5},
+        )
+        new_delegations = Delegations(keys={}, roles={"project-b": new_role})
+
+        test_repo._db = pretend.stub()
+        monkeypatch.setattr(
+            repository.targets_crud,
+            "read_role_deactivated_by_rolename",
+            pretend.call_recorder(lambda *a: None),
+        )
+
+        success, failed = test_repo._add_metadata_delegation(
+            new_delegations, targets, persist_targets=False
+        )
+
+        assert success == {}
+        assert len(failed) == 1
+        assert failed[0]["role"] == "project-b"
+        assert "overlap" in failed[0]["reason"]
+
+    def test__add_metadata_delegation_accepts_non_overlapping_paths(
+        self, test_repo, monkeypatch
+    ):
+        existing_role = DelegatedRole(
+            name="project-a",
+            keyids=["online_keyid"],
+            threshold=1,
+            terminating=True,
+            paths=["project-a/*"],
+            unrecognized_fields={"x-rstuf-expire-policy": 5},
+        )
+        targets = Metadata(Targets())
+        targets.signed.delegations = Delegations(
+            keys={}, roles={"project-a": existing_role}
+        )
+
+        new_role = DelegatedRole(
+            name="project-b",
+            keyids=[],
+            threshold=1,
+            terminating=True,
+            paths=["project-b/*"],
+            unrecognized_fields={"x-rstuf-expire-policy": 5},
+        )
+        new_delegations = Delegations(keys={}, roles={"project-b": new_role})
+
+        test_repo._db = pretend.stub()
+        monkeypatch.setattr(
+            repository.targets_crud,
+            "read_role_deactivated_by_rolename",
+            pretend.call_recorder(lambda *a: None),
+        )
+        test_repo.write_repository_settings = pretend.call_recorder(
+            lambda *a: None
+        )
+        test_repo._add_delegated_role_keys = pretend.call_recorder(
+            lambda *a: None
+        )
+        monkeypatch.setattr(
+            repository.targets_crud,
+            "create_roles",
+            pretend.call_recorder(lambda *a: None),
+        )
+
+        success, failed = test_repo._add_metadata_delegation(
+            new_delegations, targets, persist_targets=False
+        )
+
+        assert "project-b" in success
+        assert failed == []
+
+    def test__add_metadata_delegation_rejects_intra_batch_overlapping_paths(
+        self, test_repo, monkeypatch
+    ):
+        targets = Metadata(Targets())
+        targets.signed.delegations = Delegations(keys={}, roles={})
+
+        role_a = DelegatedRole(
+            name="project-a",
+            keyids=[],
+            threshold=1,
+            terminating=True,
+            paths=["project-a/*"],
+            unrecognized_fields={"x-rstuf-expire-policy": 5},
+        )
+        role_b = DelegatedRole(
+            name="project-b",
+            keyids=[],
+            threshold=1,
+            terminating=True,
+            paths=["project-a/*"],
+            unrecognized_fields={"x-rstuf-expire-policy": 5},
+        )
+        new_delegations = Delegations(
+            keys={}, roles={"project-a": role_a, "project-b": role_b}
+        )
+
+        test_repo._db = pretend.stub()
+        monkeypatch.setattr(
+            repository.targets_crud,
+            "read_role_deactivated_by_rolename",
+            pretend.call_recorder(lambda *a: None),
+        )
+        test_repo.write_repository_settings = pretend.call_recorder(
+            lambda *a: None
+        )
+        test_repo._add_delegated_role_keys = pretend.call_recorder(
+            lambda *a: None
+        )
+        monkeypatch.setattr(
+            repository.targets_crud,
+            "create_roles",
+            pretend.call_recorder(lambda *a: None),
+        )
+
+        success, failed = test_repo._add_metadata_delegation(
+            new_delegations, targets, persist_targets=False
+        )
+
+        assert "project-a" in success
+        assert len(failed) == 1
+        assert failed[0]["role"] == "project-b"
+        assert "overlap" in failed[0]["reason"]


### PR DESCRIPTION
### Description

`_add_metadata_delegation` validated role name uniqueness but did not check whether incoming role paths overlap with those already claimed by existing delegated roles.

Since TUF resolves delegations using first-match ordering, overlapping path patterns can silently coexist. In such cases, artifacts are always routed to the first matching role, making subsequent roles effectively unreachable.

This PR introduces a path-overlap validation step before accepting new delegated roles:

1. Collect all paths from existing delegated roles before processing new entries  
2. Reject any incoming role whose paths intersect with the existing set  
3. Update the path set after each successful addition to also detect intra-batch overlaps within the same request  

Rejected roles are appended to the failed list with a descriptive reason, consistent with the handling of duplicate role names.

### Tests

- `test__add_metadata_delegation_rejects_overlapping_paths`  
  Ensures a role with a path already claimed by an existing role is rejected  

- `test__add_metadata_delegation_accepts_non_overlapping_paths`  
  Ensures a role with a unique path is accepted  

- `test__add_metadata_delegation_rejects_intra_batch_overlapping_paths`  
  Ensures that when two roles in the same request share a path, the first is accepted and the second is rejected  
<img width="1048" height="125" alt="image" src="https://github.com/user-attachments/assets/a9d64c74-b55d-479b-8479-f47ddb40baa5" />

All 234 unit tests pass locally.

<img width="1062" height="119" alt="image" src="https://github.com/user-attachments/assets/7a11d83c-049b-4245-965c-20e3322aee32" />


### Fixes

Fixes: #782

### Reviewers

@srinjoydutta03 
@kairoaraujo   
@MVrachev 