### PR TITLE
fix: pin FT-runner compose images back to python 3.13

### DIFF
--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -86,7 +86,7 @@ services:
     stdin_open: true
 
   rstuf-ft-runner:
-    image: python:3.14-slim
+    image: python:3.13-slim
     command: python -V
     working_dir: /rstuf-runner
     volumes:

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -37,7 +37,7 @@ services:
         condition: service_healthy
 
   web:
-    image: python:3.14-slim
+    image: python:3.13-slim
     command: python -m http.server -d /var/opt/repository-service-tuf/storage 8080
     volumes:
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
@@ -79,7 +79,7 @@ services:
     stdin_open: true
 
   rstuf-ft-runner:
-    image: python:3.14-slim
+    image: python:3.13-slim
     command: python -V
     working_dir: /rstuf-runner
     environment:

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -34,7 +34,7 @@ services:
         condition: service_healthy
 
   web:
-    image: python:3.14-slim
+    image: python:3.13-slim
     command: python -m http.server -d /var/opt/repository-service-tuf/storage 8080
     volumes:
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
@@ -76,7 +76,7 @@ services:
     stdin_open: true
 
   rstuf-ft-runner:
-    image: python:3.14-slim
+    image: python:3.13-slim
     command: python -V
     working_dir: /rstuf-runner
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
         condition: service_healthy
 
   web:
-    image: python:3.14
+    image: python:3.13
     command: python -m http.server -d /var/opt/repository-service-tuf/storage 8080
     volumes:
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
@@ -89,7 +89,7 @@ services:
     stdin_open: true
 
   rstuf-ft-runner:
-    image: python:3.14-slim
+    image: python:3.13-slim
     command: python -V
     working_dir: /rstuf-runner
     volumes:


### PR DESCRIPTION
The functional tests run in the `rstuf-ft-runner` (and `web`) docker-compose services, which pip-install the RSTUF CLI. The CLI depends on `pykcs11`, which ships no Linux wheels and therefore builds from its sdist. On the new `python:3.14-slim` base (Debian trixie) the C++ extension links without libstdc++, producing at import time:

    ImportError: .../PyKCS11/_LowLevel.cpython-314-...so:
    undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE

This broke every FT job after the 3.14 bump (#919). The worker image itself does not use pykcs11 and is unaffected, so it stays on 3.14; only the FT-runner/web helper images are reverted to 3.13 until pykcs11 publishes 3.14 wheels.