### PR TITLE
Remove deprecated RSTUF_SQL_* environment variable fallbacks

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,16 +11,9 @@ from alembic import context
 # access to the values within the .ini file in use.
 config = context.config
 
-# Support RSTUF Worker Container multiple environment variables for SQL
-# TODO: Removed deprecated RSTUF_SQL_* environment variables in the future
-sql_server = os.getenv("RSTUF_SQL_SERVER")
-sql_user = os.getenv("RSTUF_SQL_USER")
-sql_password = os.getenv("RSTUF_SQL_PASSWORD")
-if sql_server or sql_user or sql_password:
-    logging.warning("RSTUF_SQL_* are deprecated. Use RSTUF_DB_* instead.")
-db_server = os.getenv("RSTUF_DB_SERVER", sql_server)
-db_user = os.getenv("RSTUF_DB_USER", sql_user)
-db_password = os.getenv("RSTUF_DB_PASSWORD", sql_password)
+db_server = os.getenv("RSTUF_DB_SERVER")
+db_user = os.getenv("RSTUF_DB_USER")
+db_password = os.getenv("RSTUF_DB_PASSWORD")
 
 if db_server is None:
     raise ValueError("RSTUF_DB_SERVER is required")

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -65,7 +65,7 @@ services:
       - RSTUF_ONLINE_KEY_DIR=/var/opt/repository-service-tuf/key_storage
       - RSTUF_BROKER_SERVER=redis://redis
       - RSTUF_REDIS_SERVER=redis://redis
-      - RSTUF_SQL_SERVER=mysql+pymysql://root:secret@mysql:3306/rstuf
+      - RSTUF_DB_SERVER=mysql+pymysql://root:secret@mysql:3306/rstuf
     volumes:
       - ./:/opt/repository-service-tuf-worker:z
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage


### PR DESCRIPTION
PR #562 added the RSTUF_DB_* env vars and kept RSTUF_SQL_* around as fallbacks. There's a TODO in alembic/env.py to remove them, so this does that.                                                                                                                                         
                                                                                                                                              
- Removed the RSTUF_SQL_* fallback logic and deprecation warning from alembic/env.py                                                          
- Updated docker-compose-mysql.yml to use RSTUF_DB_SERVER instead of RSTUF_SQL_SERVER  