### PR TITLE
Validate keys type and algorithm

### DIFF
--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -26,7 +26,9 @@ from securesystemslib.signer import (
     Signature,
     Signer,
     SigstoreKey,
+    SSlibKey
 )
+
 from tuf.api.exceptions import (
     BadVersionNumberError,
     RepositoryError,
@@ -62,9 +64,11 @@ from repository_service_tuf_worker.models import (
 )
 from repository_service_tuf_worker.signer import SignerStore
 
+KEY_FOR_TYPE_AND_SCHEME.clear()
 KEY_FOR_TYPE_AND_SCHEME.update(
     {
         ("sigstore-oidc", "Fulcio"): SigstoreKey,
+        ("ed25519", "ed25519"): SSlibKey,  
     }
 )
 
@@ -1346,7 +1350,8 @@ class MetadataRepository:
         # All roles except root share the same one key and it doesn't matter
         # from which role we will get the key.
         keyid: str = root.signed.roles["timestamp"].keyids[0]
-        self._online_key = root.signed.keys[keyid]
+        key_obj = root.signed.keys[keyid]
+        self._online_key = Key.from_dict(keyid, key_obj.to_dict())
         self._bootstrap_online_roles(delegations=delegations)
         self.write_repository_settings("ROOT_SIGNING", None)
         self._persist(root, Root.type)


### PR DESCRIPTION
What is the PR about?
This PR implements Validate keys type and algorithm as described in issue https://github.com/repository-service-tuf/repository-service-tuf-worker/issues/202.

Changes:

import the securesystemslib [KEY_FOR_TYPE_AND_SCHEME](https://github.com/secure-systems-lab/securesystemslib/blob/34e50cb059ea630e7a808dca7c1744b20f2d8ce4/securesystemslib/signer/__init__.py#L30) dict
Update the KEY_FOR_TYPE_AND_SCHEME by clearing its content with dict.clear() and instead adding our supported algorithms
During the bootstrap ceremony when loading the public keys stored in root.signed.keys we should do it with the [Key.from_dict](https://github.com/secure-systems-lab/securesystemslib/blob/34e50cb059ea630e7a808dca7c1744b20f2d8ce4/securesystemslib/signer/_key.py#L74) API call to use the validation inside securesystemslib.