### PR TITLE
fix: roll back partial metadata when bootstrap finalize fails

### DIFF
--- a/repository_service_tuf_worker/interfaces.py
+++ b/repository_service_tuf_worker/interfaces.py
@@ -65,6 +65,11 @@ class IStorage(ABC):
         """
         raise NotImplementedError  # pragma: no cover
 
+    @abstractmethod
+    def delete(self, filename: str) -> None:
+        """Delete a file by filename. Missing files are not an error."""
+        raise NotImplementedError  # pragma: no cover
+
 
 def _setup_service_dynaconf(cls: Any, backend: Any, settings: Dynaconf):
     """

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -140,6 +140,7 @@ class MetadataRepository:
         self._expire_timedelta = timedelta(hours=self._hours_before_expire)
         self._timeout = int(app_settings.get("LOCK_TIMEOUT", 500.0))
         self._uses_succinct_roles: Optional[bool] = None
+        self._persist_tracking: Optional[List[str]] = None
 
     @property
     def _settings(self) -> Dynaconf:
@@ -329,6 +330,8 @@ class MetadataRepository:
 
         bytes_data = role.to_bytes(JSONSerializer())
         self._storage_backend.put(bytes_data, filename)
+        if self._persist_tracking is not None:
+            self._persist_tracking.append(filename)
         return filename
 
     def _is_expired(self, role: str) -> Optional[str]:
@@ -1427,7 +1430,29 @@ class MetadataRepository:
 
         signed = self._validate_threshold(root)
         if signed:
-            self._bootstrap_finalize(root, task_id)
+            self._persist_tracking = []
+            try:
+                self._bootstrap_finalize(root, task_id)
+            except Exception as e:
+                logging.error(f"Bootstrap finalize failed ({e}); rolling back")
+                for partial in self._persist_tracking:
+                    try:
+                        self._storage_backend.delete(partial)
+                    except Exception as cleanup_err:
+                        logging.error(
+                            f"Could not delete '{partial}' during "
+                            f"rollback: {cleanup_err}"
+                        )
+                self.write_repository_settings("BOOTSTRAP", None)
+                self.write_repository_settings("ROOT_SIGNING", None)
+                return self._task_result(
+                    task=TaskName.BOOTSTRAP,
+                    message="Bootstrap Failed",
+                    error=f"Bootstrap finalize failed: {e}",
+                    details=None,
+                )
+            finally:
+                self._persist_tracking = None
             message = f"Bootstrap finished {task_id}"
             logging.info(message)
         else:
@@ -2418,7 +2443,24 @@ class MetadataRepository:
                 return _result(True, bootstrap=msg)
 
             bootstrap_task_id = bootstrap_state.split("signing-")[1]
-            self._bootstrap_finalize(metadata, bootstrap_task_id)
+            self._persist_tracking = []
+            try:
+                self._bootstrap_finalize(metadata, bootstrap_task_id)
+            except Exception as e:
+                logging.error(f"Bootstrap finalize failed ({e}); rolling back")
+                for partial in self._persist_tracking:
+                    try:
+                        self._storage_backend.delete(partial)
+                    except Exception as cleanup_err:
+                        logging.error(
+                            f"Could not delete '{partial}' during "
+                            f"rollback: {cleanup_err}"
+                        )
+                self.write_repository_settings("BOOTSTRAP", None)
+                self.write_repository_settings("ROOT_SIGNING", None)
+                return _result(False, error=f"Bootstrap finalize failed: {e}")
+            finally:
+                self._persist_tracking = None
             return _result(True, bootstrap="Bootstrap Finished")
 
         elif metadata.signed.type == Root.type:

--- a/repository_service_tuf_worker/services/storage/awss3.py
+++ b/repository_service_tuf_worker/services/storage/awss3.py
@@ -172,3 +172,10 @@ class AWSS3(IStorage):
             )
         except ClientError:
             raise StorageError(f"Can't write role file '{filename}'")
+
+    def delete(self, filename: str) -> None:
+        """Remove an object from the TUF S3 bucket."""
+        try:
+            self._s3_client.delete_object(Bucket=self._bucket, Key=filename)
+        except ClientError:
+            raise StorageError(f"Can't delete role file '{filename}'")

--- a/repository_service_tuf_worker/services/storage/local.py
+++ b/repository_service_tuf_worker/services/storage/local.py
@@ -92,3 +92,13 @@ class LocalStorage(IStorage):
                 os.fsync(destination_file.fileno())
         except OSError:
             raise StorageError(f"Can't write role file '{filename}'")
+
+    def delete(self, filename: str) -> None:
+        """Remove a file from the TUF repo path. Missing files are ignored."""
+        filepath = os.path.join(self._path, filename)
+        try:
+            os.remove(filepath)
+        except FileNotFoundError:
+            return
+        except OSError:
+            raise StorageError(f"Can't delete role file '{filepath}'")

--- a/tests/unit/tuf_repository_service_worker/services/storage/conftest.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/conftest.py
@@ -9,7 +9,8 @@ def mocked_boto3(monkeypatch):
         buckets=pretend.stub(all=pretend.call_recorder(lambda: [fake_bucket]))
     )
     fake_client = pretend.stub(
-        put_object=pretend.call_recorder(lambda **kw: None)
+        put_object=pretend.call_recorder(lambda **kw: None),
+        delete_object=pretend.call_recorder(lambda **kw: None),
     )
     fake_Session = pretend.stub(
         client=pretend.call_recorder(lambda *a, **kw: fake_client),

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
@@ -438,3 +438,36 @@ class TestAWSS3Service:
             service.put(fake_file_data, "3.bin-e.json")
 
         assert "Can't write role file '3.bin-e.json'" in str(err)
+
+    def test_delete(self, mocked_boto3):
+        test_settings = pretend.stub(
+            get=pretend.call_recorder(lambda *a: None),
+            AWS_STORAGE_BUCKET="bucket",
+            AWS_ACCESS_KEY_ID="access_key",
+            AWS_SECRET_ACCESS_KEY="secret_key",
+        )
+        service = awss3.AWSS3.configure(test_settings)
+
+        result = service.delete("3.bin-e.json")
+
+        assert result is None
+        assert service._s3_client.delete_object.calls == [
+            pretend.call(Bucket=service._bucket, Key="3.bin-e.json")
+        ]
+
+    def test_delete_ClientError(self, mocked_boto3):
+        test_settings = pretend.stub(
+            get=pretend.call_recorder(lambda *a: None),
+            AWS_STORAGE_BUCKET="bucket",
+            AWS_ACCESS_KEY_ID="access_key",
+            AWS_SECRET_ACCESS_KEY="secret_key",
+        )
+        service = awss3.AWSS3.configure(test_settings)
+        service._s3_client.delete_object = pretend.raiser(
+            awss3.ClientError({}, "delete_object")
+        )
+
+        with pytest.raises(awss3.StorageError) as err:
+            service.delete("3.bin-e.json")
+
+        assert "Can't delete role file '3.bin-e.json'" in str(err)

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_local.py
@@ -249,3 +249,56 @@ class TestLocalStorageService:
         assert fake_os.path.join.calls == [
             pretend.call(service._path, "3.bin-e.json"),
         ]
+
+    def test_delete(self, monkeypatch):
+        service = local.LocalStorage("/path")
+        fake_os = pretend.stub(
+            path=pretend.stub(
+                join=pretend.call_recorder(
+                    lambda *a, **kw: "/path/3.bin-e.json"
+                )
+            ),
+            remove=pretend.call_recorder(lambda *a: None),
+        )
+        monkeypatch.setattr(f"{MOCK_PATH}.os", fake_os)
+
+        result = service.delete("3.bin-e.json")
+
+        assert result is None
+        assert fake_os.path.join.calls == [
+            pretend.call(service._path, "3.bin-e.json"),
+        ]
+        assert fake_os.remove.calls == [pretend.call("/path/3.bin-e.json")]
+
+    def test_delete_FileNotFoundError(self, monkeypatch):
+        service = local.LocalStorage("/path")
+        fake_os = pretend.stub(
+            path=pretend.stub(
+                join=pretend.call_recorder(
+                    lambda *a, **kw: "/path/missing.json"
+                )
+            ),
+            remove=pretend.raiser(FileNotFoundError("no such file")),
+        )
+        monkeypatch.setattr(f"{MOCK_PATH}.os", fake_os)
+
+        result = service.delete("missing.json")
+
+        assert result is None
+
+    def test_delete_OSError(self, monkeypatch):
+        service = local.LocalStorage("/path")
+        fake_os = pretend.stub(
+            path=pretend.stub(
+                join=pretend.call_recorder(
+                    lambda *a, **kw: "/path/3.bin-e.json"
+                )
+            ),
+            remove=pretend.raiser(PermissionError("denied")),
+        )
+        monkeypatch.setattr(f"{MOCK_PATH}.os", fake_os)
+
+        with pytest.raises(local.StorageError) as err:
+            service.delete("3.bin-e.json")
+
+        assert "Can't delete role file '/path/3.bin-e.json'" in str(err)

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -1289,6 +1289,148 @@ class TestMetadataRepository:
             pretend.call(fake_root_md, payload["task_id"])
         ]
 
+    def test_bootstrap_rolls_back_on_finalize_failure(
+        self, monkeypatch, test_repo, mocked_datetime
+    ):
+        fake_settings = pretend.stub(
+            get_fresh=pretend.call_recorder(lambda *a: "pre-<task-id>")
+        )
+        monkeypatch.setattr(
+            repository,
+            "get_repository_settings",
+            lambda *a, **kw: fake_settings,
+        )
+        fake_root_md = pretend.stub(
+            signatures={"keyid1": "sig1"},
+            signed=pretend.stub(
+                type="root",
+                roles={
+                    "root": pretend.stub(keyids=["keyid1"], threshold=1),
+                    "timestamp": pretend.stub(
+                        keyids=["online_key_id"], threshold=1
+                    ),
+                },
+                keys={"online_key_id": "online_public_key"},
+            ),
+        )
+        repository.Metadata.from_dict = pretend.call_recorder(
+            lambda *a: fake_root_md
+        )
+        test_repo._validate_signature = pretend.call_recorder(lambda *a: True)
+        test_repo._validate_threshold = pretend.call_recorder(lambda *a: True)
+        test_repo.save_settings = pretend.call_recorder(lambda *a: None)
+        test_repo.write_repository_settings = pretend.call_recorder(
+            lambda *a: None
+        )
+        test_repo._storage_backend = pretend.stub(
+            delete=pretend.call_recorder(lambda *a: None)
+        )
+
+        def fake_finalize(root, task_id):
+            test_repo._persist_tracking.append("1.targets.json")
+            test_repo._persist_tracking.append("timestamp.json")
+            raise OSError("Permission Denied")
+
+        test_repo._bootstrap_finalize = fake_finalize
+
+        payload = {
+            "settings": {
+                "roles": {
+                    "root": {"expiration": 365},
+                    "targets": {"expiration": 365},
+                    "snapshot": {"expiration": 1},
+                    "timestamp": {"expiration": 1},
+                    "bins": {"expiration": 30, "number_of_delegated_bins": 4},
+                }
+            },
+            "metadata": {"root": {"md_k1": "md_v1"}},
+            "task_id": "fake_task_id",
+        }
+
+        result = test_repo.bootstrap(payload)
+
+        assert result["status"] is False
+        assert result["message"] == "Bootstrap Failed"
+        assert "Permission Denied" in result["error"]
+        assert test_repo._storage_backend.delete.calls == [
+            pretend.call("1.targets.json"),
+            pretend.call("timestamp.json"),
+        ]
+        # System must not stay locked after a failed bootstrap.
+        assert (
+            pretend.call("BOOTSTRAP", None)
+            in test_repo.write_repository_settings.calls
+        )
+        assert (
+            pretend.call("ROOT_SIGNING", None)
+            in test_repo.write_repository_settings.calls
+        )
+        assert test_repo._persist_tracking is None
+
+    def test_bootstrap_rollback_survives_delete_errors(
+        self, monkeypatch, test_repo, mocked_datetime
+    ):
+        fake_settings = pretend.stub(
+            get_fresh=pretend.call_recorder(lambda *a: "pre-<task-id>")
+        )
+        monkeypatch.setattr(
+            repository,
+            "get_repository_settings",
+            lambda *a, **kw: fake_settings,
+        )
+        fake_root_md = pretend.stub(
+            signatures={"keyid1": "sig1"},
+            signed=pretend.stub(
+                type="root",
+                roles={
+                    "root": pretend.stub(keyids=["keyid1"], threshold=1),
+                    "timestamp": pretend.stub(
+                        keyids=["online_key_id"], threshold=1
+                    ),
+                },
+                keys={"online_key_id": "online_public_key"},
+            ),
+        )
+        repository.Metadata.from_dict = pretend.call_recorder(
+            lambda *a: fake_root_md
+        )
+        test_repo._validate_signature = pretend.call_recorder(lambda *a: True)
+        test_repo._validate_threshold = pretend.call_recorder(lambda *a: True)
+        test_repo.save_settings = pretend.call_recorder(lambda *a: None)
+        test_repo.write_repository_settings = pretend.call_recorder(
+            lambda *a: None
+        )
+
+        # First delete raises; rollback must keep going so we still try the
+        # second file and don't strand the system in a locked state.
+        delete_calls = []
+
+        def flaky_delete(name):
+            delete_calls.append(name)
+            if name == "1.targets.json":
+                raise OSError("storage went away")
+
+        test_repo._storage_backend = pretend.stub(delete=flaky_delete)
+
+        def fake_finalize(root, task_id):
+            test_repo._persist_tracking.append("1.targets.json")
+            test_repo._persist_tracking.append("timestamp.json")
+            raise RuntimeError("boom")
+
+        test_repo._bootstrap_finalize = fake_finalize
+
+        payload = {
+            "settings": {"roles": {}},
+            "metadata": {"root": {"md_k1": "md_v1"}},
+            "task_id": "fake_task_id",
+        }
+
+        result = test_repo.bootstrap(payload)
+
+        assert delete_calls == ["1.targets.json", "timestamp.json"]
+        assert result["status"] is False
+        assert "boom" in result["error"]
+
     def test_bootstrap_no_signatures(
         self, monkeypatch, test_repo, mocked_datetime
     ):


### PR DESCRIPTION
## What is the PR about?                                                                                                              

If `_bootstrap_finalize` throws an exception after already writing some files,                                                        
those files stay on disk. The next bootstrap attempt then fails on stale data,
and the system stays locked because `BOOTSTRAP` never got reset to `None`.                                                            

The fix adds a `delete()` method to `IStorage` (and both backends) so the                                                             
bootstrap paths can clean up after themselves. Any files written before the
failure get deleted on the way out. If a delete fails it's logged and we move                                                         
on, better to leave one file than to stop and leave everything. Either way,                                                          
`BOOTSTRAP` and `ROOT_SIGNING` are reset so a retry works without manual                                                              
intervention.                                                                                                                                                                                                                                                  

Closes #248                                                                                                                           
Relates to repository-service-tuf-api#181

Tests have been added for the bug fix.
