### PR TITLE
fix: ensure root updates have at least one valid signature (#848, #367)

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -45,6 +45,7 @@ from tuf.api.metadata import (  # noqa
     TargetFile,
     Targets,
     Timestamp,
+    VerificationResult,
 )
 from tuf.api.serialization.json import CanonicalJSONSerializer, JSONSerializer
 
@@ -2054,8 +2055,14 @@ class MetadataRepository:
             self._verify_new_root_signing(current_root, new_root)
 
         except UnsignedMetadataError:
-            # TODO: Add missing sanity check - new root must have at least 1
-            # and only valid signature - use `get_verification_status` (#367)
+            # Ensure new root has at least one valid signature
+            result = self._validate_threshold(new_root)
+            if len(result.signed) == 0:
+                raise RepositoryError(
+                    f"New Root v{new_root.signed.version} has no valid "
+                    "signatures"
+                )
+
             self.write_repository_settings("ROOT_SIGNING", new_root.to_dict())
             return self._task_result(
                 task=TaskName.METADATA_UPDATE,
@@ -2335,7 +2342,7 @@ class MetadataRepository:
         metadata: Metadata,
         delegator: Optional[Metadata] = None,
         delegated_role: Optional[str] = Root.type,
-    ) -> bool:
+    ) -> VerificationResult:
         """
         Validate signature threshold using appropriate delegator(s).
         If no delegator is passed, the metadata itself is used as delegator.
@@ -2343,14 +2350,25 @@ class MetadataRepository:
         if delegator is None:
             delegator = metadata
 
-        try:
-            delegator.verify_delegate(delegated_role, metadata)
+        if delegator.signed.type == Root.type:
+            result = delegator.signed.get_verification_result(
+                delegated_role, metadata.signed_bytes, metadata.signatures
+            )
+        elif delegator.signed.type == Targets.type:
+            result = delegator.signed.get_verification_result(
+                delegated_role, metadata.signed_bytes, metadata.signatures
+            )
+        else:
+            raise TypeError("Call is valid only on delegator metadata")
 
-        except UnsignedMetadataError as e:
-            logging.info(e)
-            return False
+        if not result:
+            logging.info(
+                f"Validation failed for {delegated_role}. "
+                f"Required {result.threshold} signatures, "
+                f"but only {len(result.signed)} valid signatures found."
+            )
 
-        return True
+        return result
 
     def sign_metadata(
         self,

--- a/tests/unit/tuf_repository_service_worker/test_signature_threshold_fix.py
+++ b/tests/unit/tuf_repository_service_worker/test_signature_threshold_fix.py
@@ -1,0 +1,100 @@
+import pretend
+import pytest
+from tuf.api.metadata import Metadata, Root, VerificationResult
+from tuf.api.exceptions import UnsignedMetadataError, RepositoryError
+from repository_service_tuf_worker import repository
+
+@pytest.fixture()
+def signature_test_repo(monkeypatch):
+    """A minimal test_repo for signature threshold tests."""
+    # Mock __init__ to avoid settings/storage issues
+    monkeypatch.setattr(repository.MetadataRepository, "__init__", lambda *a: None)
+    repo = repository.MetadataRepository()
+    return repo
+
+class TestSignatureThresholdFix:
+    def test_validate_threshold_returns_verification_result(self, signature_test_repo, monkeypatch):
+        """Test that _validate_threshold returns a VerificationResult (#367)."""
+        # Create a mock root with a threshold
+        metadata = Metadata(Root())
+        metadata.signed.threshold = 2
+        metadata.signatures = {"key1": pretend.stub()}
+        
+        # Mock get_verification_result to return a result
+        mock_result = VerificationResult(
+            threshold=2,
+            signed={"key1": pretend.stub()},
+            unsigned={"key2": pretend.stub()}
+        )
+        
+        monkeypatch.setattr(
+            metadata.signed, "get_verification_result", 
+            lambda *a: mock_result
+        )
+        
+        result = signature_test_repo._validate_threshold(metadata)
+        
+        assert isinstance(result, VerificationResult)
+        assert result.threshold == 2
+        assert len(result.signed) == 1
+        assert result.missing == 1
+        assert bool(result) is False
+
+    def test_root_metadata_update_sanity_check(self, signature_test_repo, monkeypatch):
+        """Test that _root_metadata_update enforces at least one valid signature."""
+        
+        # Mock required attributes and methods manually
+        monkeypatch.setattr(signature_test_repo, "_storage_load_root", pretend.call_recorder(lambda *a: Metadata(Root())))
+        monkeypatch.setattr(signature_test_repo, "write_repository_settings", pretend.call_recorder(lambda *a: None))
+        monkeypatch.setattr(signature_test_repo, "_task_result", pretend.call_recorder(lambda **kwargs: kwargs) )
+        
+        # New root with NO signatures
+        new_root = Metadata(Root())
+        new_root.signatures = {} 
+        
+        # Mock _verify_new_root_signing to raise UnsignedMetadataError
+        monkeypatch.setattr(
+            signature_test_repo, "_verify_new_root_signing",
+            pretend.call_recorder(pretend.raiser(UnsignedMetadataError("Missing signatures")))
+        )
+        
+        # Call and expect RepositoryError
+        with pytest.raises(RepositoryError, match="has no valid signatures"):
+            signature_test_repo._root_metadata_update(new_root)
+        
+        # Ensure settings were NOT written
+        assert signature_test_repo.write_repository_settings.calls == []
+
+    def test_root_metadata_update_with_one_signature(self, signature_test_repo, monkeypatch):
+        """Test that _root_metadata_update accepts a root with at least one signature (even if threshold not met)."""
+        monkeypatch.setattr(signature_test_repo, "_storage_load_root", pretend.call_recorder(lambda *a: Metadata(Root())))
+        monkeypatch.setattr(signature_test_repo, "write_repository_settings", pretend.call_recorder(lambda *a: None))
+        monkeypatch.setattr(signature_test_repo, "_task_result", pretend.call_recorder(lambda **kwargs: kwargs))
+        
+        # New root with at least one signature
+        new_root = Metadata(Root())
+        new_root.signatures = {"key1": pretend.stub()} 
+        # Mock to_dict and version to avoid issues with stubs/empty objects
+        monkeypatch.setattr(new_root, "to_dict", lambda: {})
+        
+        # Mock _verify_new_root_signing to raise UnsignedMetadataError
+        monkeypatch.setattr(
+            signature_test_repo, "_verify_new_root_signing",
+            pretend.call_recorder(pretend.raiser(UnsignedMetadataError("Missing signatures")))
+        )
+        
+        # Mock _validate_threshold to return a result with 1 signature
+        mock_result = VerificationResult(
+            threshold=2,
+            signed={"key1": pretend.stub()},
+            unsigned={"key2": pretend.stub()}
+        )
+        monkeypatch.setattr(
+            signature_test_repo, "_validate_threshold",
+            lambda *a: mock_result
+        )
+        
+        signature_test_repo._root_metadata_update(new_root)
+        
+        # Ensure settings WERE written (pending state)
+        assert len(signature_test_repo.write_repository_settings.calls) == 1


### PR DESCRIPTION
### What is the PR about?
This PR provides a comprehensive fix for the missing sanity check in Root updates (#848) by addressing the long-standing architectural task of improving signature validation (#367).

#### 1. Architectural Improvement (#367)
Refactored `MetadataRepository._validate_threshold` to use `tuf.api.metadata.get_verification_result()`. 
- **Detail**: It now returns a `VerificationResult` object instead of a simple boolean, enabling the caller to see exactly how many valid signatures were found versus how many are required.
- **Backward Compatibility**: The new return type is boolean-compatible (via `__bool__`), ensuring no regressions in the 8 other locations where this method is used.

#### 2. Security/Logic Fix (#848)
Improved the `_root_metadata_update` logic to prevent a security/logic gap.
- **Sanity Check**: When a Root update is partially signed (caught as `UnsignedMetadataError`), the worker now explicitly verifies that at least one valid signature is present before saving the metadata to the repository settings. 
- **Impact**: This prevents the worker from persisting completely unsigned or malformed Root metadata into a "pending" state.

### Additional requirements
- [x] Tests have been added for the bug fix or new feature
- [x] All 8 existing call sites of `_validate_threshold` have been reviewed and confirmed compatible.
