### PR TITLE
build: bump python to 3.14 and use hash in Dockerfile to be updated by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     groups:
       python-deps:
         patterns:
-          - "*"    
+          - "*"
   # Monitor Github Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -26,5 +26,19 @@ updates:
     open-pull-requests-limit: 10
     groups:
       github-actions:
+        patterns:
+          - "*"
+  # Monitor Docker base images
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+      time: "10:00"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    open-pull-requests-limit: 10
+    groups:
+      docker:
         patterns:
           - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-versions: [ "3.13" ]
+        python-versions: [ "3.14" ]
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/publish_docker_dev.yml
+++ b/.github/workflows/publish_docker_dev.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
     - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
     - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8

--- a/.github/workflows/update-pre-commit-hooks.yml
+++ b/.github/workflows/update-pre-commit-hooks.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install prerequisites
         run: |
           pip install pre-commit tox

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ submodules:
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.13"
+    python: "3.14"
   apt_packages:
     - plantuml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM python:3.13-slim AS base_os
+FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 AS base_os
 
 # Builder requirements and deps
 FROM base_os AS builder
@@ -23,7 +23,7 @@ RUN apt-get remove gcc --purge -y \
 FROM base_os AS pre-final
 RUN apt-get update && apt-get install libpq-dev -y && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/bin /usr/local/bin/
-COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages/
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages/
 
 # Final stage
 FROM pre-final

--- a/Pipfile
+++ b/Pipfile
@@ -51,4 +51,4 @@ myst-parser = "*"
 dynaconf = {extras = ["ini"], version = "*"}  # required to build docs
 
 [requires]
-python_version = "3.13"
+python_version = "3.14"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "55d8f16502f3cf097af83d6f8d57a3cd8af7a479504c1a209e503ac72b3d0a3b"
+            "sha256": "691191c57134a4bb61ba585d288eb312a81ff1fa0a925da905a52821c053bfd8"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.13"
+            "python_version": "3.14"
         },
         "sources": [
             {

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -86,7 +86,7 @@ services:
     stdin_open: true
 
   rstuf-ft-runner:
-    image: python:3.13-slim
+    image: python:3.14-slim
     command: python -V
     working_dir: /rstuf-runner
     volumes:

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -37,7 +37,7 @@ services:
         condition: service_healthy
 
   web:
-    image: python:3.13-slim
+    image: python:3.14-slim
     command: python -m http.server -d /var/opt/repository-service-tuf/storage 8080
     volumes:
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
@@ -79,7 +79,7 @@ services:
     stdin_open: true
 
   rstuf-ft-runner:
-    image: python:3.13-slim
+    image: python:3.14-slim
     command: python -V
     working_dir: /rstuf-runner
     environment:

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -34,7 +34,7 @@ services:
         condition: service_healthy
 
   web:
-    image: python:3.13-slim
+    image: python:3.14-slim
     command: python -m http.server -d /var/opt/repository-service-tuf/storage 8080
     volumes:
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
@@ -76,7 +76,7 @@ services:
     stdin_open: true
 
   rstuf-ft-runner:
-    image: python:3.13-slim
+    image: python:3.14-slim
     command: python -V
     working_dir: /rstuf-runner
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
         condition: service_healthy
 
   web:
-    image: python:3.13
+    image: python:3.14
     command: python -m http.server -d /var/opt/repository-service-tuf/storage 8080
     volumes:
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
@@ -89,7 +89,7 @@ services:
     stdin_open: true
 
   rstuf-ft-runner:
-    image: python:3.13-slim
+    image: python:3.14-slim
     command: python -V
     working_dir: /rstuf-runner
     volumes:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py313,lint,precommit,test
+envlist = py314,lint,precommit,test
 
 [flake8]
 exclude = repository_service_tuf_worker/__init__.py,venv,.venv,settings.py,.git,.tox,dist,docs,*lib/python*,*egg,build,tools
@@ -69,7 +69,7 @@ commands =
 
 [gh-actions]
 python =
-    3.13: py313,pep8,lint,precommit,test
+    3.14: py314,pep8,lint,precommit,test
 
 [testenv:local-aws-kms]
 deps =


### PR DESCRIPTION
- drop 3.13 and start using 3.14
- Use base image by hash
- Configure dependabot to update Dockerfile