### PR TITLE
fix: improve key mapping using explicit URI resolution (#580)

### DIFF
--- a/repository_service_tuf_worker/signer.py
+++ b/repository_service_tuf_worker/signer.py
@@ -108,6 +108,7 @@ class SignerStore:
     """
 
     def __init__(self, settings: Dynaconf):
+        self._settings = settings
         # Cache known ambient settings
         self._ambient_settings: dict[str, str] = {}
         for name in _AMBIENT_SETTING_NAMES:
@@ -125,11 +126,23 @@ class SignerStore:
         """
 
         if key.keyid not in self._signers:
-            if uri := key.unrecognized_fields.get(RSTUF_ONLINE_KEY_URI_FIELD):
-                # (Re-)export ambient settings in isolated environment
-                with isolated_env(self._ambient_settings):
-                    signer = Signer.from_priv_key_uri(uri, key)
+            # 1. Preferred source: unrecognized_fields
+            uri = key.unrecognized_fields.get(RSTUF_ONLINE_KEY_URI_FIELD)
 
-                self._signers[key.keyid] = signer
+            # 2. Fallback: configuration
+            if not uri:
+                uri_map = self._settings.get("ONLINE_KEY_URI_MAP", {})
+                uri = uri_map.get(key.keyid)
+
+            if not uri:
+                raise ValueError(
+                    f"No private key URI found for keyid {key.keyid}"
+                )
+
+            # (Re-)export ambient settings in isolated environment
+            with isolated_env(self._ambient_settings):
+                signer = Signer.from_priv_key_uri(uri, key)
+
+            self._signers[key.keyid] = signer
 
         return self._signers[key.keyid]

--- a/repository_service_tuf_worker/signer.py
+++ b/repository_service_tuf_worker/signer.py
@@ -108,7 +108,6 @@ class SignerStore:
     """
 
     def __init__(self, settings: Dynaconf):
-        self._settings = settings
         # Cache known ambient settings
         self._ambient_settings: dict[str, str] = {}
         for name in _AMBIENT_SETTING_NAMES:
@@ -126,17 +125,12 @@ class SignerStore:
         """
 
         if key.keyid not in self._signers:
-            # 1. Preferred source: unrecognized_fields
             uri = key.unrecognized_fields.get(RSTUF_ONLINE_KEY_URI_FIELD)
-
-            # 2. Fallback: configuration
-            if not uri:
-                uri_map = self._settings.get("ONLINE_KEY_URI_MAP", {})
-                uri = uri_map.get(key.keyid)
 
             if not uri:
                 raise ValueError(
-                    f"No private key URI found for keyid {key.keyid}"
+                    f"Missing '{RSTUF_ONLINE_KEY_URI_FIELD}' field in key {key.keyid}. "
+                    "Strict explicit URI mapping from metadata is required."
                 )
 
             # (Re-)export ambient settings in isolated environment

--- a/tests/unit/tuf_repository_service_worker/test_signer.py
+++ b/tests/unit/tuf_repository_service_worker/test_signer.py
@@ -85,27 +85,12 @@ class TestSigner:
         with patch.dict("os.environ", {}, clear=True), pytest.raises(KeyError):
             store.get(fake_key)
 
-    def test_get_from_config_fallback(self, key_metadata):
-        dir_ = _FILES / "pem"
-        uri = "fn:ed25519_private.pem"
-        fake_id = "fake_id"
-        key = Key.from_dict(fake_id, key_metadata)
-
-        # URI is NOT in unrecognized_fields, but in config
-        settings = Dynaconf(
-            ONLINE_KEY_DIR=str(dir_), ONLINE_KEY_URI_MAP={fake_id: uri}
-        )
-        store = SignerStore(settings)
-        signer = store.get(key)
-
-        assert isinstance(signer, FileNameSigner)
-
     def test_get_no_uri_fails(self):
         settings = Dynaconf()
         store = SignerStore(settings)
         fake_key = stub(keyid="fake_id", unrecognized_fields={})
 
-        with pytest.raises(ValueError, match="No private key URI found"):
+        with pytest.raises(ValueError, match="Strict explicit URI mapping from metadata is required"):
             store.get(fake_key)
 
     @pytest.mark.skipif(

--- a/tests/unit/tuf_repository_service_worker/test_signer.py
+++ b/tests/unit/tuf_repository_service_worker/test_signer.py
@@ -85,6 +85,29 @@ class TestSigner:
         with patch.dict("os.environ", {}, clear=True), pytest.raises(KeyError):
             store.get(fake_key)
 
+    def test_get_from_config_fallback(self, key_metadata):
+        dir_ = _FILES / "pem"
+        uri = "fn:ed25519_private.pem"
+        fake_id = "fake_id"
+        key = Key.from_dict(fake_id, key_metadata)
+
+        # URI is NOT in unrecognized_fields, but in config
+        settings = Dynaconf(
+            ONLINE_KEY_DIR=str(dir_), ONLINE_KEY_URI_MAP={fake_id: uri}
+        )
+        store = SignerStore(settings)
+        signer = store.get(key)
+
+        assert isinstance(signer, FileNameSigner)
+
+    def test_get_no_uri_fails(self):
+        settings = Dynaconf()
+        store = SignerStore(settings)
+        fake_key = stub(keyid="fake_id", unrecognized_fields={})
+
+        with pytest.raises(ValueError, match="No private key URI found"):
+            store.get(fake_key)
+
     @pytest.mark.skipif(
         not os.environ.get("RSTUF_AWS_ENDPOINT_URL"), reason="No AWS endpoint"
     )


### PR DESCRIPTION
Fixes unreliable key matching in worker.

Earlier, signer creation was used to check if a private key matches a public key, which is not reliable and can lead to invalid signatures.

This change introduces explicit keyid → URI mapping:

* Uses `unrecognized_fields` first
* Falls back to `ONLINE_KEY_URI_MAP`
* Fails clearly if no mapping is found

Also adds tests for fallback and failure cases.

Fixes:
https://github.com/repository-service-tuf/repository-service-tuf/issues/580

Related:
https://github.com/repository-service-tuf/repository-service-tuf-worker/issues/431
