### PR TITLE
fix: add stale connection detection and recovery for DB pool connections

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional
 
 import redis
 from celery import Celery, chain, schedules, signals
+from sqlalchemy.exc import OperationalError
 
 from repository_service_tuf_worker import get_worker_settings
 from repository_service_tuf_worker.repository import (
@@ -77,7 +78,13 @@ app = Celery(
 )
 
 
-@app.task(serializer="json", bind=True)
+@app.task(
+    serializer="json",
+    bind=True,
+    autoretry_for=(OperationalError,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def repository_service_tuf_worker(
     self,
     action: str,
@@ -97,7 +104,11 @@ def repository_service_tuf_worker(
         # add task id to payload
         payload["task_id"] = self.request.id
 
-        result = repository_action(payload, update_state=self.update_state)
+        try:
+            result = repository_action(payload, update_state=self.update_state)
+        except OperationalError:
+            repository._db.rollback()
+            raise
 
     return result
 

--- a/repository_service_tuf_worker/models/__init__.py
+++ b/repository_service_tuf_worker/models/__init__.py
@@ -2,8 +2,11 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
+import os
+import sys
+
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 from repository_service_tuf_worker.models.targets import (  # noqa
     crud as targets_crud,
@@ -16,17 +19,27 @@ from repository_service_tuf_worker.models.targets import (  # noqa
 )
 
 
-def rstuf_db(db_server: str) -> sessionmaker:
+def rstuf_db(db_server: str) -> Session:
+    connect_args = {
+        "keepalives": 1,
+        "keepalives_idle": int(
+            os.environ.get("RSTUF_DB_KEEPALIVE_IDLE", "30")
+        ),
+        "keepalives_interval": int(
+            os.environ.get("RSTUF_DB_KEEPALIVE_INTERVAL", "5")
+        ),
+    }
+
+    if sys.platform == "linux":
+        connect_args["keepalives_count"] = int(
+            os.environ.get("RSTUF_DB_KEEPALIVE_COUNT", "3")
+        )
+
     engine = create_engine(
         db_server,
         pool_pre_ping=True,
         pool_recycle=1800,
-        connect_args={
-            "keepalives": 1,
-            "keepalives_idle": 30,
-            "keepalives_interval": 5,
-            "keepalives_count": 3,
-        },
+        connect_args=connect_args,
     )
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/repository_service_tuf_worker/models/__init__.py
+++ b/repository_service_tuf_worker/models/__init__.py
@@ -17,7 +17,17 @@ from repository_service_tuf_worker.models.targets import (  # noqa
 
 
 def rstuf_db(db_server: str) -> sessionmaker:
-    engine = create_engine(db_server)
+    engine = create_engine(
+        db_server,
+        pool_pre_ping=True,
+        pool_recycle=1800,
+        connect_args={
+            "keepalives": 1,
+            "keepalives_idle": 30,
+            "keepalives_interval": 5,
+            "keepalives_count": 3,
+        },
+    )
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
     # Base.metadata.create_all(bind=engine)

--- a/repository_service_tuf_worker/models/__init__.py
+++ b/repository_service_tuf_worker/models/__init__.py
@@ -20,20 +20,21 @@ from repository_service_tuf_worker.models.targets import (  # noqa
 
 
 def rstuf_db(db_server: str) -> Session:
-    connect_args = {
-        "keepalives": 1,
-        "keepalives_idle": int(
-            os.environ.get("RSTUF_DB_KEEPALIVE_IDLE", "30")
-        ),
-        "keepalives_interval": int(
-            os.environ.get("RSTUF_DB_KEEPALIVE_INTERVAL", "5")
-        ),
-    }
+    connect_args = {}
 
-    if sys.platform == "linux":
-        connect_args["keepalives_count"] = int(
-            os.environ.get("RSTUF_DB_KEEPALIVE_COUNT", "3")
+    if os.environ.get("RSTUF_DB_KEEPALIVE"):
+        connect_args["keepalives"] = 1
+        connect_args["keepalives_idle"] = int(
+            os.environ.get("RSTUF_DB_KEEPALIVE_IDLE", "30")
         )
+        connect_args["keepalives_interval"] = int(
+            os.environ.get("RSTUF_DB_KEEPALIVE_INTERVAL", "5")
+        )
+
+        if sys.platform == "linux":
+            connect_args["keepalives_count"] = int(
+                os.environ.get("RSTUF_DB_KEEPALIVE_COUNT", "3")
+            )
 
     engine = create_engine(
         db_server,


### PR DESCRIPTION
When PostgreSQL closes an idle connection (timeout, restart, network issue), the worker's long-lived SQLAlchemy session enters a pending rollback state and all subsequent tasks fail with PendingRollbackError.

- Add pool_pre_ping=True to validate connections on checkout from pool
- Add pool_recycle=1800 to auto-recycle idle connections after 30 min
- Enable TCP keepalives (idle=30s, interval=5s, count=3) so the OS detects dead sockets and closes them proactively
- Rollback session on OperationalError to restore clean state
- Add autoretry_for to automatically retry failed tasks up to 3 times with exponential backoff

Closes issue #927
