### PR TITLE
fix: encode special characters in DB password and support custom DB name

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -4,6 +4,7 @@ from logging.config import fileConfig
 from urllib.parse import urlparse
 
 from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import URL
 
 from alembic import context
 
@@ -41,9 +42,25 @@ elif db_user and db_password:
     if db_password.startswith("/run/secrets"):
         with open(db_password) as f:
             db_password = f.read().rstrip("\n")
-    sql_server_uri = f"{uri.scheme}://{db_user}:{db_password}@{uri.netloc}"
+    url = URL.create(
+        drivername=uri.scheme,
+        username=db_user,
+        password=db_password,
+        host=uri.hostname,
+        port=uri.port,
+        database=uri.path.lstrip("/") or None,
+    )
+    sql_server_uri = url.render_as_string(hide_password=False)
 else:
-    sql_server_uri = f"{uri.scheme}:{uri._replace(scheme='').geturl()}"
+    url = URL.create(
+        drivername=uri.scheme,
+        username=uri.username,
+        password=uri.password,
+        host=uri.hostname,
+        port=uri.port,
+        database=uri.path.lstrip("/") or None,
+    )
+    sql_server_uri = url.render_as_string(hide_password=False)
 
 config.set_main_option("sqlalchemy.url", sql_server_uri)
 

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -21,7 +21,6 @@ from celery.exceptions import ChordError
 from celery.result import AsyncResult, states
 from dynaconf.loaders import redis_loader
 from securesystemslib.exceptions import StorageError, UnverifiedSignatureError
-from sqlalchemy.engine import URL
 from securesystemslib.signer import (
     KEY_FOR_TYPE_AND_SCHEME,
     Key,
@@ -29,6 +28,7 @@ from securesystemslib.signer import (
     Signer,
     SigstoreKey,
 )
+from sqlalchemy.engine import URL
 from tuf.api.exceptions import (
     BadVersionNumberError,
     RepositoryError,

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -21,6 +21,7 @@ from celery.exceptions import ChordError
 from celery.result import AsyncResult, states
 from dynaconf.loaders import redis_loader
 from securesystemslib.exceptions import StorageError, UnverifiedSignatureError
+from sqlalchemy.engine import URL
 from securesystemslib.signer import (
     KEY_FOR_TYPE_AND_SCHEME,
     Key,
@@ -263,9 +264,25 @@ class MetadataRepository:
                 except OSError as err:
                     logging.error(str(err))
                     raise err
-            db_uri = f"{uri.scheme}://{db_user}:{db_password}@{uri.netloc}"
+            url = URL.create(
+                drivername=uri.scheme,
+                username=db_user,
+                password=db_password,
+                host=uri.hostname,
+                port=uri.port,
+                database=uri.path.lstrip("/") or None,
+            )
+            db_uri = url.render_as_string(hide_password=False)
         else:
-            db_uri = f"{uri.scheme}:{uri._replace(scheme='').geturl()}"
+            url = URL.create(
+                drivername=uri.scheme,
+                username=uri.username,
+                password=uri.password,
+                host=uri.hostname,
+                port=uri.port,
+                database=uri.path.lstrip("/") or None,
+            )
+            db_uri = url.render_as_string(hide_password=False)
 
         settings.SQL = rstuf_db(db_uri)
         #

--- a/tests/unit/tuf_repository_service_worker/test_repository.py
+++ b/tests/unit/tuf_repository_service_worker/test_repository.py
@@ -256,6 +256,44 @@ class TestMetadataRepository:
             pretend.call("postgresql://psql:psqlpass@fake-sql:5433")
         ]
 
+    def test_refresh_settings_with_sql_user_password_special_chars(
+        self, test_repo
+    ):
+        test_repo._worker_settings.DB_SERVER = "postgresql://fake-sql:5433"
+        test_repo._worker_settings.DB_USER = "psql"
+        test_repo._worker_settings.DB_PASSWORD = "p%ss?w^rd]!"
+        fake_sql = pretend.stub()
+        repository.rstuf_db = pretend.call_recorder(lambda *a: fake_sql)
+
+        test_repo.refresh_settings()
+
+        assert test_repo._worker_settings.SQL == fake_sql
+        assert repository.rstuf_db.calls == [
+            pretend.call(
+                "postgresql://psql:p%25ss%3Fw%5Erd%5D%21@fake-sql:5433"
+            )
+        ]
+
+    def test_refresh_settings_with_sql_user_password_custom_db(
+        self, test_repo
+    ):
+        test_repo._worker_settings.DB_SERVER = (
+            "postgresql://fake-sql:5433/db-custom-name"
+        )
+        test_repo._worker_settings.DB_USER = "psql"
+        test_repo._worker_settings.DB_PASSWORD = "psqlpass"
+        fake_sql = pretend.stub()
+        repository.rstuf_db = pretend.call_recorder(lambda *a: fake_sql)
+
+        test_repo.refresh_settings()
+
+        assert test_repo._worker_settings.SQL == fake_sql
+        assert repository.rstuf_db.calls == [
+            pretend.call(
+                "postgresql://psql:psqlpass@fake-sql:5433/db-custom-name"
+            )
+        ]
+
     def test_refresh_settings_with_sql_user_missing_password(self, test_repo):
         test_repo._worker_settings.DB_SERVER = "postgresql://fake-sql:5433"
         test_repo._worker_settings.DB_USER = "psql"


### PR DESCRIPTION
Use sqlalchemy.engine.URL.create() for constructing the database connection URI instead of f-string interpolation. This properly encodes special characters (%, ?, ', ", etc.) in RSTUF_DB_PASSWORD and RSTUF_DB_USER, preventing configparser interpolation errors that previously leaked credentials into logs.

Additionally, preserve the database name from RSTUF_DB_SERVER when using RSTUF_DB_USER/RSTUF_DB_PASSWORD, which was previously dropped.

Closes issue #924
