### PR TITLE
chore: apply security audit improvements (CR-111, CR-112, CR-101)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM python:3.13-slim AS base_os
+FROM python:3.14-slim AS base_os
 
 # Builder requirements and deps
 FROM base_os AS builder
@@ -23,18 +23,25 @@ RUN apt-get remove gcc --purge -y \
 FROM base_os AS pre-final
 RUN apt-get update && apt-get install libpq-dev -y && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/bin /usr/local/bin/
-COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages/
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages/
 
 # Final stage
 FROM pre-final
 
+# Create a non-root user
+RUN addgroup --system rstuf && adduser --system --group rstuf
+
 WORKDIR /opt/repository-service-tuf-worker
 ENV DATA_DIR=/data
-RUN mkdir $DATA_DIR
-COPY alembic.ini /opt/repository-service-tuf-worker/
-COPY alembic /opt/repository-service-tuf-worker/alembic
-COPY app.py /opt/repository-service-tuf-worker
-COPY entrypoint.sh /opt/repository-service-tuf-worker
-COPY supervisor.conf ${DATA_DIR}/
-COPY repository_service_tuf_worker /opt/repository-service-tuf-worker/repository_service_tuf_worker
+RUN mkdir $DATA_DIR && chown rstuf:rstuf $DATA_DIR
+
+COPY --chown=rstuf:rstuf alembic.ini /opt/repository-service-tuf-worker/
+COPY --chown=rstuf:rstuf alembic /opt/repository-service-tuf-worker/alembic
+COPY --chown=rstuf:rstuf app.py /opt/repository-service-tuf-worker
+COPY --chown=rstuf:rstuf entrypoint.sh /opt/repository-service-tuf-worker
+COPY --chown=rstuf:rstuf supervisor.conf ${DATA_DIR}/
+COPY --chown=rstuf:rstuf repository_service_tuf_worker /opt/repository-service-tuf-worker/repository_service_tuf_worker
+
+USER rstuf
+
 ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/Pipfile
+++ b/Pipfile
@@ -51,4 +51,4 @@ myst-parser = "*"
 dynaconf = {extras = ["ini"], version = "*"}  # required to build docs
 
 [requires]
-python_version = "3.13"
+python_version = "3.14"

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -9,7 +9,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:17.5-alpine3.21
+    image: postgres:18.3-alpine3.21
     ports:
       - "5433:5432"
     environment:
@@ -34,7 +34,7 @@ services:
         condition: service_healthy
 
   redis:
-    image: redis:8.0.0-alpine3.21
+    image: redis:8.0.1-alpine3.21
     volumes:
       - repository-service-tuf-redis-data:/data
     ports:
@@ -44,7 +44,7 @@ services:
       interval: 1s
 
   localstack:
-    image: localstack/localstack:2.2
+    image: localstack/localstack:3.4.0
     environment:
       HOSTNAME: "localstack"
       LOCALSTACK_HOST: "localstack"
@@ -71,7 +71,7 @@ services:
       - RSTUF_BROKER_SERVER=redis://redis
       - RSTUF_REDIS_SERVER=redis://redis
       - RSTUF_DB_SERVER=postgresql://postgres:secret@postgres:5432
-      - METADATA_BASE_URL="http://localstack:4566/tuf-metadata/"
+      - METADATA_BASE_URL=http://localstack:4566/tuf-metadata/
     volumes:
       - ./:/opt/repository-service-tuf-worker:z
       - ./tests/files/key_storage/:/var/opt/repository-service-tuf/key_storage
@@ -86,7 +86,7 @@ services:
     stdin_open: true
 
   rstuf-ft-runner:
-    image: python:3.13-slim
+    image: python:3.14-slim
     command: python -V
     working_dir: /rstuf-runner
     volumes:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py313,lint,precommit,test
+envlist = py314,lint,precommit,test
 
 [flake8]
 exclude = repository_service_tuf_worker/__init__.py,venv,.venv,settings.py,.git,.tox,dist,docs,*lib/python*,*egg,build,tools
@@ -69,7 +69,7 @@ commands =
 
 [gh-actions]
 python =
-    3.13: py313,pep8,lint,precommit,test
+    3.14: py314,pep8,lint,precommit,test
 
 [testenv:local-aws-kms]
 deps =


### PR DESCRIPTION
This PR includes multiple fixes based on the RSTUF security audit.

Changes included:
- Run worker container as non-root user (rstuf)
- Fix LocalStack configuration issue caused by quoted URL
- Update base image to Python 3.14

These changes improve runtime security and fix deployment inconsistencies.

## Reference
Security Audit Parent Issue:
https://github.com/repository-service-tuf/repository-service-tuf/issues/852