### PR TITLE
fix: copy online key dict before mutating in _online_key property

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -149,7 +149,7 @@ class MetadataRepository:
     def _online_key(self) -> Key:
         key_dict = self._settings.get_fresh("ONLINE_KEY")
         if key_dict is not None:
-            key_dict = key_dict.copy()
+            key_dict = copy.deepcopy(key_dict)
             return Key.from_dict(key_dict.pop("keyid"), key_dict)
         else:
             root: Metadata[Root] = self._storage_load_root()

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -149,6 +149,7 @@ class MetadataRepository:
     def _online_key(self) -> Key:
         key_dict = self._settings.get_fresh("ONLINE_KEY")
         if key_dict is not None:
+            key_dict = key_dict.copy()
             return Key.from_dict(key_dict.pop("keyid"), key_dict)
         else:
             root: Metadata[Root] = self._storage_load_root()

--- a/repository_service_tuf_worker/signer.py
+++ b/repository_service_tuf_worker/signer.py
@@ -125,11 +125,17 @@ class SignerStore:
         """
 
         if key.keyid not in self._signers:
-            if uri := key.unrecognized_fields.get(RSTUF_ONLINE_KEY_URI_FIELD):
-                # (Re-)export ambient settings in isolated environment
-                with isolated_env(self._ambient_settings):
-                    signer = Signer.from_priv_key_uri(uri, key)
+            uri = key.unrecognized_fields.get(RSTUF_ONLINE_KEY_URI_FIELD)
+            if not uri:
+                raise ValueError(
+                    f"Online key {key.keyid!r} is missing the "
+                    f"'{RSTUF_ONLINE_KEY_URI_FIELD}' field. "
+                    "Re-run the TUF ceremony to set the correct key URI."
+                )
+            # (Re-)export ambient settings in isolated environment
+            with isolated_env(self._ambient_settings):
+                signer = Signer.from_priv_key_uri(uri, key)
 
-                self._signers[key.keyid] = signer
+            self._signers[key.keyid] = signer
 
         return self._signers[key.keyid]

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -102,7 +102,7 @@ class TestMetadataRepository:
     def test_online_key_property_does_not_mutate_settings_dict(
         self, test_repo, monkeypatch
     ):
-        fake_key_dict = {"keyval": "foo", "keyid": "key_id"}
+        fake_key_dict = {"keyval": {"public": "abc"}, "keyid": "key_id"}
         fake_settings = pretend.stub(
             get_fresh=pretend.call_recorder(lambda a: fake_key_dict)
         )
@@ -122,8 +122,8 @@ class TestMetadataRepository:
 
         assert "keyid" in fake_key_dict
         assert fake_key_obj.from_dict.calls == [
-            pretend.call("key_id", {"keyval": "foo"}),
-            pretend.call("key_id", {"keyval": "foo"}),
+            pretend.call("key_id", {"keyval": {"public": "abc"}}),
+            pretend.call("key_id", {"keyval": {"public": "abc"}}),
         ]
 
     def test_online_key_property_from_storage(self, test_repo, monkeypatch):

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -99,6 +99,33 @@ class TestMetadataRepository:
             pretend.call(fake_key_dict.pop("keyid"), fake_key_dict)
         ]
 
+    def test_online_key_property_does_not_mutate_settings_dict(
+        self, test_repo, monkeypatch
+    ):
+        fake_key_dict = {"keyval": "foo", "keyid": "key_id"}
+        fake_settings = pretend.stub(
+            get_fresh=pretend.call_recorder(lambda a: fake_key_dict)
+        )
+        monkeypatch.setattr(
+            repository,
+            "get_repository_settings",
+            lambda *a, **kw: fake_settings,
+        )
+        key = pretend.stub(keyid="key_id")
+        fake_key_obj = pretend.stub(
+            from_dict=pretend.call_recorder(lambda *a: key)
+        )
+        monkeypatch.setattr(f"{REPOSITORY_PATH}.Key", fake_key_obj)
+
+        test_repo._online_key
+        test_repo._online_key
+
+        assert "keyid" in fake_key_dict
+        assert fake_key_obj.from_dict.calls == [
+            pretend.call("key_id", {"keyval": "foo"}),
+            pretend.call("key_id", {"keyval": "foo"}),
+        ]
+
     def test_online_key_property_from_storage(self, test_repo, monkeypatch):
         fake_settings = pretend.stub(
             get_fresh=pretend.call_recorder(lambda a: None)

--- a/tests/unit/tuf_repository_service_worker/test_signer.py
+++ b/tests/unit/tuf_repository_service_worker/test_signer.py
@@ -47,6 +47,14 @@ class TestSigner:
 
         assert store.get(fake_key) == fake_signer
 
+    def test_get_missing_uri_field(self):
+        settings = Dynaconf()
+        store = SignerStore(settings)
+        fake_key = stub(keyid="fake_id", unrecognized_fields={})
+
+        with pytest.raises(ValueError, match=RSTUF_ONLINE_KEY_URI_FIELD):
+            store.get(fake_key)
+
     def test_get_from_file_name_uri(self, key_metadata):
         dir_ = _FILES / "pem"
         uri = "fn:ed25519_private.pem"


### PR DESCRIPTION
## Description

This PR fixes two issues in the worker's online key handling, both part of the remaining gaps tracked in #431.

### 1. `_online_key` mutates shared settings dict (repository.py)

`Key.from_dict(key_dict.pop("keyid"), key_dict)` was calling `.pop()` directly on the dict returned from settings.  
This mutated the shared object in place, so subsequent calls to `_online_key` received a dict with `keyid` already removed, leading to inconsistent state.

**Fix:**  
Create a copy of the dict before calling `.pop()` to avoid mutating shared state.

### 2. `SignerStore.get()` raises unclear `KeyError` when URI is missing (signer.py)

If the `x-rstuf-online-key-uri` field was missing from the online key metadata (e.g. due to a ceremony run with an older CLI), `SignerStore.get()` skipped loading the signer and later raised a `KeyError` during lookup.

This made the failure mode hard to diagnose.

**Fix:**  
Add an explicit check for the missing field and raise a `ValueError` with a clear message indicating that the issue likely originates from the ceremony step.


Fixes #431


## Type of change

- Bug fix (non-breaking change)

## Additional requirements

- [x] Tests have been added for the bug fix

## Code of Conduct

- [x] I agree to follow this project's Code of Conduct


**note** 
Worker pr  [#845 ](https://github.com/repository-service-tuf/repository-service-tuf-worker/pull/845) fixes the dict mutation `(.pop("keyid")` modifying shared state) and adds a clear error message when `x-rstuf-online-key-uri `is missing
CLI pr [#918](https://github.com/repository-service-tuf/repository-service-tuf-cli/pull/918) — fixes the ceremony writing the key identifier instead of `fn:<filename> `into `x-rstuf-online-key-uri`, so the worker can actually find the key file at signing time