### PR TITLE
feat(app): configure Celery broker TLS via RSTUF env

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ import redis
 from celery import Celery, chain, schedules, signals
 
 from repository_service_tuf_worker import get_worker_settings
+from repository_service_tuf_worker.celery_broker_ssl import build_broker_use_ssl
 from repository_service_tuf_worker.repository import (
     MetadataRepository,
     MetaFile,
@@ -49,19 +50,19 @@ redis_backend = redis.StrictRedis.from_url(
     db=worker_settings.get("REDIS_SERVER_DB_RESULT", 0),
 )
 
-# TODO: Issue https://github.com/repository-service-tuf/vmware/issues/6
-# BROKER_USE_SSL = {
-#     "keyfile": "data/certs/engine_mq.pem",
-#     "certfile": "data/certs/engine_mq.crt",
-#     "ca_certs": "data/certs/ca_mq.crt",
-#     "cert_reqs": ssl.CERT_REQUIRED,
-# }
+try:
+    _broker_use_ssl = build_broker_use_ssl(worker_settings)
+except ValueError as err:
+    raise ValueError(
+        "Invalid Celery broker SSL settings "
+        "(check RSTUF_BROKER_USE_SSL / RSTUF_BROKER_SSL_* / "
+        "RSTUF_BROKER_SSL_OPTIONS): "
+        f"{err}"
+    ) from err
 
 repository = MetadataRepository.create_service()
 
-
-app = Celery(
-    f"repository_service_tuf_worker_{worker_settings.WORKER_ID}",
+_celery_kwargs: Dict[str, Any] = dict(
     broker=worker_settings.BROKER_SERVER,
     backend=(
         f"{worker_settings.REDIS_SERVER}"
@@ -72,8 +73,13 @@ app = Celery(
     task_acks_late=True,
     task_track_started=True,
     broker_heartbeat=0,
-    # broker_use_ssl=BROKER_USE_SSL
-    # (https://github.com/repository-service-tuf/vmware/issues/6)
+)
+if _broker_use_ssl is not None:
+    _celery_kwargs["broker_use_ssl"] = _broker_use_ssl
+
+app = Celery(
+    f"repository_service_tuf_worker_{worker_settings.WORKER_ID}",
+    **_celery_kwargs,
 )
 
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -59,6 +59,35 @@ See [Celery Broker Instructions](https://docs.celeryq.dev/en/stable/getting-star
 
 Example: `guest:guest@rabbitmq:5672`
 
+#### (Optional) Celery broker TLS (`RSTUF_BROKER_USE_SSL` and related)
+
+When the AMQP broker requires TLS (or you use an ``amqps://`` broker URL), pass
+SSL options into Celery’s ``broker_use_ssl`` setting using either:
+
+* **Structured env vars** — set ``RSTUF_BROKER_USE_SSL`` to a truthy value
+  (``true``, ``1``, ``yes``, ``on``). Optional paths (must be existing files
+  inside the container):
+
+  * ``RSTUF_BROKER_SSL_KEYFILE`` — client private key
+  * ``RSTUF_BROKER_SSL_CERTFILE`` — client certificate
+  * ``RSTUF_BROKER_SSL_CA_CERTS`` — CA bundle for broker verification
+  * ``RSTUF_BROKER_SSL_CERT_REQS`` — ``required`` (default), ``optional``, or
+    ``none`` (maps to Python ``ssl.CERT_*``)
+
+  With only ``RSTUF_BROKER_USE_SSL=true``, the worker uses
+  ``cert_reqs=CERT_REQUIRED`` and no client certificate paths (suitable for
+  many server-authenticated TLS setups when the runtime trust store is enough).
+
+* **JSON override** — ``RSTUF_BROKER_SSL_OPTIONS`` as a JSON object is merged
+  as Celery’s ``broker_use_ssl`` dict (after normalizing ``cert_reqs`` strings).
+  When this variable is set to a non-empty object, it takes precedence over
+  ``RSTUF_BROKER_USE_SSL`` for building the dict.
+
+Invalid JSON, unknown ``cert_reqs``, or missing certificate files make the
+worker fail at startup with a clear error.
+
+See also [Celery broker-use-ssl](https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-use-ssl).
+
 #### (Required) `RSTUF_REDIS_SERVER`
 
 Redis server address.

--- a/repository_service_tuf_worker/celery_broker_ssl.py
+++ b/repository_service_tuf_worker/celery_broker_ssl.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: 2025-2026 Repository Service for TUF Contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Celery AMQP broker TLS options from worker settings (``RSTUF_*`` env)."""
+
+from __future__ import annotations
+
+import json
+import os
+import ssl
+from typing import Any, Dict, Optional
+
+_CERT_REQS_BY_NAME: Dict[str, int] = {
+    "required": ssl.CERT_REQUIRED,
+    "optional": ssl.CERT_OPTIONAL,
+    "none": ssl.CERT_NONE,
+}
+
+
+def _truthy(value: Any) -> bool:
+    if value is True:
+        return True
+    if value is False or value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
+def _parse_cert_reqs(value: Any) -> int:
+    if isinstance(value, int):
+        if value in (ssl.CERT_NONE, ssl.CERT_OPTIONAL, ssl.CERT_REQUIRED):
+            return value
+        raise ValueError(
+            f"Invalid BROKER_SSL_CERT_REQS integer: {value!r} "
+            "(use ssl.CERT_* values or a string name)"
+        )
+    if value is None:
+        return ssl.CERT_REQUIRED
+    name = str(value).strip().lower()
+    if name not in _CERT_REQS_BY_NAME:
+        allowed = ", ".join(sorted(_CERT_REQS_BY_NAME))
+        raise ValueError(
+            f"Invalid BROKER_SSL_CERT_REQS {value!r}; use one of: {allowed}"
+        )
+    return _CERT_REQS_BY_NAME[name]
+
+
+def _normalize_ssl_dict(opts: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy with ``cert_reqs`` as an ``ssl.CERT_*`` int if present."""
+    out = dict(opts)
+    if "cert_reqs" in out:
+        out["cert_reqs"] = _parse_cert_reqs(out["cert_reqs"])
+    return out
+
+
+def _existing_file_path(label: str, path: str) -> str:
+    expanded = os.path.expanduser(path.strip())
+    if not os.path.isfile(expanded):
+        raise ValueError(f"{label} is not a readable file: {path!r}")
+    return expanded
+
+
+def build_broker_use_ssl(settings: Any) -> Optional[Dict[str, Any]]:
+    """Build Celery ``broker_use_ssl`` from Dynaconf worker settings.
+
+    Precedence:
+
+    1. ``BROKER_SSL_OPTIONS`` — JSON object (or dict) merged as-is after
+       normalizing ``cert_reqs`` strings. Enables TLS without requiring
+       ``BROKER_USE_SSL``.
+    2. Else if ``BROKER_USE_SSL`` is truthy — build a dict from
+       ``BROKER_SSL_KEYFILE``, ``BROKER_SSL_CERTFILE``, ``BROKER_SSL_CA_CERTS``,
+       and ``BROKER_SSL_CERT_REQS`` (default ``required``).
+
+    Env vars use the ``RSTUF_`` prefix (e.g. ``RSTUF_BROKER_USE_SSL``).
+
+    Returns:
+        A dict for Celery's ``broker_use_ssl``, or ``None`` when TLS is off.
+
+    Raises:
+        ValueError: invalid JSON, unknown ``cert_reqs``, or missing SSL file.
+    """
+    raw_options = settings.get("BROKER_SSL_OPTIONS")
+    if raw_options not in (None, "", {}):
+        if isinstance(raw_options, dict):
+            opts = raw_options
+        else:
+            try:
+                opts = json.loads(str(raw_options))
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"BROKER_SSL_OPTIONS must be valid JSON object: {e}"
+                ) from e
+        if not isinstance(opts, dict):
+            raise ValueError("BROKER_SSL_OPTIONS must be a JSON object")
+        return _normalize_ssl_dict(opts)
+
+    if not _truthy(settings.get("BROKER_USE_SSL")):
+        return None
+
+    ssl_dict: Dict[str, Any] = {}
+    cert_reqs = _parse_cert_reqs(settings.get("BROKER_SSL_CERT_REQS"))
+    ssl_dict["cert_reqs"] = cert_reqs
+
+    keyfile = settings.get("BROKER_SSL_KEYFILE")
+    certfile = settings.get("BROKER_SSL_CERTFILE")
+    ca_certs = settings.get("BROKER_SSL_CA_CERTS")
+
+    if keyfile:
+        ssl_dict["keyfile"] = _existing_file_path("BROKER_SSL_KEYFILE", keyfile)
+    if certfile:
+        ssl_dict["certfile"] = _existing_file_path(
+            "BROKER_SSL_CERTFILE", certfile
+        )
+    if ca_certs:
+        ssl_dict["ca_certs"] = _existing_file_path(
+            "BROKER_SSL_CA_CERTS", ca_certs
+        )
+
+    return ssl_dict

--- a/tests/unit/test_celery_broker_ssl.py
+++ b/tests/unit/test_celery_broker_ssl.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2025-2026 Repository Service for TUF Contributors
+#
+# SPDX-License-Identifier: MIT
+
+import json
+import ssl
+
+import pytest
+
+from repository_service_tuf_worker.celery_broker_ssl import build_broker_use_ssl
+
+
+class _Settings:
+    def __init__(self, data):
+        self._data = data
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+
+def test_build_broker_use_ssl_disabled_by_default():
+    assert build_broker_use_ssl(_Settings({})) is None
+
+
+@pytest.mark.parametrize("flag", ("true", "1", "yes", "on", True))
+def test_build_broker_use_ssl_minimal(flag):
+    result = build_broker_use_ssl(_Settings({"BROKER_USE_SSL": flag}))
+    assert result == {"cert_reqs": ssl.CERT_REQUIRED}
+
+
+def test_build_broker_use_ssl_cert_reqs_optional():
+    result = build_broker_use_ssl(
+        _Settings({"BROKER_USE_SSL": True, "BROKER_SSL_CERT_REQS": "optional"})
+    )
+    assert result == {"cert_reqs": ssl.CERT_OPTIONAL}
+
+
+def test_build_broker_use_ssl_cert_reqs_none():
+    result = build_broker_use_ssl(
+        _Settings({"BROKER_USE_SSL": True, "BROKER_SSL_CERT_REQS": "none"})
+    )
+    assert result == {"cert_reqs": ssl.CERT_NONE}
+
+
+def test_build_broker_use_ssl_invalid_cert_reqs():
+    with pytest.raises(ValueError, match="Invalid BROKER_SSL_CERT_REQS"):
+        build_broker_use_ssl(
+            _Settings({"BROKER_USE_SSL": True, "BROKER_SSL_CERT_REQS": "bogus"})
+        )
+
+
+def test_build_broker_use_ssl_with_key_and_cert(tmp_path):
+    key = tmp_path / "k.pem"
+    cert = tmp_path / "c.pem"
+    ca = tmp_path / "ca.pem"
+    key.write_text("k")
+    cert.write_text("c")
+    ca.write_text("ca")
+    result = build_broker_use_ssl(
+        _Settings(
+            {
+                "BROKER_USE_SSL": True,
+                "BROKER_SSL_KEYFILE": str(key),
+                "BROKER_SSL_CERTFILE": str(cert),
+                "BROKER_SSL_CA_CERTS": str(ca),
+            }
+        )
+    )
+    assert result["cert_reqs"] == ssl.CERT_REQUIRED
+    assert result["keyfile"] == str(key)
+    assert result["certfile"] == str(cert)
+    assert result["ca_certs"] == str(ca)
+
+
+def test_build_broker_use_ssl_missing_keyfile(tmp_path):
+    cert = tmp_path / "c.pem"
+    cert.write_text("c")
+    with pytest.raises(ValueError, match="not a readable file"):
+        build_broker_use_ssl(
+            _Settings(
+                {
+                    "BROKER_USE_SSL": True,
+                    "BROKER_SSL_KEYFILE": str(tmp_path / "missing.pem"),
+                    "BROKER_SSL_CERTFILE": str(cert),
+                }
+            )
+        )
+
+
+def test_build_broker_use_ssl_options_json_string():
+    payload = json.dumps(
+        {"cert_reqs": "none", "ca_certs": "/does/not/exist"}
+    )
+    # Paths in JSON are not validated by build_broker_use_ssl for OPTIONS
+    result = build_broker_use_ssl(_Settings({"BROKER_SSL_OPTIONS": payload}))
+    assert result["cert_reqs"] == ssl.CERT_NONE
+    assert result["ca_certs"] == "/does/not/exist"
+
+
+def test_build_broker_use_ssl_options_dict():
+    result = build_broker_use_ssl(
+        _Settings(
+            {
+                "BROKER_SSL_OPTIONS": {"cert_reqs": "required"},
+                "BROKER_USE_SSL": False,
+            }
+        )
+    )
+    assert result == {"cert_reqs": ssl.CERT_REQUIRED}
+
+
+def test_build_broker_use_ssl_options_invalid_json():
+    with pytest.raises(ValueError, match="valid JSON"):
+        build_broker_use_ssl(_Settings({"BROKER_SSL_OPTIONS": "not-json"}))
+
+
+def test_build_broker_use_ssl_options_not_object():
+    with pytest.raises(ValueError, match="JSON object"):
+        build_broker_use_ssl(_Settings({"BROKER_SSL_OPTIONS": "[1,2]"}))
+
+
+def test_build_broker_use_ssl_options_takes_precedence_over_use_ssl(tmp_path):
+    """Explicit JSON options win; BROKER_USE_SSL is ignored when OPTIONS set."""
+    ca = tmp_path / "ca.pem"
+    ca.write_text("ca")
+    raw = json.dumps({"cert_reqs": "none", "ca_certs": str(ca)})
+    result = build_broker_use_ssl(
+        _Settings(
+            {
+                "BROKER_SSL_OPTIONS": raw,
+                "BROKER_USE_SSL": True,
+                "BROKER_SSL_CERT_REQS": "required",
+            }
+        )
+    )
+    assert result["cert_reqs"] == ssl.CERT_NONE
+    assert result["ca_certs"] == str(ca)


### PR DESCRIPTION
### PR description

Adds `build_broker_use_ssl()` and wires `broker_use_ssl` into the Celery app from `RSTUF_BROKER_USE_SSL`, `RSTUF_BROKER_SSL_*`, or `RSTUF_BROKER_SSL_OPTIONS`. Documents variables in `Docker_README.md`. Invalid SSL config fails fast at startup with a clear error.

**How to test**

```bash
cd /path/to/repository-service-tuf-worker
export RSTUF_WORKER_ID=test RSTUF_BROKER_SERVER=fakeserver RSTUF_REDIS_SERVER=redis://fake-redis \
  RSTUF_DB_SERVER=postgresql://fake-sql RSTUF_STORAGE_BACKEND=LocalStorage \
  RSTUF_LOCAL_STORAGE_BACKEND_PATH=./data-test/s DATA_DIR=./data-test

# New broker SSL unit tests
python -m pytest tests/unit/test_celery_broker_ssl.py -q
python -m pytest tests/unit/test_app.py -q
python -m pytest tests/unit/ -q
```