### PR TITLE
fix: replace poisoned session recovery with scoped_session lifecycle

### DIFF
--- a/app.py
+++ b/app.py
@@ -136,7 +136,13 @@ def _end_bor_chain_callback(result, start_time: float):
     return {"result": result, "execution_time_seconds": total_time}
 
 
-@app.task(serializer="json", queue="rstuf_internals")
+@app.task(
+    serializer="json",
+    queue="rstuf_internals",
+    autoretry_for=(OperationalError,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def _update_online_role(role: str) -> Optional[str]:
     """
     Update online role (DB and JSON)
@@ -144,7 +150,13 @@ def _update_online_role(role: str) -> Optional[str]:
     return repository.update_targets_delegated_role(role)
 
 
-@app.task(serializer="json", queue="rstuf_internals")
+@app.task(
+    serializer="json",
+    queue="rstuf_internals",
+    autoretry_for=(OperationalError,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def _update_snapshot_timestamp(*args) -> Dict[str, Any]:
     """
     Update the snapshot timestamp with the updated roles data.
@@ -303,6 +315,15 @@ def _publish_signals(
             {"status": status.value, "task_id": task_id, "result": result}
         ),
     )
+
+
+@signals.task_postrun.connect
+def cleanup_db_session(**kwargs):
+    """Remove scoped session after every task to ensure clean state."""
+    try:
+        repository._reset_db_session()
+    except Exception:
+        logging.warning("Failed to reset DB session", exc_info=True)
 
 
 @signals.task_prerun.connect(sender=repository_service_tuf_worker)

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -136,7 +136,8 @@ class MetadataRepository:
         raw_session = app_settings.SQL  # Session instance from rstuf_db()
         self._Session = scoped_session(
             sessionmaker(
-                autocommit=False, autoflush=False,
+                autocommit=False,
+                autoflush=False,
                 bind=raw_session.get_bind(),
             )
         )

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -20,7 +20,6 @@ from celery.app.task import Task
 from celery.exceptions import ChordError
 from celery.result import AsyncResult, states
 from dynaconf.loaders import redis_loader
-from sqlalchemy.orm import scoped_session, sessionmaker
 from securesystemslib.exceptions import StorageError, UnverifiedSignatureError
 from securesystemslib.signer import (
     KEY_FOR_TYPE_AND_SCHEME,
@@ -30,6 +29,7 @@ from securesystemslib.signer import (
     SigstoreKey,
 )
 from sqlalchemy.engine import URL
+from sqlalchemy.orm import scoped_session, sessionmaker
 from tuf.api.exceptions import (
     BadVersionNumberError,
     RepositoryError,

--- a/repository_service_tuf_worker/repository.py
+++ b/repository_service_tuf_worker/repository.py
@@ -20,6 +20,7 @@ from celery.app.task import Task
 from celery.exceptions import ChordError
 from celery.result import AsyncResult, states
 from dynaconf.loaders import redis_loader
+from sqlalchemy.orm import scoped_session, sessionmaker
 from securesystemslib.exceptions import StorageError, UnverifiedSignatureError
 from securesystemslib.signer import (
     KEY_FOR_TYPE_AND_SCHEME,
@@ -132,7 +133,14 @@ class MetadataRepository:
         app_settings = self.refresh_settings()
         self._storage_backend: IStorage = app_settings.STORAGE
         self._signer_store = SignerStore(app_settings)
-        self._db = app_settings.SQL
+        raw_session = app_settings.SQL  # Session instance from rstuf_db()
+        self._Session = scoped_session(
+            sessionmaker(
+                autocommit=False, autoflush=False,
+                bind=raw_session.get_bind(),
+            )
+        )
+        self._db_override = None
         self._redis = redis.StrictRedis.from_url(
             self._worker_settings.REDIS_SERVER
         )
@@ -142,6 +150,20 @@ class MetadataRepository:
         self._expire_timedelta = timedelta(hours=self._hours_before_expire)
         self._timeout = int(app_settings.get("LOCK_TIMEOUT", 500.0))
         self._uses_succinct_roles: Optional[bool] = None
+
+    @property
+    def _db(self):
+        if self._db_override is not None:
+            return self._db_override
+        return self._Session()
+
+    @_db.setter
+    def _db(self, value):
+        self._db_override = value
+
+    def _reset_db_session(self):
+        self._db_override = None
+        self._Session.remove()
 
     @property
     def _settings(self) -> Dynaconf:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,11 +9,17 @@ from types import ModuleType
 import pretend
 import pytest
 
+from repository_service_tuf_worker import repository
 from repository_service_tuf_worker.repository import MetadataRepository
 
 
 @pytest.fixture()
 def test_repo(monkeypatch: pytest.MonkeyPatch) -> MetadataRepository:
+    fake_engine = pretend.stub()
+    fake_sql = pretend.stub(get_bind=lambda: fake_engine)
+    monkeypatch.setattr(
+        repository, "rstuf_db", pretend.call_recorder(lambda *a: fake_sql)
+    )
     return MetadataRepository.create_service()
 
 


### PR DESCRIPTION
When PostgreSQL drops a connection, the worker's long-lived SQLAlchemy Session enters a PendingRollbackError state that never recovers. PR #928 addressed this at the connection pool level (pool_pre_ping, TCP keepalives) but only added autoretry_for to the main task repository_service_tuf_worker, not to _update_online_role or _update_snapshot_timestamp which are the tasks that actually fail in the bump_online_roles chain.

Changes:
- Replace static self._db Session with scoped_session + sessionmaker bound to the same engine, so each task gets a fresh session
- Add _reset_db_session() method that clears the scoped session registry via Session.remove(), disposing the connection entirely
- Add @signals.task_postrun.connect handler that calls _reset_db_session() after every Celery task, ensuring the next task always starts with a clean session regardless of prior failures
- Add autoretry_for=(OperationalError,) with max_retries=3 and exponential backoff to _update_online_role and _update_snapshot_timestamp
- Make _db a property with getter/setter to preserve backward compatibility with existing test mocks (test_repo._db = pretend.stub)