### PR TITLE
Security hardening: run services as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,17 @@ FROM pre-final
 WORKDIR /opt/repository-service-tuf-worker
 ENV DATA_DIR=/data
 RUN mkdir $DATA_DIR
+
+RUN groupadd -g 1000 tuf && useradd -r -u 1000 -g tuf tuf
+
 COPY alembic.ini /opt/repository-service-tuf-worker/
 COPY alembic /opt/repository-service-tuf-worker/alembic
 COPY app.py /opt/repository-service-tuf-worker
 COPY entrypoint.sh /opt/repository-service-tuf-worker
 COPY supervisor.conf ${DATA_DIR}/
 COPY repository_service_tuf_worker /opt/repository-service-tuf-worker/repository_service_tuf_worker
+
+RUN chown -R tuf:tuf /opt/repository-service-tuf-worker ${DATA_DIR}
+USER 1000
+
 ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/supervisor-dev.conf
+++ b/supervisor-dev.conf
@@ -25,6 +25,6 @@ stdout_logfile_maxbytes = 0
 [supervisord]
 loglevel = info
 nodaemon = true
-pidfile = /tmp/supervisord.pid
+pidfile = /data/supervisord.pid
 logfile = /dev/null
 logfile_maxbytes = 0

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -25,6 +25,6 @@ stdout_logfile_maxbytes = 0
 [supervisord]
 loglevel = info
 nodaemon = true
-pidfile = /tmp/supervisord.pid
+pidfile = /data/supervisord.pid
 logfile = /dev/null
 logfile_maxbytes = 0


### PR DESCRIPTION
This change updates the containers to run as a non-root user instead of root.

Summary of changes:
- Created a dedicated user named tuf (UID 1000) inside the containers
- Updated file and directory permissions so the tuf user can access required paths
- Changed internal service ports from 80 to 8080 so root privileges are not required
- Updated container and deployment configuration to enforce non-root execution
- Adjusted supervisor configuration for worker to use writable directories
- Updated Helm charts to set securityContext with runAsNonRoot

Why this change:
Running containers as root is not recommended for security reasons. Running as a non-root user follows container security best practices and reduces risk in production environments.

Testing:
The configuration was verified to ensure the API and Worker can start under non-root permissions and the container setup remains consistent with docker-compose and Helm deployment.

This change is coordinated with the umbrella repository PR:
https://github.com/repository-service-tuf/repository-service-tuf/pull/934