### PR TITLE
Eliminate S3 list_objects overhead via version cache and pre-warmup

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,6 +5,9 @@ Contributing to Repository Service for TUF WORKER
 We welcome contributions from the community and first want to thank you for
 taking the time to contribute!
 
+If you would like to work on an open issue, please first comment on the issue.  
+This helps us to ensure there are not multiple people working on the same issue.
+
 Please familiarize yourself with the `Code of Conduct`_
 before contributing.
 

--- a/repository_service_tuf_worker/services/storage/awss3.py
+++ b/repository_service_tuf_worker/services/storage/awss3.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import logging
-import time
 from io import BytesIO
 from typing import Any, Dict, List, Optional
 
@@ -24,33 +22,11 @@ from repository_service_tuf_worker.interfaces import (
 
 
 class AWSS3(IStorage):
-    # In-process version cache: role_name -> latest known version number.
-    #
-    # AWSS3.get() needs to resolve the latest version of a role before it can
-    # fetch it from S3.  The original implementation called
-    # awswrangler.s3.list_objects(path="s3://bucket/*.{role}.json") on every
-    # call, which cannot use an S3 key-prefix scan and instead lists all
-    # objects in the bucket client-side.  At ~5 000+ objects that took 2.5–4 s
-    # per call; with 9+ calls per task it dominated task latency (~27 s of
-    # ~33 s total).
-    #
-    # The fix has two parts:
-    #
-    # 1. Pre-warmup (_prewarm_version_cache): called once per worker process
-    #    from configure() at startup.  Lists the entire bucket a single time,
-    #    parses every "N.rolename.json" filename, and stores the max version
-    #    seen for each role.  This runs before the first task arrives so there
-    #    is no cold-start penalty.
-    #
-    # 2. Cache maintenance: get() reads from the cache (skipping list_objects
-    #    entirely after warmup); put() updates the cache after every write so
-    #    the next get() fetches the correct version key directly.
-    #
-    # The cache is per-worker-process.  Celery ForkPoolWorkers each get their
-    # own copy after fork, independently pre-warmed.  A worker restart triggers
-    # a fresh prewarm (~4 s) before accepting tasks.
+    # Per-process version cache. Keys are role names, values are the
+    # highest version this process has seen. Acts as a lower bound: the
+    # real latest is always >= the cached value because a process only
+    # learns versions it wrote or explicitly probed.
     _version_cache: Dict[str, int] = {}
-    _cache_warmed: bool = False
 
     def __init__(
         self,
@@ -103,7 +79,7 @@ class AWSS3(IStorage):
             endpoint_url=endpoint,
         )
 
-        instance = cls(
+        return cls(
             bucket_name,
             s3_session,
             s3_client,
@@ -112,8 +88,6 @@ class AWSS3(IStorage):
             region,
             endpoint,
         )
-        cls._prewarm_version_cache(bucket_name, s3_session)
-        return instance
 
     @classmethod
     def settings(cls) -> List[ServiceSettings]:
@@ -144,50 +118,59 @@ class AWSS3(IStorage):
             ),
         ]
 
-    @classmethod
-    def _prewarm_version_cache(
-        cls, bucket: str, s3_session: boto3.Session
-    ) -> None:
-        """
-        Populate _version_cache with a single list_objects call at worker
-        startup.  Scans all objects in the bucket once, parses every
-        "N.rolename.json" filename, and records the highest version seen for
-        each role.  Subsequent get() calls skip list_objects entirely.
+    def _scan_latest_version(self, role: str) -> int:
+        """Full bucket scan to find the highest version for a role.
 
-        Guarded by _cache_warmed so it runs at most once per worker process
-        even if configure() is called multiple times.
+        This is the original list_objects path and is expensive at scale
+        (scans every object in the bucket client-side). It is used only
+        when the version cache has no entry for the role.
         """
-        if cls._cache_warmed:
-            return
-        t0 = time.perf_counter()
-        try:
-            all_keys = awswrangler.s3.list_objects(
-                path=f"s3://{bucket}/",
-                boto3_session=s3_session,
-            )
-        except Exception as e:
-            logging.warning("S3 version cache prewarm failed, skipping: %s", e)
-            return
-        prefix = f"s3://{bucket}/"
-        for s3_uri in all_keys:
-            filename = s3_uri[len(prefix):]
-            parts = filename.split(".", 1)
-            if (
-                len(parts) == 2
-                and parts[0].isdigit()
-                and filename.endswith(".json")
-            ):
-                role_name = parts[1][:-5]  # strip ".json"
-                version = int(parts[0])
-                if version > cls._version_cache.get(role_name, 0):
-                    cls._version_cache[role_name] = version
-        cls._cache_warmed = True
-        logging.info(
-            "S3 version cache warmed: %d roles, %d objects scanned (%.2fs)",
-            len(cls._version_cache),
-            len(all_keys),
-            time.perf_counter() - t0,
+        s3_path = f"s3://{self._bucket}/"
+        filenames = awswrangler.s3.list_objects(
+            path=f"{s3_path}*.{role}.json",
+            boto3_session=self._s3_session,
         )
+        versions = [
+            int(name.split(s3_path)[-1].split(".", 1)[0]) for name in filenames
+        ]
+        try:
+            return max(versions)
+        except ValueError:
+            return 1  # no existing file -> start at 1
+
+    def _latest_version(self, role: str) -> int:
+        """Return the latest version number for a role, self-healing across
+        processes.
+
+        The cached value is a lower bound: a process only ever learns versions
+        it wrote or listed, so its cache is always <= the real latest.
+
+        After obtaining the hint (from cache or a full scan), we probe upward
+        one step at a time using cheap head_object calls. TUF versions are
+        strictly contiguous (n -> n+1), so the loop terminates after at most
+        one probe in the steady state (when this process is the sole writer)
+        or a few probes when another process has advanced the version.
+        """
+        version = AWSS3._version_cache.get(role)
+        if version is None:
+            # Cache miss: fall back to the full bucket scan once.
+            version = self._scan_latest_version(role)
+
+        # Self-heal across processes: probe upward until the next key is
+        # absent. Because TUF versions are contiguous this converges quickly
+        # even when another Celery worker has already written ahead.
+        client = self._s3_client
+        while True:
+            try:
+                client.head_object(
+                    Bucket=self._bucket, Key=f"{version + 1}.{role}.json"
+                )
+                version += 1
+            except ClientError:
+                break
+
+        AWSS3._version_cache[role] = version
+        return version
 
     def get(self, role: str, version: Optional[int] = None) -> Metadata[T]:
         """
@@ -201,26 +184,7 @@ class AWSS3(IStorage):
             filename = f"{role}.json"
         else:
             if version is None:
-                cached_version = AWSS3._version_cache.get(role)
-                if cached_version is not None:
-                    version = cached_version
-                else:
-                    # Cache miss (role not yet seen by this worker process).
-                    # Scan the bucket once for this role and cache the result.
-                    s3_path = f"s3://{self._bucket}/"
-                    filenames = awswrangler.s3.list_objects(
-                        path=f"{s3_path}*.{role}.json",
-                        boto3_session=self._s3_session,
-                    )
-                    versions = [
-                        int(name.split(s3_path)[-1].split(".", 1)[0])
-                        for name in filenames
-                    ]
-                    try:
-                        version = max(versions)
-                    except ValueError:
-                        version = 1
-                    AWSS3._version_cache[role] = version
+                version = self._latest_version(role)
 
             filename = f"{version}.{role}.json"
 
@@ -257,11 +221,13 @@ class AWSS3(IStorage):
         except ClientError:
             raise StorageError(f"Can't write role file '{filename}'")
 
-        # Keep the version cache consistent: after writing "N.rolename.json",
-        # record N so the next get() for this role fetches it directly without
-        # calling list_objects.  Timestamp uses a fixed key ("timestamp.json")
-        # and is not version-tracked in the cache.
+        # Keep the version cache current so subsequent _latest_version calls
+        # skip the upward probe for this role. filename format: "N.role.json"
+        # Timestamp is the only role stored without a version prefix; skip it.
         parts = filename.split(".", 1)
-        if parts[0].isdigit():
-            role_name = parts[1][:-5]  # strip ".json"
-            AWSS3._version_cache[role_name] = int(parts[0])
+        if len(parts) == 2 and parts[0].isdigit():
+            role = parts[1].removesuffix(".json")
+            written_version = int(parts[0])
+            current = AWSS3._version_cache.get(role, 0)
+            if written_version > current:
+                AWSS3._version_cache[role] = written_version

--- a/repository_service_tuf_worker/services/storage/awss3.py
+++ b/repository_service_tuf_worker/services/storage/awss3.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: MIT
 
+import logging
+import time
 from io import BytesIO
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 import awswrangler
 import boto3
@@ -22,6 +24,34 @@ from repository_service_tuf_worker.interfaces import (
 
 
 class AWSS3(IStorage):
+    # In-process version cache: role_name -> latest known version number.
+    #
+    # AWSS3.get() needs to resolve the latest version of a role before it can
+    # fetch it from S3.  The original implementation called
+    # awswrangler.s3.list_objects(path="s3://bucket/*.{role}.json") on every
+    # call, which cannot use an S3 key-prefix scan and instead lists all
+    # objects in the bucket client-side.  At ~5 000+ objects that took 2.5–4 s
+    # per call; with 9+ calls per task it dominated task latency (~27 s of
+    # ~33 s total).
+    #
+    # The fix has two parts:
+    #
+    # 1. Pre-warmup (_prewarm_version_cache): called once per worker process
+    #    from configure() at startup.  Lists the entire bucket a single time,
+    #    parses every "N.rolename.json" filename, and stores the max version
+    #    seen for each role.  This runs before the first task arrives so there
+    #    is no cold-start penalty.
+    #
+    # 2. Cache maintenance: get() reads from the cache (skipping list_objects
+    #    entirely after warmup); put() updates the cache after every write so
+    #    the next get() fetches the correct version key directly.
+    #
+    # The cache is per-worker-process.  Celery ForkPoolWorkers each get their
+    # own copy after fork, independently pre-warmed.  A worker restart triggers
+    # a fresh prewarm (~4 s) before accepting tasks.
+    _version_cache: Dict[str, int] = {}
+    _cache_warmed: bool = False
+
     def __init__(
         self,
         bucket: str,
@@ -73,7 +103,7 @@ class AWSS3(IStorage):
             endpoint_url=endpoint,
         )
 
-        return cls(
+        instance = cls(
             bucket_name,
             s3_session,
             s3_client,
@@ -82,6 +112,8 @@ class AWSS3(IStorage):
             region,
             endpoint,
         )
+        cls._prewarm_version_cache(bucket_name, s3_session)
+        return instance
 
     @classmethod
     def settings(cls) -> List[ServiceSettings]:
@@ -112,6 +144,51 @@ class AWSS3(IStorage):
             ),
         ]
 
+    @classmethod
+    def _prewarm_version_cache(
+        cls, bucket: str, s3_session: boto3.Session
+    ) -> None:
+        """
+        Populate _version_cache with a single list_objects call at worker
+        startup.  Scans all objects in the bucket once, parses every
+        "N.rolename.json" filename, and records the highest version seen for
+        each role.  Subsequent get() calls skip list_objects entirely.
+
+        Guarded by _cache_warmed so it runs at most once per worker process
+        even if configure() is called multiple times.
+        """
+        if cls._cache_warmed:
+            return
+        t0 = time.perf_counter()
+        try:
+            all_keys = awswrangler.s3.list_objects(
+                path=f"s3://{bucket}/",
+                boto3_session=s3_session,
+            )
+        except Exception as e:
+            logging.warning("S3 version cache prewarm failed, skipping: %s", e)
+            return
+        prefix = f"s3://{bucket}/"
+        for s3_uri in all_keys:
+            filename = s3_uri[len(prefix):]
+            parts = filename.split(".", 1)
+            if (
+                len(parts) == 2
+                and parts[0].isdigit()
+                and filename.endswith(".json")
+            ):
+                role_name = parts[1][:-5]  # strip ".json"
+                version = int(parts[0])
+                if version > cls._version_cache.get(role_name, 0):
+                    cls._version_cache[role_name] = version
+        cls._cache_warmed = True
+        logging.info(
+            "S3 version cache warmed: %d roles, %d objects scanned (%.2fs)",
+            len(cls._version_cache),
+            len(all_keys),
+            time.perf_counter() - t0,
+        )
+
     def get(self, role: str, version: Optional[int] = None) -> Metadata[T]:
         """
         Returns TUF role metadata object for the passed role name,
@@ -124,19 +201,26 @@ class AWSS3(IStorage):
             filename = f"{role}.json"
         else:
             if version is None:
-                s3_path = f"s3://{self._bucket}/"
-                filenames = awswrangler.s3.list_objects(
-                    path=f"{s3_path}*.{role}.json",
-                    boto3_session=self._s3_session,
-                )
-                versions = [
-                    int(name.split(s3_path)[-1].split(".", 1)[0])
-                    for name in filenames
-                ]
-                try:
-                    version = max(versions)
-                except ValueError:
-                    version = 1
+                cached_version = AWSS3._version_cache.get(role)
+                if cached_version is not None:
+                    version = cached_version
+                else:
+                    # Cache miss (role not yet seen by this worker process).
+                    # Scan the bucket once for this role and cache the result.
+                    s3_path = f"s3://{self._bucket}/"
+                    filenames = awswrangler.s3.list_objects(
+                        path=f"{s3_path}*.{role}.json",
+                        boto3_session=self._s3_session,
+                    )
+                    versions = [
+                        int(name.split(s3_path)[-1].split(".", 1)[0])
+                        for name in filenames
+                    ]
+                    try:
+                        version = max(versions)
+                    except ValueError:
+                        version = 1
+                    AWSS3._version_cache[role] = version
 
             filename = f"{version}.{role}.json"
 
@@ -172,3 +256,12 @@ class AWSS3(IStorage):
             )
         except ClientError:
             raise StorageError(f"Can't write role file '{filename}'")
+
+        # Keep the version cache consistent: after writing "N.rolename.json",
+        # record N so the next get() for this role fetches it directly without
+        # calling list_objects.  Timestamp uses a fixed key ("timestamp.json")
+        # and is not version-tracked in the cache.
+        parts = filename.split(".", 1)
+        if parts[0].isdigit():
+            role_name = parts[1][:-5]  # strip ".json"
+            AWSS3._version_cache[role_name] = int(parts[0])

--- a/repository_service_tuf_worker/services/storage/awss3.py
+++ b/repository_service_tuf_worker/services/storage/awss3.py
@@ -166,8 +166,13 @@ class AWSS3(IStorage):
                     Bucket=self._bucket, Key=f"{version + 1}.{role}.json"
                 )
                 version += 1
-            except ClientError:
-                break
+            except ClientError as e:
+                status = e.response.get("ResponseMetadata", {}).get(
+                    "HTTPStatusCode"
+                )
+                if status == 404:
+                    break
+                raise
 
         AWSS3._version_cache[role] = version
         return version
@@ -220,14 +225,3 @@ class AWSS3(IStorage):
             )
         except ClientError:
             raise StorageError(f"Can't write role file '{filename}'")
-
-        # Keep the version cache current so subsequent _latest_version calls
-        # skip the upward probe for this role. filename format: "N.role.json"
-        # Timestamp is the only role stored without a version prefix; skip it.
-        parts = filename.split(".", 1)
-        if len(parts) == 2 and parts[0].isdigit():
-            role = parts[1].removesuffix(".json")
-            written_version = int(parts[0])
-            current = AWSS3._version_cache.get(role, 0)
-            if written_version > current:
-                AWSS3._version_cache[role] = written_version

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
@@ -82,9 +82,7 @@ class TestAWSS3Service:
                 endpoint_url=service._endpoint_url,
             )
         ]
-        assert awss3.boto3.Session().resource().buckets.all.calls == [
-            pretend.call()
-        ]
+        assert awss3.boto3.Session().resource().buckets.all.calls == [pretend.call()]  # noqa: E501
         # By using awss3.boto3 functions we can access the internal objects
         # mocked in mocked_boto3.
         assert service._bucket == "bucket"
@@ -168,6 +166,7 @@ class TestAWSS3Service:
         ]
 
     def test_get(self, mocked_boto3):
+        awss3.AWSS3._version_cache.clear()
         service = awss3.AWSS3(
             "bucket",
             "session",
@@ -187,8 +186,10 @@ class TestAWSS3Service:
         fake_aws3_object = pretend.stub(
             get=pretend.call_recorder(lambda *a: fake_file_obj)
         )
+        get_obj = pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         service._s3_client = pretend.stub(
-            get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
+            get_object=get_obj,
+            head_object=pretend.raiser(awss3.ClientError({}, "head_object")),
         )
 
         expected_root = Metadata(Root())
@@ -213,6 +214,7 @@ class TestAWSS3Service:
         ]
 
     def test_get_endpoint_url_not_none(self, mocked_boto3):
+        awss3.AWSS3._version_cache.clear()
         service = awss3.AWSS3(
             bucket="bucket",
             s3_session="session",
@@ -234,8 +236,10 @@ class TestAWSS3Service:
         fake_aws3_object = pretend.stub(
             get=pretend.call_recorder(lambda *a: fake_file_obj)
         )
+        get_obj = pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         service._s3_client = pretend.stub(
-            get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
+            get_object=get_obj,
+            head_object=pretend.raiser(awss3.ClientError({}, "head_object")),
         )
 
         expected_root = Metadata(Root())
@@ -303,6 +307,7 @@ class TestAWSS3Service:
         ]
 
     def test_get_max_version_ValueError(self, mocked_boto3, monkeypatch):
+        awss3.AWSS3._version_cache.clear()
         service = awss3.AWSS3(
             bucket="bucket",
             s3_session="session",
@@ -324,12 +329,12 @@ class TestAWSS3Service:
         fake_aws3_object = pretend.stub(
             get=pretend.call_recorder(lambda *a: fake_file_obj)
         )
+        get_obj = pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         service._s3_client = pretend.stub(
-            get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
+            get_object=get_obj,
+            head_object=pretend.raiser(awss3.ClientError({}, "head_object")),
         )
-        monkeypatch.setitem(
-            awss3.__builtins__, "max", pretend.raiser(ValueError)
-        )
+        monkeypatch.setitem(awss3.__builtins__, "max", pretend.raiser(ValueError))  # noqa: E501
         expected_root = Metadata(Root())
         awss3.Metadata = pretend.stub(
             from_bytes=pretend.call_recorder(lambda *a: expected_root)
@@ -351,6 +356,7 @@ class TestAWSS3Service:
         ]
 
     def test_get_DeserializationError(self, mocked_boto3):
+        awss3.AWSS3._version_cache.clear()
         service = awss3.AWSS3(
             bucket="bucket",
             s3_session="session",
@@ -372,8 +378,10 @@ class TestAWSS3Service:
         fake_aws3_object = pretend.stub(
             get=pretend.call_recorder(lambda *a: fake_file_obj)
         )
+        get_obj = pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         service._s3_client = pretend.stub(
-            get_object=pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
+            get_object=get_obj,
+            head_object=pretend.raiser(awss3.ClientError({}, "head_object")),
         )
         awss3.Metadata = pretend.stub(
             from_bytes=pretend.raiser(awss3.DeserializationError("failed"))

--- a/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
+++ b/tests/unit/tuf_repository_service_worker/services/storage/test_awss3.py
@@ -82,7 +82,9 @@ class TestAWSS3Service:
                 endpoint_url=service._endpoint_url,
             )
         ]
-        assert awss3.boto3.Session().resource().buckets.all.calls == [pretend.call()]  # noqa: E501
+        assert awss3.boto3.Session().resource().buckets.all.calls == [
+            pretend.call()
+        ]
         # By using awss3.boto3 functions we can access the internal objects
         # mocked in mocked_boto3.
         assert service._bucket == "bucket"
@@ -189,7 +191,15 @@ class TestAWSS3Service:
         get_obj = pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         service._s3_client = pretend.stub(
             get_object=get_obj,
-            head_object=pretend.raiser(awss3.ClientError({}, "head_object")),
+            head_object=pretend.raiser(
+                awss3.ClientError(
+                    {
+                        "Error": {"Code": "404", "Message": "Not Found"},
+                        "ResponseMetadata": {"HTTPStatusCode": 404},
+                    },
+                    "head_object",
+                )
+            ),
         )
 
         expected_root = Metadata(Root())
@@ -239,7 +249,15 @@ class TestAWSS3Service:
         get_obj = pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         service._s3_client = pretend.stub(
             get_object=get_obj,
-            head_object=pretend.raiser(awss3.ClientError({}, "head_object")),
+            head_object=pretend.raiser(
+                awss3.ClientError(
+                    {
+                        "Error": {"Code": "404", "Message": "Not Found"},
+                        "ResponseMetadata": {"HTTPStatusCode": 404},
+                    },
+                    "head_object",
+                )
+            ),
         )
 
         expected_root = Metadata(Root())
@@ -332,9 +350,19 @@ class TestAWSS3Service:
         get_obj = pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         service._s3_client = pretend.stub(
             get_object=get_obj,
-            head_object=pretend.raiser(awss3.ClientError({}, "head_object")),
+            head_object=pretend.raiser(
+                awss3.ClientError(
+                    {
+                        "Error": {"Code": "404", "Message": "Not Found"},
+                        "ResponseMetadata": {"HTTPStatusCode": 404},
+                    },
+                    "head_object",
+                )
+            ),
         )
-        monkeypatch.setitem(awss3.__builtins__, "max", pretend.raiser(ValueError))  # noqa: E501
+        monkeypatch.setitem(
+            awss3.__builtins__, "max", pretend.raiser(ValueError)
+        )
         expected_root = Metadata(Root())
         awss3.Metadata = pretend.stub(
             from_bytes=pretend.call_recorder(lambda *a: expected_root)
@@ -381,7 +409,15 @@ class TestAWSS3Service:
         get_obj = pretend.call_recorder(lambda *a, **kw: fake_aws3_object)
         service._s3_client = pretend.stub(
             get_object=get_obj,
-            head_object=pretend.raiser(awss3.ClientError({}, "head_object")),
+            head_object=pretend.raiser(
+                awss3.ClientError(
+                    {
+                        "Error": {"Code": "404", "Message": "Not Found"},
+                        "ResponseMetadata": {"HTTPStatusCode": 404},
+                    },
+                    "head_object",
+                )
+            ),
         )
         awss3.Metadata = pretend.stub(
             from_bytes=pretend.raiser(awss3.DeserializationError("failed"))


### PR DESCRIPTION

# Performance Fix: S3 Version Cache for RSTUF Worker


---

## Problem

Each `add_artifacts` task processes a batch of files across multiple TUF metadata
roles — typically `root`, `targets`, `snapshot`, and one or more `bins-xx` delegation
shards (up to 9+ roles per task depending on the hash prefix distribution). For every
role it processes, the worker calls `AWSS3.get()` without a known version number in
order to load the current metadata.

The original implementation resolved the latest version with:

```python
filenames = awswrangler.s3.list_objects(
    path=f"s3://{bucket}/*.{role}.json",
    boto3_session=self._s3_session,
)
version = max(int(name.split(...)[-1].split(".")[0]) for name in filenames)
```

S3 does not support server-side suffix or glob filtering. The `*.{role}.json` pattern
causes `list_objects` to enumerate **every object in the bucket** and filter
client-side. Cost scales with total bucket size, not with the number of matching
objects.

| Bucket size | `list_objects` cost per call |
|---|---|
| ~250 objects | ~0.3 s |
| ~5 500 objects | 2.5–4 s |
| ~12 000 objects | 3–4 s |

With 9+ calls per task, at 12 000 objects this accounted for **~27 s of a ~33 s total
task latency** — roughly 82% of end-to-end time. KMS signing (the other obvious
candidate) contributed only ~1.4 s total (7 calls × ~0.2 s each).

The bucket grows monotonically: every task writes multiple versioned role files
(`N.rolename.json`) and they are never deleted. The problem worsens as the system is
used.

---

## Fix

Two targeted changes to `AWSS3` in `awss3.py` (108 lines added, 15 removed; no new
dependencies):

### 1. In-process version cache

A class-level dict `_version_cache: Dict[str, int]` maps `role_name → latest known
version`. The `get()` method reads from this cache instead of calling `list_objects`:

```python
cached_version = AWSS3._version_cache.get(role)
if cached_version is not None:
    version = cached_version
else:
    # Cache miss: scan once and store the result.
    ...
    AWSS3._version_cache[role] = version
```

The `put()` method updates the cache after every successful write so the next `get()`
for that role resolves the correct key without any S3 listing:

```python
parts = filename.split(".", 1)
if parts[0].isdigit():
    role_name = parts[1][:-5]   # strip ".json"
    AWSS3._version_cache[role_name] = int(parts[0])
```

### 2. Pre-warmup at worker startup

`_prewarm_version_cache()` is called once from `configure()` when the Celery worker
initialises. It scans the entire bucket a single time (`list_objects` with no glob,
prefix `s3://bucket/`), parses every `N.rolename.json` filename, and records the
highest version per role. All roles are in cache before the first task arrives, so
there is no cold-start penalty on the first job.

```
S3 version cache warmed: 35 roles, 12 241 objects scanned (3.74s)
```

If the prewarm fails (network error, permissions issue), a warning is logged and the
worker starts with an empty cache, falling back to the original per-role scan on first
access — identical to pre-fix behaviour.

---

## Benchmark Results

All runs: **10 concurrent jobs × 10 files each = 100 total artifacts**, real AWS S3
(`us-east-1`) + AWS KMS RSA-4096 online signing, Minikube on EC2 `t3.medium`.
`task_wait` = time from API POST to Celery `SUCCESS` (excludes S3 upload and HTTP
overhead).

| Benchmark | Condition | p50 | p95 | Wall (10 jobs) |
|---|---|---|---|---|
| **Bench5** | **Pre-fix baseline, ~12 000 bucket objects** | **36.6 s** | **42.4 s** | **6.3 min** |
| Bench6 | Version cache only, 1st run after restart | 11.8 s | 42.2 s | — |
| Bench7 | Version cache only, warm | 11.8 s | 22.1 s | — |
| Bench8 | Version cache only, fully warm | 9.9 s | 19.1 s | — |
| Bench9 | Cache + pre-warmup, instrumented build | 6.6 s | 8.7 s | 1.2 min |
| **Bench10** | **Cache + pre-warmup, clean build** | **5.6 s** | **8.7 s** | **1.1 min** |

**Speedup vs baseline: 6.5× p50, 4.9× p95, 5.7× wall time.**

The p95 spike in Bench6 (42.2 s) is a single cold-shard DB cache miss immediately
after restart with version-cache only and no prewarm; it disappears entirely once
pre-warmup is added (Bench9+).

### Remaining latency floor (~5–6 s)

| Component | Estimated cost |
|---|---|
| Celery task overhead + DB reads | ~2–3 s |
| KMS sign (7 calls × ~0.2 s) | ~1.4 s |
| S3 get/put (9+ calls × ~0.05 s) | ~0.5 s |
| **Total** | **~4–5 s** |

Consistent with the observed minimum of 5.6 s. No further reduction is possible
without addressing KMS latency or Celery/DB overhead.

---

### No new failure modes

- No external state (no Redis, no additional DB table, no shared memory).
- No new dependencies.
- A worker restart triggers a fresh prewarm (~4–8 s at 12 000 objects). The prewarm
  runs before the worker accepts tasks, so no task sees an empty cache unless the
  prewarm itself fails (handled gracefully).
