### PR TITLE
fix: add soft time limit to repository_service_tuf_worker task

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional
 
 import redis
 from celery import Celery, chain, schedules, signals
+from celery.exceptions import SoftTimeLimitExceeded
 
 from repository_service_tuf_worker import get_worker_settings
 from repository_service_tuf_worker.repository import (
@@ -77,7 +78,12 @@ app = Celery(
 )
 
 
-@app.task(serializer="json", bind=True)
+@app.task(
+    serializer="json",
+    bind=True,
+    soft_time_limit=worker_settings.get("TASK_SOFT_TIME_LIMIT", 300),
+    time_limit=worker_settings.get("TASK_TIME_LIMIT", 600),
+)
 def repository_service_tuf_worker(
     self,
     action: str,
@@ -90,16 +96,24 @@ def repository_service_tuf_worker(
         action: which action to be executed by the task.
         payload: data that will be given to the action.
     """
-    repository_action = getattr(repository, action)
-    if payload is None:
-        result = repository_action()
-    else:
-        # add task id to payload
-        payload["task_id"] = self.request.id
+    try:
+        repository_action = getattr(repository, action)
+        if payload is None:
+            result = repository_action()
+        else:
+            # add task id to payload
+            payload["task_id"] = self.request.id
 
-        result = repository_action(payload, update_state=self.update_state)
+            result = repository_action(payload, update_state=self.update_state)
 
-    return result
+        return result
+    except SoftTimeLimitExceeded:
+        logging.error(
+            f"Task {self.request.id} exceeded the soft time limit "
+            f"({worker_settings.get('TASK_SOFT_TIME_LIMIT', 300)}s). "
+            "The task will be terminated."
+        )
+        raise
 
 
 @app.task(serializer="json", queue="rstuf_internals")

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -51,6 +51,24 @@ class TestApp:
             pretend.call(),
         ]
 
+    def test_repository_service_tuf_worker_soft_time_limit(self, app, caplog):
+        caplog.set_level(app.logging.ERROR)
+
+        app.repository = pretend.stub(
+            test_action=pretend.raiser(app.SoftTimeLimitExceeded()),
+        )
+
+        with pytest.raises(app.SoftTimeLimitExceeded):
+            app.repository_service_tuf_worker(
+                "test_action",
+                payload={"k": "v"},
+            )
+
+        assert [
+            "Task None exceeded the soft time limit (300s). "
+            "The task will be terminated."
+        ] == [rec.message for rec in caplog.records]
+
     def test__publish_signals(self, app):
         app.redis_backend = pretend.stub(
             set=pretend.call_recorder(lambda *a: None)


### PR DESCRIPTION
Fixes #708

## Problem

The main `repository_service_tuf_worker` Celery task had no time limit.

If a task hangs (network call, lock contention, slow signing backend), it can occupy a worker indefinitely. Over time, this can exhaust the worker pool and block all new signing requests. This was flagged in the X41 D-Sec audit (RSTUF-CR-25-106).

PR #743 attempted to address this, but applied time limits to BOR chain tasks (`bump_online_roles`, `_update_online_role`, `_update_snapshot_timestamp`). These tasks have variable runtime and interact with `BOR_LOCK`, so limiting them can break expected behavior.

This PR applies the time limit only to `repository_service_tuf_worker`.

## Changes

**`app.py`**

* Import `SoftTimeLimitExceeded` from `celery.exceptions`
* Add `soft_time_limit` and `time_limit` to `repository_service_tuf_worker` only
* BOR chain tasks remain unchanged
* Wrap task body in try/except to log the timeout and re-raise before the hard limit

**`tests/unit/test_app.py`**

* Add `test_repository_service_tuf_worker_soft_time_limit` to verify the exception is logged and re-raised

## Test 

```bash
pipenv run pytest tests/unit/test_app.py -v
```

## Task config verification

```bash
pipenv run python -c "import app; t = app.repository_service_tuf_worker; print('soft_time_limit:', t.soft_time_limit); print('time_limit:', t.time_limit)"
```
<img width="1042" height="159" alt="image" src="https://github.com/user-attachments/assets/0978ee93-f6e7-4e1a-9519-27194345f8a5" />